### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## [0.1.1](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.0...v0.1.1) - 2026-03-23
+
+### Added
+
+- *(exec)* add Debug impl for CommandOutput that redacts long stdout/stderr ([#10](https://github.com/joshrotenberg/codex-wrapper/pull/10))
+- add missing CLI commands, integration tests, and docs ([#2](https://github.com/joshrotenberg/codex-wrapper/pull/2))
+
+### Fixed
+
+- *(exec)* validate non-empty model name in ExecCommand::model() ([#11](https://github.com/joshrotenberg/codex-wrapper/pull/11))
+
+### Other
+
+- *(error)* add Display impl test coverage for each Error variant closes #4 ([#7](https://github.com/joshrotenberg/codex-wrapper/pull/7))
+- note SandboxMode and ApprovalPolicy defaults in crate-level docs closes #3 ([#5](https://github.com/joshrotenberg/codex-wrapper/pull/5))
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-wrapper"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-wrapper"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `codex-wrapper`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.0...v0.1.1) - 2026-03-23

### Added

- *(exec)* add Debug impl for CommandOutput that redacts long stdout/stderr ([#10](https://github.com/joshrotenberg/codex-wrapper/pull/10))
- add missing CLI commands, integration tests, and docs ([#2](https://github.com/joshrotenberg/codex-wrapper/pull/2))

### Fixed

- *(exec)* validate non-empty model name in ExecCommand::model() ([#11](https://github.com/joshrotenberg/codex-wrapper/pull/11))

### Other

- *(error)* add Display impl test coverage for each Error variant closes #4 ([#7](https://github.com/joshrotenberg/codex-wrapper/pull/7))
- note SandboxMode and ApprovalPolicy defaults in crate-level docs closes #3 ([#5](https://github.com/joshrotenberg/codex-wrapper/pull/5))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).