### PR TITLE
docs: note SandboxMode and ApprovalPolicy defaults in crate-level docs

### DIFF
--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -2,6 +2,33 @@
 //!
 //! `codex-wrapper` mirrors the builder-oriented shape of `claude-wrapper`, but
 //! targets the current Codex CLI surface.
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use codex_wrapper::{Codex, ExecCommand, SandboxMode, ApprovalPolicy};
+//!
+//! # async fn example() -> codex_wrapper::Result<()> {
+//! let codex = Codex::builder().build()?;
+//!
+//! // SandboxMode defaults to WorkspaceWrite; ApprovalPolicy defaults to OnRequest.
+//! // Both can be overridden per-command:
+//! let cmd = ExecCommand::new("fix the failing tests")
+//!     .sandbox_mode(SandboxMode::ReadOnly)
+//!     .approval_policy(ApprovalPolicy::Never);
+//!
+//! let output = cmd.execute(&codex).await?;
+//! println!("{}", output.stdout);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Defaults
+//!
+//! | Type | Default variant |
+//! |------|-----------------|
+//! | [`SandboxMode`] | [`SandboxMode::WorkspaceWrite`] |
+//! | [`ApprovalPolicy`] | [`ApprovalPolicy::OnRequest`] |
 
 pub mod command;
 pub mod error;


### PR DESCRIPTION
## Summary

- Documentation-only update to `crates/codex-wrapper/src/lib.rs`
- Adds a `# Quick Start` code example to the crate-level doc comment showing minimal usage
- Adds a `## Defaults` table explicitly documenting that `SandboxMode::WorkspaceWrite` and `ApprovalPolicy::OnRequest` are the default variants
- No source logic changes; purely improves discoverability of default behavior

## Files changed

- `crates/codex-wrapper/src/lib.rs` — expanded crate-level doc comment with quick-start example and defaults table

## Test plan

- [ ] `cargo doc --no-deps --all-features` builds without warnings
- [ ] `cargo test --doc --all-features` passes
- [ ] Doc links `[SandboxMode]` and `[ApprovalPolicy]` resolve correctly (re-exported via `pub use types::*`)
- [ ] Verified `SandboxMode::WorkspaceWrite` and `ApprovalPolicy::OnRequest` are marked `#[default]` in `types.rs`

Closes #3