### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.2...v0.2.0) - 2026-07-24
+
+### Added
+
+- close exec-adjacent flag drift on fork, resume, mcp add, login ([#49](https://github.com/joshrotenberg/codex-wrapper/pull/49))
+- add plugin command group ([#48](https://github.com/joshrotenberg/codex-wrapper/pull/48))
+- add doctor and update commands ([#46](https://github.com/joshrotenberg/codex-wrapper/pull/46))
+- add archive/delete/unarchive session-lifecycle commands ([#45](https://github.com/joshrotenberg/codex-wrapper/pull/45))
+- add typed QueryResult and make Error non_exhaustive for trait parity ([#44](https://github.com/joshrotenberg/codex-wrapper/pull/44))
+
+### Fixed
+
+- correct sandbox command for codex-cli 0.145.0, add real integration tests ([#50](https://github.com/joshrotenberg/codex-wrapper/pull/50))
+- catch codex exec family up to codex-cli 0.145.0 ([#42](https://github.com/joshrotenberg/codex-wrapper/pull/42))
+
 ## [0.1.2](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.1...v0.1.2) - 2026-04-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-wrapper"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-wrapper"
-version = "0.1.2"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `codex-wrapper`: 0.1.2 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `codex-wrapper` breaking changes

```text
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Error in /tmp/.tmpDEesyR/codex-wrapper/crates/codex-wrapper/src/error.rs:12
  enum Error in /tmp/.tmpDEesyR/codex-wrapper/crates/codex-wrapper/src/error.rs:12

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum codex_wrapper::command::sandbox::SandboxPlatform, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/sandbox.rs:11
  enum codex_wrapper::SandboxPlatform, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/sandbox.rs:11

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ExecCommand::approval_policy, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/exec.rs:170
  ExecCommand::search, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/exec.rs:223
  ExecCommand::progress_cursor, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/exec.rs:251
  ExecCommand::approval_policy, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/exec.rs:170
  ExecCommand::search, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/exec.rs:223
  ExecCommand::progress_cursor, previously in file /tmp/.tmpdHvS6f/codex-wrapper/src/command/exec.rs:251

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  codex_wrapper::command::sandbox::SandboxCommand::new takes 2 parameters in /tmp/.tmpdHvS6f/codex-wrapper/src/command/sandbox.rs:41, but now takes 1 parameters in /tmp/.tmpDEesyR/codex-wrapper/crates/codex-wrapper/src/command/sandbox.rs:30
  codex_wrapper::SandboxCommand::new takes 2 parameters in /tmp/.tmpdHvS6f/codex-wrapper/src/command/sandbox.rs:41, but now takes 1 parameters in /tmp/.tmpDEesyR/codex-wrapper/crates/codex-wrapper/src/command/sandbox.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/joshrotenberg/codex-wrapper/compare/v0.1.2...v0.2.0) - 2026-07-24

### Added

- close exec-adjacent flag drift on fork, resume, mcp add, login ([#49](https://github.com/joshrotenberg/codex-wrapper/pull/49))
- add plugin command group ([#48](https://github.com/joshrotenberg/codex-wrapper/pull/48))
- add doctor and update commands ([#46](https://github.com/joshrotenberg/codex-wrapper/pull/46))
- add archive/delete/unarchive session-lifecycle commands ([#45](https://github.com/joshrotenberg/codex-wrapper/pull/45))
- add typed QueryResult and make Error non_exhaustive for trait parity ([#44](https://github.com/joshrotenberg/codex-wrapper/pull/44))

### Fixed

- correct sandbox command for codex-cli 0.145.0, add real integration tests ([#50](https://github.com/joshrotenberg/codex-wrapper/pull/50))
- catch codex exec family up to codex-cli 0.145.0 ([#42](https://github.com/joshrotenberg/codex-wrapper/pull/42))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).