### PR TITLE
fix: gate streaming tests behind cfg(unix) for Windows CI

### DIFF
--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -182,7 +182,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};


### PR DESCRIPTION
All 4 streaming tests use /bin/bash to run fake-codex shell scripts, which does not exist on Windows. This gates the streaming test module with cfg(all(test, unix)) so the tests are skipped on Windows while still running on macOS and Linux CI.