### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.1...v0.1.2) - 2026-04-13
+
+### Added
+
+- add streaming support via callback (closes #20) ([#24](https://github.com/joshrotenberg/codex-wrapper/pull/24))
+- add execute_json_lines to ExecResumeCommand ([#19](https://github.com/joshrotenberg/codex-wrapper/pull/19))
+- add Session struct for multi-turn state management ([#25](https://github.com/joshrotenberg/codex-wrapper/pull/25))
+
+### Fixed
+
+- gate streaming tests behind cfg(unix) for Windows CI ([#27](https://github.com/joshrotenberg/codex-wrapper/pull/27))
+
+### Other
+
+- *(exec)* add doc comments to ExecCommand and ExecResumeCommand builder methods ([#17](https://github.com/joshrotenberg/codex-wrapper/pull/17))
+- *(command)* add doc comments to RawCommand and VersionCommand ([#15](https://github.com/joshrotenberg/codex-wrapper/pull/15))
+
 ## [0.1.1] - 2026-03-23
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-wrapper"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-wrapper"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `codex-wrapper`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.1...v0.1.2) - 2026-04-13

### Added

- add streaming support via callback (closes #20) ([#24](https://github.com/joshrotenberg/codex-wrapper/pull/24))
- add execute_json_lines to ExecResumeCommand ([#19](https://github.com/joshrotenberg/codex-wrapper/pull/19))
- add Session struct for multi-turn state management ([#25](https://github.com/joshrotenberg/codex-wrapper/pull/25))

### Fixed

- gate streaming tests behind cfg(unix) for Windows CI ([#27](https://github.com/joshrotenberg/codex-wrapper/pull/27))

### Other

- *(exec)* add doc comments to ExecCommand and ExecResumeCommand builder methods ([#17](https://github.com/joshrotenberg/codex-wrapper/pull/17))
- *(command)* add doc comments to RawCommand and VersionCommand ([#15](https://github.com/joshrotenberg/codex-wrapper/pull/15))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).