### PR TITLE
test(error): add Display impl test coverage for each Error variant closes #4

### DIFF
--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -59,3 +59,95 @@ impl From<std::io::Error> for Error {
 
 /// Result type alias for codex-wrapper operations.
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_not_found() {
+        let err = Error::NotFound;
+        assert_eq!(err.to_string(), "codex binary not found in PATH");
+    }
+
+    #[test]
+    fn display_command_failed_minimal() {
+        let err = Error::CommandFailed {
+            command: "exec".to_string(),
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: String::new(),
+            working_dir: None,
+        };
+        assert_eq!(err.to_string(), "codex command failed: exec (exit code 1)");
+    }
+
+    #[test]
+    fn display_command_failed_with_all_fields() {
+        let err = Error::CommandFailed {
+            command: "exec".to_string(),
+            exit_code: 2,
+            stdout: "out".to_string(),
+            stderr: "err".to_string(),
+            working_dir: Some(PathBuf::from("/tmp")),
+        };
+        assert_eq!(
+            err.to_string(),
+            "codex command failed: exec (exit code 2) (in /tmp)\nstdout: out\nstderr: err"
+        );
+    }
+
+    #[test]
+    fn display_io_without_working_dir() {
+        let source = std::io::Error::other("disk full");
+        let err = Error::Io {
+            message: source.to_string(),
+            source,
+            working_dir: None,
+        };
+        assert_eq!(err.to_string(), "io error: disk full");
+    }
+
+    #[test]
+    fn display_io_with_working_dir() {
+        let source = std::io::Error::other("disk full");
+        let err = Error::Io {
+            message: source.to_string(),
+            source,
+            working_dir: Some(PathBuf::from("/home/user")),
+        };
+        assert_eq!(err.to_string(), "io error: disk full (in /home/user)");
+    }
+
+    #[test]
+    fn display_timeout() {
+        let err = Error::Timeout {
+            timeout_seconds: 30,
+        };
+        assert_eq!(err.to_string(), "codex command timed out after 30s");
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn display_json() {
+        let source: serde_json::Error =
+            serde_json::from_str::<serde_json::Value>("invalid").unwrap_err();
+        let err = Error::Json {
+            message: source.to_string(),
+            source,
+        };
+        assert!(err.to_string().starts_with("json parse error:"));
+    }
+
+    #[test]
+    fn display_version_mismatch() {
+        let err = Error::VersionMismatch {
+            found: crate::version::CliVersion::new(0, 100, 0),
+            minimum: crate::version::CliVersion::new(0, 116, 0),
+        };
+        assert_eq!(
+            err.to_string(),
+            "CLI version 0.100.0 does not meet minimum requirement 0.116.0"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `#[cfg(test)]` module to `error.rs` with unit tests verifying the `Display` output for each `Error` variant
- Covers all variants: `NotFound`, `CommandFailed` (minimal and all-fields), `Io` (with/without `working_dir`), `Timeout`, `Json` (feature-gated), and `VersionMismatch`
- Tests use idiomatic construction (`std::io::Error::other(...)`, `serde_json::from_str` on invalid JSON) without touching the filesystem or network
- All 34 library tests pass with `--all-features`

## Files changed
- `crates/codex-wrapper/src/error.rs` — added `#[cfg(test)]` module with 8 new `Display` tests

## Test plan
- [ ] `cargo test --lib --all-features` passes (34/34 ok)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes

Closes #4