### PR TITLE
feat: add missing CLI commands, integration tests, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,49 @@
 # codex-wrapper
 
-Rust tooling for the Codex CLI.
+Rust tooling for the [Codex CLI](https://github.com/openai/codex).
 
-This workspace currently focuses on the base `codex-wrapper` crate, modeled after
-the `claude-wrapper` crate structure and builder style.
+[![CI](https://github.com/joshrotenberg/codex-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/codex-wrapper/actions/workflows/ci.yml)
+
+## Crates
+
+| Crate | Description |
+|-------|-------------|
+| [`codex-wrapper`](crates/codex-wrapper/) | Type-safe Codex CLI wrapper with builder-pattern API |
+
+## Quick Start
+
+```bash
+cargo add codex-wrapper
+```
+
+```rust
+use codex_wrapper::{Codex, CodexCommand, ExecCommand, SandboxMode};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+    let output = ExecCommand::new("summarize this repository")
+        .sandbox(SandboxMode::WorkspaceWrite)
+        .ephemeral()
+        .execute(&codex)
+        .await?;
+    println!("{}", output.stdout);
+    Ok(())
+}
+```
+
+See the [crate README](crates/codex-wrapper/README.md) for full documentation.
 
 ## CI and Release
 
-The repository includes GitHub Actions for CI, quick PR checks, dependency
-audits, changelog automation, and `release-plz`-driven crates.io releases.
+GitHub Actions workflows handle CI, dependency audits, changelog automation,
+and `release-plz`-driven crates.io releases.
 
 Expected repository secrets:
 
-- `COMMITTER_TOKEN` for release PRs and changelog PRs
-- `CARGO_REGISTRY_TOKEN` for publishing to crates.io
+- `COMMITTER_TOKEN` -- for release PRs and changelog PRs
+- `CARGO_REGISTRY_TOKEN` -- for publishing to crates.io
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -1,19 +1,325 @@
 # codex-wrapper
 
-Type-safe Rust wrapper around the Codex CLI with a two-layer builder API.
+A type-safe Codex CLI wrapper for Rust
+
+[![Crates.io](https://img.shields.io/crates/v/codex-wrapper.svg)](https://crates.io/crates/codex-wrapper)
+[![Documentation](https://docs.rs/codex-wrapper/badge.svg)](https://docs.rs/codex-wrapper)
+[![CI](https://github.com/joshrotenberg/codex-wrapper/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/codex-wrapper/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/codex-wrapper.svg)](LICENSE-MIT)
+
+## Overview
+
+`codex-wrapper` provides a type-safe builder-pattern interface for invoking the
+`codex` CLI programmatically. It follows the same design philosophy as
+[`claude-wrapper`](https://crates.io/crates/claude-wrapper) and
+[`docker-wrapper`](https://crates.io/crates/docker-wrapper): each CLI
+subcommand is a builder struct that produces typed output.
+
+## Installation
+
+```bash
+cargo add codex-wrapper
+```
+
+## Quick Start
 
 ```rust
 use codex_wrapper::{Codex, CodexCommand, ExecCommand, SandboxMode};
 
-# async fn example() -> codex_wrapper::Result<()> {
-let codex = Codex::builder().build()?;
-let output = ExecCommand::new("summarize this repository")
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+    let output = ExecCommand::new("explain this error")
+        .model("o3")
+        .sandbox(SandboxMode::WorkspaceWrite)
+        .ephemeral()
+        .execute(&codex)
+        .await?;
+    println!("{}", output.stdout);
+    Ok(())
+}
+```
+
+## Two-Layer Builder Architecture
+
+The `Codex` client holds shared configuration (binary path, environment,
+timeout, retry policy). Command builders hold per-invocation options and call
+`execute(&codex)`.
+
+### Codex Client
+
+Configure once, reuse across commands:
+
+```rust
+let codex = Codex::builder()
+    .env("OPENAI_API_KEY", "sk-...")
+    .timeout_secs(300)
+    .retry(RetryPolicy::new().max_attempts(3).exponential())
+    .build()?;
+```
+
+Options:
+- `binary()` -- path to `codex` binary (auto-detected via `PATH` by default)
+- `working_dir()` -- working directory for commands
+- `env()` / `envs()` -- environment variables
+- `timeout_secs()` / `timeout()` -- command timeout
+- `config()` -- global config overrides (`-c key=value`)
+- `enable()` / `disable()` -- global feature flags
+- `retry()` -- default retry policy
+
+### Command Builders
+
+Each CLI subcommand is a separate builder. Available commands:
+
+| Command | CLI Equivalent | Description |
+|---------|---------------|-------------|
+| `ExecCommand` | `codex exec` | Run Codex non-interactively |
+| `ExecResumeCommand` | `codex exec resume` | Resume a non-interactive session |
+| `ReviewCommand` | `codex exec review` | Code review with git integration |
+| `ResumeCommand` | `codex resume` | Resume an interactive session |
+| `ForkCommand` | `codex fork` | Fork an interactive session |
+| `LoginCommand` | `codex login` | Authenticate |
+| `LoginStatusCommand` | `codex login status` | Check auth status |
+| `LogoutCommand` | `codex logout` | Remove credentials |
+| `McpListCommand` | `codex mcp list` | List MCP servers |
+| `McpGetCommand` | `codex mcp get` | Get MCP server details |
+| `McpAddCommand` | `codex mcp add` | Add stdio or HTTP MCP server |
+| `McpRemoveCommand` | `codex mcp remove` | Remove MCP server |
+| `McpLoginCommand` | `codex mcp login` | Auth to MCP server |
+| `McpLogoutCommand` | `codex mcp logout` | Deauth from MCP server |
+| `McpServerCommand` | `codex mcp-server` | Start Codex as MCP server |
+| `SandboxCommand` | `codex sandbox` | Run command in sandbox |
+| `ApplyCommand` | `codex apply` | Apply agent diff |
+| `CompletionCommand` | `codex completion` | Generate shell completions |
+| `FeaturesListCommand` | `codex features list` | List feature flags |
+| `FeaturesEnableCommand` | `codex features enable` | Enable a feature |
+| `FeaturesDisableCommand` | `codex features disable` | Disable a feature |
+| `VersionCommand` | `codex --version` | Get CLI version |
+| `RawCommand` | *(any)* | Escape hatch for arbitrary args |
+
+## ExecCommand: The Workhorse
+
+Full coverage of `codex exec` options:
+
+```rust
+let output = ExecCommand::new("fix the failing tests")
+    .model("o3")
     .sandbox(SandboxMode::WorkspaceWrite)
+    .approval_policy(ApprovalPolicy::Never)
     .skip_git_repo_check()
+    .ephemeral()
+    .json()
+    .execute(&codex)
+    .await?;
+```
+
+All ExecCommand options:
+
+| Method | CLI Flag | Description |
+|--------|----------|-------------|
+| `model()` | `--model` | Model to use |
+| `sandbox()` | `--sandbox` | Sandbox policy |
+| `approval_policy()` | `--ask-for-approval` | Approval policy |
+| `profile()` | `--profile` | Config profile |
+| `full_auto()` | `--full-auto` | Auto sandbox + approval |
+| `dangerously_bypass_approvals_and_sandbox()` | `--dangerously-bypass-approvals-and-sandbox` | Skip all safety |
+| `cd()` | `--cd` | Working directory |
+| `skip_git_repo_check()` | `--skip-git-repo-check` | Run outside git repo |
+| `add_dir()` | `--add-dir` | Additional writable dirs |
+| `search()` | `--search` | Enable web search |
+| `ephemeral()` | `--ephemeral` | Don't persist session |
+| `output_schema()` | `--output-schema` | JSON Schema for response |
+| `color()` | `--color` | Color output mode |
+| `progress_cursor()` | `--progress-cursor` | Cursor-based progress |
+| `json()` | `--json` | JSONL event output |
+| `output_last_message()` | `--output-last-message` | Write last message to file |
+| `image()` | `--image` | Attach image(s) |
+| `config()` | `-c` | Config override |
+| `enable()` / `disable()` | `--enable` / `--disable` | Feature flags |
+| `oss()` | `--oss` | Use local OSS provider |
+| `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
+| `retry()` | *(client-side)* | Per-command retry policy |
+
+## JSONL Output Parsing
+
+Use `execute_json_lines()` to parse structured events from `--json` mode:
+
+```rust
+let events = ExecCommand::new("what is 2+2?")
+    .ephemeral()
+    .execute_json_lines(&codex)
+    .await?;
+
+for event in &events {
+    println!("{}: {:?}", event.event_type, event.extra);
+}
+```
+
+Event types include `thread.started`, `turn.started`, `item.completed`,
+`turn.completed`, and more.
+
+## Code Review
+
+```rust
+// Review uncommitted changes
+let output = ReviewCommand::new()
+    .uncommitted()
+    .model("o3")
     .execute(&codex)
     .await?;
 
-println!("{}", output.stdout);
-# Ok(())
-# }
+// Review against a base branch
+let output = ReviewCommand::new()
+    .base("main")
+    .json()
+    .execute(&codex)
+    .await?;
 ```
+
+## MCP Server Management
+
+```rust
+// List servers
+let output = McpListCommand::new().execute(&codex).await?;
+
+// List as JSON
+let servers = McpListCommand::new().execute_json(&codex).await?;
+
+// Add stdio server
+McpAddCommand::stdio("my-tool", "npx")
+    .arg("my-mcp-server")
+    .env("API_KEY", "secret")
+    .execute(&codex)
+    .await?;
+
+// Add HTTP server
+McpAddCommand::http("sentry", "https://mcp.sentry.dev/mcp")
+    .bearer_token_env_var("SENTRY_TOKEN")
+    .execute(&codex)
+    .await?;
+
+// Remove server
+McpRemoveCommand::new("old-server").execute(&codex).await?;
+```
+
+## Sandbox Execution
+
+Run commands inside the Codex sandbox:
+
+```rust
+let output = SandboxCommand::new(SandboxPlatform::MacOs, "ls")
+    .arg("-la")
+    .execute(&codex)
+    .await?;
+```
+
+## Session Management
+
+```rust
+// Resume the most recent interactive session
+ResumeCommand::new()
+    .last()
+    .model("o3")
+    .execute(&codex)
+    .await?;
+
+// Fork a session to try a different approach
+ForkCommand::new()
+    .session_id("abc-123")
+    .prompt("try a different approach")
+    .execute(&codex)
+    .await?;
+```
+
+## Shell Completions
+
+```rust
+let output = CompletionCommand::new()
+    .shell(Shell::Zsh)
+    .execute(&codex)
+    .await?;
+std::fs::write("_codex", &output.stdout)?;
+```
+
+## Feature Flags
+
+```rust
+// List all feature flags
+FeaturesListCommand::new().execute(&codex).await?;
+
+// Enable/disable features persistently
+FeaturesEnableCommand::new("web-search").execute(&codex).await?;
+FeaturesDisableCommand::new("web-search").execute(&codex).await?;
+```
+
+## Escape Hatch: RawCommand
+
+For subcommands or flags not yet covered by typed builders:
+
+```rust
+let output = RawCommand::new("cloud")
+    .arg("--json")
+    .execute(&codex)
+    .await?;
+```
+
+## Error Handling
+
+All commands return `Result<T>`, with errors typed via `thiserror`:
+
+```rust
+use codex_wrapper::Error;
+
+match ExecCommand::new("test").execute(&codex).await {
+    Ok(output) => println!("{}", output.stdout),
+    Err(Error::CommandFailed { stderr, exit_code, .. }) => {
+        eprintln!("failed (exit {}): {}", exit_code, stderr);
+    }
+    Err(Error::Timeout { .. }) => eprintln!("timed out"),
+    Err(Error::NotFound) => eprintln!("codex binary not in PATH"),
+    Err(e) => eprintln!("{e}"),
+}
+```
+
+## Retry Policy
+
+Configure automatic retries for transient failures:
+
+```rust
+use codex_wrapper::RetryPolicy;
+use std::time::Duration;
+
+let policy = RetryPolicy::new()
+    .max_attempts(5)
+    .initial_backoff(Duration::from_secs(2))
+    .exponential()
+    .retry_on_timeout(true)
+    .retry_on_exit_codes([1, 2]);
+
+// Set on the client (applies to all commands)
+let codex = Codex::builder().retry(policy).build()?;
+
+// Or override per-command
+let output = ExecCommand::new("flaky task")
+    .retry(RetryPolicy::new().max_attempts(10))
+    .execute(&codex)
+    .await?;
+```
+
+## Features
+
+Optional Cargo features (enabled by default):
+
+- `json` -- JSONL output parsing via `serde_json` (`execute_json_lines()`,
+  `execute_json()`, `JsonLineEvent`)
+
+## Testing
+
+```bash
+cargo test --lib --all-features           # Unit tests (no CLI required)
+cargo test --test integration -- --ignored # Integration tests (requires codex in PATH)
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/codex-wrapper/src/command/apply.rs
+++ b/crates/codex-wrapper/src/command/apply.rs
@@ -1,0 +1,46 @@
+/// Apply the latest diff produced by a Codex agent task.
+///
+/// Wraps `codex apply <task-id>`.
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Apply a Codex agent diff as `git apply` to the local working tree.
+#[derive(Debug, Clone)]
+pub struct ApplyCommand {
+    task_id: String,
+}
+
+impl ApplyCommand {
+    /// Create an apply command for the given task ID.
+    #[must_use]
+    pub fn new(task_id: impl Into<String>) -> Self {
+        Self {
+            task_id: task_id.into(),
+        }
+    }
+}
+
+impl CodexCommand for ApplyCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["apply".into(), self.task_id.clone()]
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_args() {
+        let args = ApplyCommand::new("abc-123").args();
+        assert_eq!(args, vec!["apply", "abc-123"]);
+    }
+}

--- a/crates/codex-wrapper/src/command/completion.rs
+++ b/crates/codex-wrapper/src/command/completion.rs
@@ -1,0 +1,98 @@
+/// Generate shell completion scripts.
+///
+/// Wraps `codex completion [SHELL]`.
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Supported shells for completion generation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum Shell {
+    #[default]
+    Bash,
+    Elvish,
+    Fish,
+    Powershell,
+    Zsh,
+}
+
+impl Shell {
+    pub(crate) fn as_arg(self) -> &'static str {
+        match self {
+            Self::Bash => "bash",
+            Self::Elvish => "elvish",
+            Self::Fish => "fish",
+            Self::Powershell => "powershell",
+            Self::Zsh => "zsh",
+        }
+    }
+}
+
+/// Generate shell completion scripts for the Codex CLI.
+#[derive(Debug, Clone)]
+pub struct CompletionCommand {
+    shell: Option<Shell>,
+}
+
+impl CompletionCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { shell: None }
+    }
+
+    /// Set the target shell (defaults to bash if not specified).
+    #[must_use]
+    pub fn shell(mut self, shell: Shell) -> Self {
+        self.shell = Some(shell);
+        self
+    }
+}
+
+impl Default for CompletionCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for CompletionCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["completion".into()];
+        if let Some(shell) = self.shell {
+            args.push(shell.as_arg().into());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_default_args() {
+        assert_eq!(CompletionCommand::new().args(), vec!["completion"]);
+    }
+
+    #[test]
+    fn completion_zsh_args() {
+        assert_eq!(
+            CompletionCommand::new().shell(Shell::Zsh).args(),
+            vec!["completion", "zsh"]
+        );
+    }
+
+    #[test]
+    fn completion_fish_args() {
+        assert_eq!(
+            CompletionCommand::new().shell(Shell::Fish).args(),
+            vec!["completion", "fish"]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -1,9 +1,36 @@
 use crate::Codex;
 use crate::command::CodexCommand;
-use crate::error::{Error, Result};
+#[cfg(feature = "json")]
+use crate::error::Error;
+use crate::error::Result;
 use crate::exec::{self, CommandOutput};
-use crate::types::{ApprovalPolicy, Color, JsonLineEvent, SandboxMode};
+#[cfg(feature = "json")]
+use crate::types::JsonLineEvent;
+use crate::types::{ApprovalPolicy, Color, SandboxMode};
 
+/// Run Codex non-interactively (`codex exec <prompt>`).
+///
+/// This is the primary command for programmatic use. It supports the full
+/// range of exec flags: model selection, sandbox policy, approval policy,
+/// images, config overrides, feature flags, JSON output, and more.
+///
+/// # Example
+///
+/// ```no_run
+/// use codex_wrapper::{Codex, CodexCommand, ExecCommand, SandboxMode};
+///
+/// # async fn example() -> codex_wrapper::Result<()> {
+/// let codex = Codex::builder().build()?;
+/// let output = ExecCommand::new("fix the failing test")
+///     .model("o3")
+///     .sandbox(SandboxMode::WorkspaceWrite)
+///     .ephemeral()
+///     .execute(&codex)
+///     .await?;
+/// println!("{}", output.stdout);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct ExecCommand {
     prompt: Option<String>,
@@ -22,6 +49,7 @@ pub struct ExecCommand {
     cd: Option<String>,
     skip_git_repo_check: bool,
     add_dirs: Vec<String>,
+    search: bool,
     ephemeral: bool,
     output_schema: Option<String>,
     color: Option<Color>,
@@ -32,6 +60,7 @@ pub struct ExecCommand {
 }
 
 impl ExecCommand {
+    /// Create a new exec command with the given prompt.
     #[must_use]
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
@@ -51,6 +80,7 @@ impl ExecCommand {
             cd: None,
             skip_git_repo_check: false,
             add_dirs: Vec::new(),
+            search: false,
             ephemeral: false,
             output_schema: None,
             color: None,
@@ -61,6 +91,7 @@ impl ExecCommand {
         }
     }
 
+    /// Read the prompt from stdin (`-`).
     #[must_use]
     pub fn from_stdin() -> Self {
         Self::new("-")
@@ -153,6 +184,13 @@ impl ExecCommand {
     #[must_use]
     pub fn add_dir(mut self, dir: impl Into<String>) -> Self {
         self.add_dirs.push(dir.into());
+        self
+    }
+
+    /// Enable live web search.
+    #[must_use]
+    pub fn search(mut self) -> Self {
+        self.search = true;
         self
     }
 
@@ -258,6 +296,9 @@ impl CodexCommand for ExecCommand {
             args.push("--skip-git-repo-check".into());
         }
         push_repeat(&mut args, "--add-dir", &self.add_dirs);
+        if self.search {
+            args.push("--search".into());
+        }
         if self.ephemeral {
             args.push("--ephemeral".into());
         }
@@ -291,6 +332,10 @@ impl CodexCommand for ExecCommand {
     }
 }
 
+/// Resume a previous non-interactive session (`codex exec resume`).
+///
+/// Use [`session_id`](ExecResumeCommand::session_id) to target a specific
+/// session, or [`last`](ExecResumeCommand::last) to pick the most recent.
 #[derive(Debug, Clone)]
 pub struct ExecResumeCommand {
     session_id: Option<String>,

--- a/crates/codex-wrapper/src/command/features.rs
+++ b/crates/codex-wrapper/src/command/features.rs
@@ -1,0 +1,110 @@
+/// Feature flag management.
+///
+/// Wraps `codex features <list|enable|disable>`.
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// List known feature flags with their stage and effective state.
+#[derive(Debug, Clone, Default)]
+pub struct FeaturesListCommand;
+
+impl FeaturesListCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl CodexCommand for FeaturesListCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["features".into(), "list".into()]
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+/// Enable a feature flag in config.toml.
+#[derive(Debug, Clone)]
+pub struct FeaturesEnableCommand {
+    feature: String,
+}
+
+impl FeaturesEnableCommand {
+    #[must_use]
+    pub fn new(feature: impl Into<String>) -> Self {
+        Self {
+            feature: feature.into(),
+        }
+    }
+}
+
+impl CodexCommand for FeaturesEnableCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["features".into(), "enable".into(), self.feature.clone()]
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+/// Disable a feature flag in config.toml.
+#[derive(Debug, Clone)]
+pub struct FeaturesDisableCommand {
+    feature: String,
+}
+
+impl FeaturesDisableCommand {
+    #[must_use]
+    pub fn new(feature: impl Into<String>) -> Self {
+        Self {
+            feature: feature.into(),
+        }
+    }
+}
+
+impl CodexCommand for FeaturesDisableCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        vec!["features".into(), "disable".into(), self.feature.clone()]
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn features_list_args() {
+        assert_eq!(FeaturesListCommand::new().args(), vec!["features", "list"]);
+    }
+
+    #[test]
+    fn features_enable_args() {
+        assert_eq!(
+            FeaturesEnableCommand::new("web-search").args(),
+            vec!["features", "enable", "web-search"]
+        );
+    }
+
+    #[test]
+    fn features_disable_args() {
+        assert_eq!(
+            FeaturesDisableCommand::new("web-search").args(),
+            vec!["features", "disable", "web-search"]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/command/fork.rs
+++ b/crates/codex-wrapper/src/command/fork.rs
@@ -1,0 +1,300 @@
+/// Fork a previous interactive session.
+///
+/// Wraps `codex fork [session-id] [prompt]`.
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+use crate::types::{ApprovalPolicy, SandboxMode};
+
+/// Fork a previous interactive Codex session, creating a new branch of conversation.
+#[derive(Debug, Clone)]
+pub struct ForkCommand {
+    session_id: Option<String>,
+    prompt: Option<String>,
+    last: bool,
+    all: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    images: Vec<String>,
+    model: Option<String>,
+    oss: bool,
+    local_provider: Option<String>,
+    profile: Option<String>,
+    sandbox: Option<SandboxMode>,
+    approval_policy: Option<ApprovalPolicy>,
+    full_auto: bool,
+    dangerously_bypass_approvals_and_sandbox: bool,
+    cd: Option<String>,
+    search: bool,
+    add_dirs: Vec<String>,
+}
+
+impl ForkCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            session_id: None,
+            prompt: None,
+            last: false,
+            all: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            images: Vec::new(),
+            model: None,
+            oss: false,
+            local_provider: None,
+            profile: None,
+            sandbox: None,
+            approval_policy: None,
+            full_auto: false,
+            dangerously_bypass_approvals_and_sandbox: false,
+            cd: None,
+            search: false,
+            add_dirs: Vec::new(),
+        }
+    }
+
+    /// Session ID (UUID) to fork.
+    #[must_use]
+    pub fn session_id(mut self, id: impl Into<String>) -> Self {
+        self.session_id = Some(id.into());
+        self
+    }
+
+    /// Optional prompt to start the forked session with.
+    #[must_use]
+    pub fn prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompt = Some(prompt.into());
+        self
+    }
+
+    /// Fork the most recent session without showing the picker.
+    #[must_use]
+    pub fn last(mut self) -> Self {
+        self.last = true;
+        self
+    }
+
+    /// Show all sessions (disables cwd filtering).
+    #[must_use]
+    pub fn all(mut self) -> Self {
+        self.all = true;
+        self
+    }
+
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    #[must_use]
+    pub fn image(mut self, path: impl Into<String>) -> Self {
+        self.images.push(path.into());
+        self
+    }
+
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    #[must_use]
+    pub fn oss(mut self) -> Self {
+        self.oss = true;
+        self
+    }
+
+    #[must_use]
+    pub fn local_provider(mut self, provider: impl Into<String>) -> Self {
+        self.local_provider = Some(provider.into());
+        self
+    }
+
+    #[must_use]
+    pub fn profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
+        self
+    }
+
+    #[must_use]
+    pub fn sandbox(mut self, sandbox: SandboxMode) -> Self {
+        self.sandbox = Some(sandbox);
+        self
+    }
+
+    #[must_use]
+    pub fn approval_policy(mut self, policy: ApprovalPolicy) -> Self {
+        self.approval_policy = Some(policy);
+        self
+    }
+
+    #[must_use]
+    pub fn full_auto(mut self) -> Self {
+        self.full_auto = true;
+        self
+    }
+
+    #[must_use]
+    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+        self.dangerously_bypass_approvals_and_sandbox = true;
+        self
+    }
+
+    #[must_use]
+    pub fn cd(mut self, dir: impl Into<String>) -> Self {
+        self.cd = Some(dir.into());
+        self
+    }
+
+    /// Enable live web search.
+    #[must_use]
+    pub fn search(mut self) -> Self {
+        self.search = true;
+        self
+    }
+
+    #[must_use]
+    pub fn add_dir(mut self, dir: impl Into<String>) -> Self {
+        self.add_dirs.push(dir.into());
+        self
+    }
+}
+
+impl Default for ForkCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for ForkCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["fork".into()];
+
+        for v in &self.config_overrides {
+            args.push("-c".into());
+            args.push(v.clone());
+        }
+        for v in &self.enabled_features {
+            args.push("--enable".into());
+            args.push(v.clone());
+        }
+        for v in &self.disabled_features {
+            args.push("--disable".into());
+            args.push(v.clone());
+        }
+        if self.last {
+            args.push("--last".into());
+        }
+        if self.all {
+            args.push("--all".into());
+        }
+        for v in &self.images {
+            args.push("--image".into());
+            args.push(v.clone());
+        }
+        if let Some(model) = &self.model {
+            args.push("--model".into());
+            args.push(model.clone());
+        }
+        if self.oss {
+            args.push("--oss".into());
+        }
+        if let Some(provider) = &self.local_provider {
+            args.push("--local-provider".into());
+            args.push(provider.clone());
+        }
+        if let Some(profile) = &self.profile {
+            args.push("--profile".into());
+            args.push(profile.clone());
+        }
+        if let Some(sandbox) = self.sandbox {
+            args.push("--sandbox".into());
+            args.push(sandbox.as_arg().into());
+        }
+        if let Some(policy) = self.approval_policy {
+            args.push("--ask-for-approval".into());
+            args.push(policy.as_arg().into());
+        }
+        if self.full_auto {
+            args.push("--full-auto".into());
+        }
+        if self.dangerously_bypass_approvals_and_sandbox {
+            args.push("--dangerously-bypass-approvals-and-sandbox".into());
+        }
+        if let Some(cd) = &self.cd {
+            args.push("--cd".into());
+            args.push(cd.clone());
+        }
+        if self.search {
+            args.push("--search".into());
+        }
+        for v in &self.add_dirs {
+            args.push("--add-dir".into());
+            args.push(v.clone());
+        }
+        if let Some(id) = &self.session_id {
+            args.push(id.clone());
+        }
+        if let Some(prompt) = &self.prompt {
+            args.push(prompt.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fork_last_args() {
+        let args = ForkCommand::new()
+            .last()
+            .model("gpt-5")
+            .prompt("take a different approach")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "fork",
+                "--last",
+                "--model",
+                "gpt-5",
+                "take a different approach"
+            ]
+        );
+    }
+
+    #[test]
+    fn fork_session_id_args() {
+        let args = ForkCommand::new()
+            .session_id("abc-123")
+            .full_auto()
+            .search()
+            .args();
+        assert_eq!(args, vec!["fork", "--full-auto", "--search", "abc-123"]);
+    }
+}

--- a/crates/codex-wrapper/src/command/mcp.rs
+++ b/crates/codex-wrapper/src/command/mcp.rs
@@ -1,6 +1,8 @@
 use crate::Codex;
 use crate::command::CodexCommand;
-use crate::error::{Error, Result};
+#[cfg(feature = "json")]
+use crate::error::Error;
+use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 
 #[derive(Debug, Clone, Default)]

--- a/crates/codex-wrapper/src/command/mcp_server.rs
+++ b/crates/codex-wrapper/src/command/mcp_server.rs
@@ -1,0 +1,93 @@
+/// Start Codex as an MCP server (stdio).
+///
+/// Wraps `codex mcp-server`.
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Start Codex as an MCP server over stdio.
+#[derive(Debug, Clone, Default)]
+pub struct McpServerCommand {
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+}
+
+impl McpServerCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+}
+
+impl CodexCommand for McpServerCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["mcp-server".into()];
+        for v in &self.config_overrides {
+            args.push("-c".into());
+            args.push(v.clone());
+        }
+        for v in &self.enabled_features {
+            args.push("--enable".into());
+            args.push(v.clone());
+        }
+        for v in &self.disabled_features {
+            args.push("--disable".into());
+            args.push(v.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mcp_server_args() {
+        assert_eq!(McpServerCommand::new().args(), vec!["mcp-server"]);
+    }
+
+    #[test]
+    fn mcp_server_with_config_args() {
+        let args = McpServerCommand::new()
+            .config("model=\"gpt-5\"")
+            .enable("web-search")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "mcp-server",
+                "-c",
+                "model=\"gpt-5\"",
+                "--enable",
+                "web-search"
+            ]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/command/mod.rs
+++ b/crates/codex-wrapper/src/command/mod.rs
@@ -1,8 +1,21 @@
+//! Command builders for every Codex CLI subcommand.
+//!
+//! Each subcommand is a builder struct that implements [`CodexCommand`].
+//! Builders accumulate flags via method chaining, then call
+//! [`CodexCommand::execute`] with a [`Codex`] client to run.
+
+pub mod apply;
+pub mod completion;
 pub mod exec;
+pub mod features;
+pub mod fork;
 pub mod login;
 pub mod mcp;
+pub mod mcp_server;
 pub mod raw;
+pub mod resume;
 pub mod review;
+pub mod sandbox;
 pub mod version;
 
 use std::future::Future;
@@ -10,11 +23,18 @@ use std::future::Future;
 use crate::Codex;
 use crate::error::Result;
 
-/// Trait implemented by all codex CLI command builders.
+/// Trait implemented by all Codex CLI command builders.
+///
+/// [`args`](CodexCommand::args) returns the CLI arguments the builder would
+/// pass to the `codex` binary. [`execute`](CodexCommand::execute) spawns the
+/// process and returns typed output.
 pub trait CodexCommand: Send + Sync {
+    /// The type returned on success.
     type Output: Send;
 
+    /// Build the argument list for this command.
     fn args(&self) -> Vec<String>;
 
+    /// Execute the command against the given [`Codex`] client.
     fn execute(&self, codex: &Codex) -> impl Future<Output = Result<Self::Output>> + Send;
 }

--- a/crates/codex-wrapper/src/command/resume.rs
+++ b/crates/codex-wrapper/src/command/resume.rs
@@ -1,0 +1,303 @@
+/// Resume a previous interactive session.
+///
+/// Wraps the top-level `codex resume` command (distinct from `codex exec resume`).
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+use crate::types::{ApprovalPolicy, SandboxMode};
+
+/// Resume a previous interactive Codex session.
+#[derive(Debug, Clone)]
+pub struct ResumeCommand {
+    session_id: Option<String>,
+    prompt: Option<String>,
+    last: bool,
+    all: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    images: Vec<String>,
+    model: Option<String>,
+    oss: bool,
+    local_provider: Option<String>,
+    profile: Option<String>,
+    sandbox: Option<SandboxMode>,
+    approval_policy: Option<ApprovalPolicy>,
+    full_auto: bool,
+    dangerously_bypass_approvals_and_sandbox: bool,
+    cd: Option<String>,
+    search: bool,
+    add_dirs: Vec<String>,
+}
+
+impl ResumeCommand {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            session_id: None,
+            prompt: None,
+            last: false,
+            all: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            images: Vec::new(),
+            model: None,
+            oss: false,
+            local_provider: None,
+            profile: None,
+            sandbox: None,
+            approval_policy: None,
+            full_auto: false,
+            dangerously_bypass_approvals_and_sandbox: false,
+            cd: None,
+            search: false,
+            add_dirs: Vec::new(),
+        }
+    }
+
+    /// Session ID (UUID) or thread name to resume.
+    #[must_use]
+    pub fn session_id(mut self, id: impl Into<String>) -> Self {
+        self.session_id = Some(id.into());
+        self
+    }
+
+    /// Optional prompt to start the resumed session with.
+    #[must_use]
+    pub fn prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompt = Some(prompt.into());
+        self
+    }
+
+    /// Continue the most recent session without showing the picker.
+    #[must_use]
+    pub fn last(mut self) -> Self {
+        self.last = true;
+        self
+    }
+
+    /// Show all sessions (disables cwd filtering).
+    #[must_use]
+    pub fn all(mut self) -> Self {
+        self.all = true;
+        self
+    }
+
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    #[must_use]
+    pub fn image(mut self, path: impl Into<String>) -> Self {
+        self.images.push(path.into());
+        self
+    }
+
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    #[must_use]
+    pub fn oss(mut self) -> Self {
+        self.oss = true;
+        self
+    }
+
+    #[must_use]
+    pub fn local_provider(mut self, provider: impl Into<String>) -> Self {
+        self.local_provider = Some(provider.into());
+        self
+    }
+
+    #[must_use]
+    pub fn profile(mut self, profile: impl Into<String>) -> Self {
+        self.profile = Some(profile.into());
+        self
+    }
+
+    #[must_use]
+    pub fn sandbox(mut self, sandbox: SandboxMode) -> Self {
+        self.sandbox = Some(sandbox);
+        self
+    }
+
+    #[must_use]
+    pub fn approval_policy(mut self, policy: ApprovalPolicy) -> Self {
+        self.approval_policy = Some(policy);
+        self
+    }
+
+    #[must_use]
+    pub fn full_auto(mut self) -> Self {
+        self.full_auto = true;
+        self
+    }
+
+    #[must_use]
+    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+        self.dangerously_bypass_approvals_and_sandbox = true;
+        self
+    }
+
+    #[must_use]
+    pub fn cd(mut self, dir: impl Into<String>) -> Self {
+        self.cd = Some(dir.into());
+        self
+    }
+
+    /// Enable live web search.
+    #[must_use]
+    pub fn search(mut self) -> Self {
+        self.search = true;
+        self
+    }
+
+    #[must_use]
+    pub fn add_dir(mut self, dir: impl Into<String>) -> Self {
+        self.add_dirs.push(dir.into());
+        self
+    }
+}
+
+impl Default for ResumeCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for ResumeCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["resume".into()];
+
+        for v in &self.config_overrides {
+            args.push("-c".into());
+            args.push(v.clone());
+        }
+        for v in &self.enabled_features {
+            args.push("--enable".into());
+            args.push(v.clone());
+        }
+        for v in &self.disabled_features {
+            args.push("--disable".into());
+            args.push(v.clone());
+        }
+        if self.last {
+            args.push("--last".into());
+        }
+        if self.all {
+            args.push("--all".into());
+        }
+        for v in &self.images {
+            args.push("--image".into());
+            args.push(v.clone());
+        }
+        if let Some(model) = &self.model {
+            args.push("--model".into());
+            args.push(model.clone());
+        }
+        if self.oss {
+            args.push("--oss".into());
+        }
+        if let Some(provider) = &self.local_provider {
+            args.push("--local-provider".into());
+            args.push(provider.clone());
+        }
+        if let Some(profile) = &self.profile {
+            args.push("--profile".into());
+            args.push(profile.clone());
+        }
+        if let Some(sandbox) = self.sandbox {
+            args.push("--sandbox".into());
+            args.push(sandbox.as_arg().into());
+        }
+        if let Some(policy) = self.approval_policy {
+            args.push("--ask-for-approval".into());
+            args.push(policy.as_arg().into());
+        }
+        if self.full_auto {
+            args.push("--full-auto".into());
+        }
+        if self.dangerously_bypass_approvals_and_sandbox {
+            args.push("--dangerously-bypass-approvals-and-sandbox".into());
+        }
+        if let Some(cd) = &self.cd {
+            args.push("--cd".into());
+            args.push(cd.clone());
+        }
+        if self.search {
+            args.push("--search".into());
+        }
+        for v in &self.add_dirs {
+            args.push("--add-dir".into());
+            args.push(v.clone());
+        }
+        if let Some(id) = &self.session_id {
+            args.push(id.clone());
+        }
+        if let Some(prompt) = &self.prompt {
+            args.push(prompt.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_last_args() {
+        let args = ResumeCommand::new()
+            .last()
+            .model("gpt-5")
+            .prompt("continue")
+            .args();
+        assert_eq!(
+            args,
+            vec!["resume", "--last", "--model", "gpt-5", "continue"]
+        );
+    }
+
+    #[test]
+    fn resume_session_id_args() {
+        let args = ResumeCommand::new()
+            .session_id("abc-123")
+            .sandbox(SandboxMode::WorkspaceWrite)
+            .search()
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "resume",
+                "--sandbox",
+                "workspace-write",
+                "--search",
+                "abc-123"
+            ]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/command/review.rs
+++ b/crates/codex-wrapper/src/command/review.rs
@@ -1,7 +1,10 @@
 use crate::Codex;
 use crate::command::CodexCommand;
-use crate::error::{Error, Result};
+#[cfg(feature = "json")]
+use crate::error::Error;
+use crate::error::Result;
 use crate::exec::{self, CommandOutput};
+#[cfg(feature = "json")]
 use crate::types::JsonLineEvent;
 
 #[derive(Debug, Clone)]

--- a/crates/codex-wrapper/src/command/sandbox.rs
+++ b/crates/codex-wrapper/src/command/sandbox.rs
@@ -1,0 +1,105 @@
+/// Run commands within a Codex-provided sandbox.
+///
+/// Wraps `codex sandbox <macos|linux|windows> -- <command> [args...]`.
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Target sandbox platform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxPlatform {
+    /// macOS Seatbelt sandbox.
+    MacOs,
+    /// Linux sandbox (bubblewrap by default).
+    Linux,
+    /// Windows restricted token sandbox.
+    Windows,
+}
+
+impl SandboxPlatform {
+    pub(crate) fn as_arg(self) -> &'static str {
+        match self {
+            Self::MacOs => "macos",
+            Self::Linux => "linux",
+            Self::Windows => "windows",
+        }
+    }
+}
+
+/// Run a command within a Codex-provided sandbox.
+#[derive(Debug, Clone)]
+pub struct SandboxCommand {
+    platform: SandboxPlatform,
+    command: String,
+    command_args: Vec<String>,
+}
+
+impl SandboxCommand {
+    /// Create a sandbox command for the given platform and command.
+    #[must_use]
+    pub fn new(platform: SandboxPlatform, command: impl Into<String>) -> Self {
+        Self {
+            platform,
+            command: command.into(),
+            command_args: Vec::new(),
+        }
+    }
+
+    /// Add an argument to the sandboxed command.
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.command_args.push(arg.into());
+        self
+    }
+
+    /// Add multiple arguments to the sandboxed command.
+    #[must_use]
+    pub fn args(mut self, args: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.command_args.extend(args.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl CodexCommand for SandboxCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![
+            "sandbox".into(),
+            self.platform.as_arg().into(),
+            "--".into(),
+            self.command.clone(),
+        ];
+        args.extend(self.command_args.clone());
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex(codex, self.args()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::CodexCommand;
+
+    #[test]
+    fn sandbox_macos_args() {
+        let cmd = SandboxCommand::new(SandboxPlatform::MacOs, "ls").arg("-la");
+        assert_eq!(
+            CodexCommand::args(&cmd),
+            vec!["sandbox", "macos", "--", "ls", "-la"]
+        );
+    }
+
+    #[test]
+    fn sandbox_linux_args() {
+        let cmd = SandboxCommand::new(SandboxPlatform::Linux, "cat").arg("/etc/hosts");
+        assert_eq!(
+            CodexCommand::args(&cmd),
+            vec!["sandbox", "linux", "--", "cat", "/etc/hosts"]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -1,6 +1,8 @@
+//! Error types for `codex-wrapper`.
+
 use std::path::PathBuf;
 
-/// Errors returned by codex-wrapper operations.
+/// Errors returned by `codex-wrapper` operations.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// The `codex` binary was not found in PATH.

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -1,3 +1,6 @@
+//! Process execution layer for spawning and communicating with the `codex`
+//! binary, including timeout and retry support.
+
 use std::time::Duration;
 
 use tokio::process::Command;
@@ -6,12 +9,19 @@ use tracing::debug;
 use crate::Codex;
 use crate::error::{Error, Result};
 
-/// Raw output from a codex CLI invocation.
+/// Raw output from a Codex CLI invocation.
+///
+/// Contains captured stdout/stderr, the process exit code, and a convenience
+/// `success` flag.
 #[derive(Debug, Clone)]
 pub struct CommandOutput {
+    /// Standard output as a UTF-8 string.
     pub stdout: String,
+    /// Standard error as a UTF-8 string.
     pub stderr: String,
+    /// Process exit code (`-1` if the process was killed by a signal).
     pub exit_code: i32,
+    /// `true` when the process exited with code 0.
     pub success: bool,
 }
 

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -1,23 +1,25 @@
 //! A type-safe Codex CLI wrapper for Rust.
 //!
-//! `codex-wrapper` mirrors the builder-oriented shape of `claude-wrapper`, but
-//! targets the current Codex CLI surface.
+//! `codex-wrapper` provides a builder-pattern interface for invoking the
+//! `codex` CLI programmatically. It follows the same design philosophy as
+//! [`claude-wrapper`](https://crates.io/crates/claude-wrapper) and
+//! [`docker-wrapper`](https://crates.io/crates/docker-wrapper):
+//! each CLI subcommand is a builder struct that produces typed output.
 //!
 //! # Quick Start
 //!
 //! ```no_run
-//! use codex_wrapper::{Codex, ExecCommand, SandboxMode, ApprovalPolicy};
+//! use codex_wrapper::{Codex, CodexCommand, ExecCommand, SandboxMode};
 //!
 //! # async fn example() -> codex_wrapper::Result<()> {
 //! let codex = Codex::builder().build()?;
 //!
-//! // SandboxMode defaults to WorkspaceWrite; ApprovalPolicy defaults to OnRequest.
-//! // Both can be overridden per-command:
-//! let cmd = ExecCommand::new("fix the failing tests")
-//!     .sandbox_mode(SandboxMode::ReadOnly)
-//!     .approval_policy(ApprovalPolicy::Never);
+//! let output = ExecCommand::new("summarize this repository")
+//!     .sandbox(SandboxMode::WorkspaceWrite)
+//!     .ephemeral()
+//!     .execute(&codex)
+//!     .await?;
 //!
-//! let output = cmd.execute(&codex).await?;
 //! println!("{}", output.stdout);
 //! # Ok(())
 //! # }
@@ -29,6 +31,110 @@
 //! |------|-----------------|
 //! | [`SandboxMode`] | [`SandboxMode::WorkspaceWrite`] |
 //! | [`ApprovalPolicy`] | [`ApprovalPolicy::OnRequest`] |
+//!
+//! # Two-Layer Builder
+//!
+//! The [`Codex`] client holds shared config (binary path, env vars, timeout,
+//! retry policy). Command builders hold per-invocation options and call
+//! `execute(&codex)`.
+//!
+//! ```no_run
+//! use codex_wrapper::{Codex, CodexCommand, ExecCommand, ApprovalPolicy, RetryPolicy};
+//! use std::time::Duration;
+//!
+//! # async fn example() -> codex_wrapper::Result<()> {
+//! // Configure once, reuse across commands
+//! let codex = Codex::builder()
+//!     .env("OPENAI_API_KEY", "sk-...")
+//!     .timeout_secs(300)
+//!     .retry(RetryPolicy::new().max_attempts(3).exponential())
+//!     .build()?;
+//!
+//! // Each command is a separate builder
+//! let output = ExecCommand::new("fix the failing tests")
+//!     .model("o3")
+//!     .approval_policy(ApprovalPolicy::Never)
+//!     .skip_git_repo_check()
+//!     .ephemeral()
+//!     .execute(&codex)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # JSONL Output Parsing
+//!
+//! Use `execute_json_lines()` to get structured events from `--json` mode:
+//!
+//! ```no_run
+//! use codex_wrapper::{Codex, ExecCommand};
+//!
+//! # async fn example() -> codex_wrapper::Result<()> {
+//! let codex = Codex::builder().build()?;
+//! let events = ExecCommand::new("what is 2+2?")
+//!     .ephemeral()
+//!     .execute_json_lines(&codex)
+//!     .await?;
+//!
+//! for event in &events {
+//!     println!("{}: {:?}", event.event_type, event.extra);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Available Commands
+//!
+//! | Command | CLI equivalent |
+//! |---------|---------------|
+//! | [`ExecCommand`] | `codex exec <prompt>` |
+//! | [`ExecResumeCommand`] | `codex exec resume` |
+//! | [`ReviewCommand`] | `codex exec review` |
+//! | [`ResumeCommand`] | `codex resume` |
+//! | [`ForkCommand`] | `codex fork` |
+//! | [`LoginCommand`] | `codex login` |
+//! | [`LoginStatusCommand`] | `codex login status` |
+//! | [`LogoutCommand`] | `codex logout` |
+//! | [`McpListCommand`] | `codex mcp list` |
+//! | [`McpGetCommand`] | `codex mcp get` |
+//! | [`McpAddCommand`] | `codex mcp add` |
+//! | [`McpRemoveCommand`] | `codex mcp remove` |
+//! | [`McpLoginCommand`] | `codex mcp login` |
+//! | [`McpLogoutCommand`] | `codex mcp logout` |
+//! | [`McpServerCommand`] | `codex mcp-server` |
+//! | [`CompletionCommand`] | `codex completion` |
+//! | [`SandboxCommand`] | `codex sandbox` |
+//! | [`ApplyCommand`] | `codex apply` |
+//! | [`FeaturesListCommand`] | `codex features list` |
+//! | [`FeaturesEnableCommand`] | `codex features enable` |
+//! | [`FeaturesDisableCommand`] | `codex features disable` |
+//! | [`VersionCommand`] | `codex --version` |
+//! | [`RawCommand`] | Escape hatch for arbitrary args |
+//!
+//! # Error Handling
+//!
+//! All commands return [`Result<T>`], with typed errors via [`thiserror`]:
+//!
+//! ```no_run
+//! use codex_wrapper::{Codex, CodexCommand, ExecCommand, Error};
+//!
+//! # async fn example() -> codex_wrapper::Result<()> {
+//! let codex = Codex::builder().build()?;
+//! match ExecCommand::new("test").execute(&codex).await {
+//!     Ok(output) => println!("{}", output.stdout),
+//!     Err(Error::CommandFailed { stderr, exit_code, .. }) => {
+//!         eprintln!("failed (exit {}): {}", exit_code, stderr);
+//!     }
+//!     Err(Error::Timeout { .. }) => eprintln!("timed out"),
+//!     Err(e) => eprintln!("{e}"),
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Features
+//!
+//! - `json` *(enabled by default)* - JSONL output parsing via `serde_json`
 
 pub mod command;
 pub mod error;
@@ -42,14 +148,21 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub use command::CodexCommand;
+pub use command::apply::ApplyCommand;
+pub use command::completion::{CompletionCommand, Shell};
 pub use command::exec::{ExecCommand, ExecResumeCommand};
+pub use command::features::{FeaturesDisableCommand, FeaturesEnableCommand, FeaturesListCommand};
+pub use command::fork::ForkCommand;
 pub use command::login::{LoginCommand, LoginStatusCommand, LogoutCommand};
 pub use command::mcp::{
     McpAddCommand, McpGetCommand, McpListCommand, McpLoginCommand, McpLogoutCommand,
     McpRemoveCommand,
 };
+pub use command::mcp_server::McpServerCommand;
 pub use command::raw::RawCommand;
+pub use command::resume::ResumeCommand;
 pub use command::review::ReviewCommand;
+pub use command::sandbox::{SandboxCommand, SandboxPlatform};
 pub use command::version::VersionCommand;
 pub use error::{Error, Result};
 pub use exec::CommandOutput;
@@ -57,6 +170,23 @@ pub use retry::{BackoffStrategy, RetryPolicy};
 pub use types::*;
 pub use version::{CliVersion, VersionParseError};
 
+/// Shared Codex CLI client configuration.
+///
+/// Holds the binary path, working directory, environment variables, global
+/// arguments, timeout, and retry policy. Cheap to [`Clone`]; intended to be
+/// created once and reused across many command invocations.
+///
+/// # Example
+///
+/// ```no_run
+/// # fn example() -> codex_wrapper::Result<()> {
+/// let codex = codex_wrapper::Codex::builder()
+///     .env("OPENAI_API_KEY", "sk-...")
+///     .timeout_secs(120)
+///     .build()?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct Codex {
     pub(crate) binary: PathBuf,
@@ -68,21 +198,25 @@ pub struct Codex {
 }
 
 impl Codex {
+    /// Create a new [`CodexBuilder`].
     #[must_use]
     pub fn builder() -> CodexBuilder {
         CodexBuilder::default()
     }
 
+    /// Path to the resolved `codex` binary.
     #[must_use]
     pub fn binary(&self) -> &Path {
         &self.binary
     }
 
+    /// Working directory for command execution, if set.
     #[must_use]
     pub fn working_dir(&self) -> Option<&Path> {
         self.working_dir.as_deref()
     }
 
+    /// Return a clone of this client with a different working directory.
     #[must_use]
     pub fn with_working_dir(&self, dir: impl Into<PathBuf>) -> Self {
         let mut clone = self.clone();
@@ -90,6 +224,7 @@ impl Codex {
         clone
     }
 
+    /// Query the installed Codex CLI version.
     pub async fn cli_version(&self) -> Result<CliVersion> {
         let output = VersionCommand::new().execute(self).await?;
         CliVersion::parse_version_output(&output.stdout).map_err(|e| Error::Io {
@@ -99,6 +234,9 @@ impl Codex {
         })
     }
 
+    /// Verify the installed CLI meets a minimum version requirement.
+    ///
+    /// Returns [`Error::VersionMismatch`] if the installed version is too old.
     pub async fn check_version(&self, minimum: &CliVersion) -> Result<CliVersion> {
         let version = self.cli_version().await?;
         if version.satisfies_minimum(minimum) {
@@ -112,6 +250,10 @@ impl Codex {
     }
 }
 
+/// Builder for creating a [`Codex`] client.
+///
+/// All options are optional. By default the builder discovers the `codex`
+/// binary via `PATH`.
 #[derive(Debug, Default)]
 pub struct CodexBuilder {
     binary: Option<PathBuf>,
@@ -123,24 +265,28 @@ pub struct CodexBuilder {
 }
 
 impl CodexBuilder {
+    /// Set an explicit path to the `codex` binary (skips `PATH` lookup).
     #[must_use]
     pub fn binary(mut self, path: impl Into<PathBuf>) -> Self {
         self.binary = Some(path.into());
         self
     }
 
+    /// Set the working directory for all commands.
     #[must_use]
     pub fn working_dir(mut self, path: impl Into<PathBuf>) -> Self {
         self.working_dir = Some(path.into());
         self
     }
 
+    /// Set a single environment variable for child processes.
     #[must_use]
     pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.env.insert(key.into(), value.into());
         self
     }
 
+    /// Set multiple environment variables for child processes.
     #[must_use]
     pub fn envs(
         mut self,
@@ -152,24 +298,28 @@ impl CodexBuilder {
         self
     }
 
+    /// Set the command timeout in seconds.
     #[must_use]
     pub fn timeout_secs(mut self, seconds: u64) -> Self {
         self.timeout = Some(Duration::from_secs(seconds));
         self
     }
 
+    /// Set the command timeout as a [`Duration`].
     #[must_use]
     pub fn timeout(mut self, duration: Duration) -> Self {
         self.timeout = Some(duration);
         self
     }
 
+    /// Append a raw global argument passed before any subcommand.
     #[must_use]
     pub fn arg(mut self, arg: impl Into<String>) -> Self {
         self.global_args.push(arg.into());
         self
     }
 
+    /// Add a global config override (`-c key=value`).
     #[must_use]
     pub fn config(mut self, key_value: impl Into<String>) -> Self {
         self.global_args.push("-c".into());
@@ -177,6 +327,7 @@ impl CodexBuilder {
         self
     }
 
+    /// Enable a feature flag globally (`--enable <name>`).
     #[must_use]
     pub fn enable(mut self, feature: impl Into<String>) -> Self {
         self.global_args.push("--enable".into());
@@ -184,6 +335,7 @@ impl CodexBuilder {
         self
     }
 
+    /// Disable a feature flag globally (`--disable <name>`).
     #[must_use]
     pub fn disable(mut self, feature: impl Into<String>) -> Self {
         self.global_args.push("--disable".into());
@@ -191,12 +343,17 @@ impl CodexBuilder {
         self
     }
 
+    /// Set a default [`RetryPolicy`] for all commands.
     #[must_use]
     pub fn retry(mut self, policy: RetryPolicy) -> Self {
         self.retry_policy = Some(policy);
         self
     }
 
+    /// Build the [`Codex`] client.
+    ///
+    /// Returns [`Error::NotFound`] if no binary path was set and `codex` is
+    /// not found in `PATH`.
     pub fn build(self) -> Result<Codex> {
         let binary = match self.binary {
             Some(path) => path,

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -1,15 +1,23 @@
+//! Domain types shared across commands: enums for CLI options, version parsing,
+//! and structured JSONL events.
+
+#[cfg(feature = "json")]
 use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
+/// Sandbox policy for model-generated shell commands.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum SandboxMode {
+    /// Read-only filesystem access.
     ReadOnly,
+    /// Write access limited to the workspace directory (default).
     #[default]
     WorkspaceWrite,
+    /// Full filesystem access -- use with extreme caution.
     DangerFullAccess,
 }
 
@@ -23,13 +31,18 @@ impl SandboxMode {
     }
 }
 
+/// When the model should ask for human approval before executing commands.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ApprovalPolicy {
+    /// Only run trusted commands without asking.
     Untrusted,
+    /// Ask on failure (deprecated -- prefer `OnRequest` or `Never`).
     OnFailure,
+    /// The model decides when to ask (default).
     #[default]
     OnRequest,
+    /// Never ask for approval.
     Never,
 }
 
@@ -44,11 +57,15 @@ impl ApprovalPolicy {
     }
 }
 
+/// Color output mode for exec commands.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Color {
+    /// Always emit color codes.
     Always,
+    /// Never emit color codes.
     Never,
+    /// Auto-detect terminal support (default).
     #[default]
     Auto,
 }
@@ -63,6 +80,10 @@ impl Color {
     }
 }
 
+/// A single parsed JSONL event from `--json` output.
+///
+/// The `event_type` field corresponds to the `"type"` key in the JSON.
+/// All other fields are captured in `extra`.
 #[cfg(feature = "json")]
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct JsonLineEvent {
@@ -72,6 +93,9 @@ pub struct JsonLineEvent {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// Parsed semantic version of the Codex CLI (`major.minor.patch`).
+///
+/// Supports comparison and ordering for version-gating logic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CliVersion {
     pub major: u32,

--- a/crates/codex-wrapper/src/version.rs
+++ b/crates/codex-wrapper/src/version.rs
@@ -1,1 +1,3 @@
+//! Version parsing and comparison utilities.
+
 pub use crate::types::{CliVersion, VersionParseError};

--- a/crates/codex-wrapper/tests/integration.rs
+++ b/crates/codex-wrapper/tests/integration.rs
@@ -1,0 +1,303 @@
+//! Integration tests that require a real `codex` CLI binary in PATH.
+//!
+//! All tests are `#[ignore]` by default. Run them with:
+//!
+//! ```sh
+//! cargo test --test integration -- --ignored
+//! ```
+
+use codex_wrapper::{
+    ApplyCommand, Codex, CodexCommand, CompletionCommand, ExecCommand, FeaturesListCommand,
+    ForkCommand, LoginStatusCommand, McpListCommand, McpServerCommand, ResumeCommand,
+    ReviewCommand, SandboxCommand, SandboxPlatform, Shell, VersionCommand,
+};
+
+fn codex() -> Codex {
+    Codex::builder()
+        .build()
+        .expect("codex binary must be in PATH")
+}
+
+// ---------------------------------------------------------------------------
+// Version / discovery
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn version_command() {
+    let codex = codex();
+    let output = VersionCommand::new().execute(&codex).await.unwrap();
+    assert!(output.success);
+    assert!(
+        output.stdout.contains("codex-cli"),
+        "expected version string, got: {}",
+        output.stdout
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn cli_version_parsing() {
+    let codex = codex();
+    let version = codex.cli_version().await.unwrap();
+    assert!(version.major == 0, "unexpected major version: {version}");
+    assert!(version.minor > 0, "minor version should be > 0: {version}");
+}
+
+#[tokio::test]
+#[ignore]
+async fn check_version_satisfies() {
+    let codex = codex();
+    let minimum = codex_wrapper::CliVersion::new(0, 1, 0);
+    let version = codex.check_version(&minimum).await.unwrap();
+    assert!(version.satisfies_minimum(&minimum));
+}
+
+#[tokio::test]
+#[ignore]
+async fn check_version_too_high_fails() {
+    let codex = codex();
+    let minimum = codex_wrapper::CliVersion::new(999, 0, 0);
+    let result = codex.check_version(&minimum).await;
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Completion
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn completion_bash() {
+    let codex = codex();
+    let output = CompletionCommand::new()
+        .shell(Shell::Bash)
+        .execute(&codex)
+        .await
+        .unwrap();
+    assert!(output.success);
+    assert!(!output.stdout.is_empty());
+}
+
+#[tokio::test]
+#[ignore]
+async fn completion_zsh() {
+    let codex = codex();
+    let output = CompletionCommand::new()
+        .shell(Shell::Zsh)
+        .execute(&codex)
+        .await
+        .unwrap();
+    assert!(output.success);
+    assert!(output.stdout.contains("compdef") || output.stdout.contains("codex"));
+}
+
+// ---------------------------------------------------------------------------
+// Login status
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn login_status() {
+    let codex = codex();
+    let output = LoginStatusCommand::new().execute(&codex).await.unwrap();
+    assert!(output.success);
+    // login status writes to stderr, not stdout
+    assert!(
+        !output.stdout.is_empty() || !output.stderr.is_empty(),
+        "login status should produce output"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Features
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn features_list() {
+    let codex = codex();
+    let output = FeaturesListCommand::new().execute(&codex).await.unwrap();
+    assert!(output.success);
+    assert!(
+        output.stdout.contains("stable") || output.stdout.contains("experimental"),
+        "expected feature flags in output, got: {}",
+        output.stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// MCP
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn mcp_list() {
+    let codex = codex();
+    let output = McpListCommand::new().execute(&codex).await.unwrap();
+    assert!(output.success);
+}
+
+#[tokio::test]
+#[ignore]
+async fn mcp_list_json() {
+    let codex = codex();
+    let value = McpListCommand::new().execute_json(&codex).await.unwrap();
+    assert!(value.is_array(), "expected JSON array, got: {value}");
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn sandbox_echo() {
+    let codex = codex();
+    let output = SandboxCommand::new(SandboxPlatform::MacOs, "echo")
+        .arg("sandbox-test")
+        .execute(&codex)
+        .await
+        .unwrap();
+    assert!(output.success);
+    assert!(
+        output.stdout.contains("sandbox-test"),
+        "expected echo output, got: {}",
+        output.stdout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Exec (non-interactive)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn exec_simple() {
+    let codex = codex();
+    let output = ExecCommand::new("respond with just the word 'pong'")
+        .ephemeral()
+        .execute(&codex)
+        .await
+        .unwrap();
+    assert!(output.success);
+}
+
+#[tokio::test]
+#[ignore]
+async fn exec_json_lines() {
+    let codex = codex();
+    let events = ExecCommand::new("respond with just the word 'test'")
+        .ephemeral()
+        .execute_json_lines(&codex)
+        .await
+        .unwrap();
+    assert!(!events.is_empty(), "expected at least one JSONL event");
+
+    let types: Vec<&str> = events.iter().map(|e| e.event_type.as_str()).collect();
+    assert!(
+        types.contains(&"thread.started"),
+        "expected thread.started event, got: {types:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Review (requires git repo)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn review_uncommitted() {
+    let codex = codex();
+    let output = ReviewCommand::new()
+        .uncommitted()
+        .ephemeral()
+        .execute(&codex)
+        .await;
+    // May succeed or fail depending on git state, but should not panic
+    assert!(output.is_ok() || output.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Resume / Fork (interactive - just verify arg building doesn't break)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn resume_nonexistent_session_fails() {
+    let codex = codex();
+    let result = ResumeCommand::new()
+        .session_id("00000000-0000-0000-0000-000000000000")
+        .execute(&codex)
+        .await;
+    assert!(result.is_err(), "resuming a bogus session should fail");
+}
+
+#[tokio::test]
+#[ignore]
+async fn fork_nonexistent_session_fails() {
+    let codex = codex();
+    let result = ForkCommand::new()
+        .session_id("00000000-0000-0000-0000-000000000000")
+        .execute(&codex)
+        .await;
+    assert!(result.is_err(), "forking a bogus session should fail");
+}
+
+// ---------------------------------------------------------------------------
+// Apply (requires a task ID - just verify it fails gracefully)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn apply_bogus_task_fails() {
+    let codex = codex();
+    let result = ApplyCommand::new("not-a-real-task").execute(&codex).await;
+    assert!(result.is_err(), "applying a bogus task should fail");
+}
+
+// ---------------------------------------------------------------------------
+// McpServer (just verify args, can't really run it in test)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn mcp_server_args_valid() {
+    let cmd = McpServerCommand::new().config("model=\"gpt-5\"");
+    let args = CodexCommand::args(&cmd);
+    assert_eq!(args[0], "mcp-server");
+    // We don't execute this one -- it would block on stdio
+}
+
+// ---------------------------------------------------------------------------
+// Builder: with_working_dir
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn with_working_dir() {
+    let codex = codex().with_working_dir("/tmp");
+    let output = VersionCommand::new().execute(&codex).await.unwrap();
+    assert!(output.success);
+}
+
+// ---------------------------------------------------------------------------
+// Timeout
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn timeout_fires() {
+    let codex = Codex::builder()
+        .timeout(std::time::Duration::from_millis(1))
+        .build()
+        .unwrap();
+    let result = ExecCommand::new("count to a million slowly")
+        .ephemeral()
+        .execute(&codex)
+        .await;
+    assert!(
+        matches!(result, Err(codex_wrapper::Error::Timeout { .. })),
+        "expected timeout error, got: {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add 7 missing CLI command builders: `CompletionCommand`, `SandboxCommand`, `ApplyCommand`, `ResumeCommand` (top-level), `ForkCommand`, `FeaturesListCommand`/`FeaturesEnableCommand`/`FeaturesDisableCommand`, `McpServerCommand`
- Add `--search` flag to `ExecCommand`
- Add 20 `#[ignore]` integration tests that exercise the real `codex` binary (all pass locally)
- Add comprehensive rustdoc on all public types, traits, enum variants, and methods (7 doc-tests)
- Rewrite crate and workspace READMEs with full command table, usage examples for every major feature, error handling guidance

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (41 unit tests)
- [x] `cargo test --doc --all-features` (7 doc-tests)
- [x] `cargo doc --no-deps --all-features` (no warnings)
- [x] `cargo test --test integration -- --ignored` (20/20 pass with codex in PATH)