### PR TITLE
feat: add typed QueryResult and make Error non_exhaustive for trait parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,32 @@ let output = ExecCommand::new("fix the failing tests")
 | `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
 | `retry()` | *(client-side)* | Per-command retry policy |
 
+## Typed Result
+
+Use `execute_json()` for a typed `QueryResult` summarizing the run, assembled
+from the JSONL event stream. This mirrors `claude-wrapper`'s `QueryResult` so a
+downstream abstraction can treat both wrappers uniformly:
+
+```rust
+use codex_wrapper::ExecCommand;
+
+let result = ExecCommand::new("what is 2+2?")
+    .ephemeral()
+    .execute_json(&codex)
+    .await?;
+
+println!("{}", result.result);
+println!("thread: {:?}", result.thread_id);
+println!("cost: {:?}", result.cost_usd);
+```
+
+`QueryResult` fields: `result`, `session_id`, `thread_id`, `cost_usd`, and the
+full `events` stream as an escape hatch.
+
 ## JSONL Output Parsing
 
-Use `execute_json_lines()` to parse structured events from `--json` mode.
-Available on both `ExecCommand` and `ExecResumeCommand`:
+Use `execute_json_lines()` to parse the raw structured events from `--json`
+mode. Available on both `ExecCommand` and `ExecResumeCommand`:
 
 ```rust
 use codex_wrapper::ExecCommand;

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -140,9 +140,26 @@ All ExecCommand options:
 | `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
 | `retry()` | *(client-side)* | Per-command retry policy |
 
+## Typed Result
+
+Use `execute_json()` for a typed `QueryResult` summarizing the run (final
+`result` text, `session_id`, `thread_id`, `cost_usd`, and the full `events`
+stream). It mirrors `claude-wrapper`'s `QueryResult` so a downstream abstraction
+can treat both wrappers uniformly:
+
+```rust
+let result = ExecCommand::new("what is 2+2?")
+    .ephemeral()
+    .execute_json(&codex)
+    .await?;
+
+println!("{}", result.result);
+```
+
 ## JSONL Output Parsing
 
-Use `execute_json_lines()` to parse structured events from `--json` mode:
+Use `execute_json_lines()` to parse the raw structured events from `--json`
+mode:
 
 ```rust
 let events = ExecCommand::new("what is 2+2?")
@@ -311,7 +328,7 @@ let output = ExecCommand::new("flaky task")
 Optional Cargo features (enabled by default):
 
 - `json` -- JSONL output parsing via `serde_json` (`execute_json_lines()`,
-  `execute_json()`, `JsonLineEvent`)
+  `execute_json()`, `QueryResult`, `JsonLineEvent`)
 
 ## Testing
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -4,15 +4,15 @@ use crate::command::CodexCommand;
 use crate::error::Error;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
-#[cfg(feature = "json")]
-use crate::types::JsonLineEvent;
 use crate::types::{Color, SandboxMode};
+#[cfg(feature = "json")]
+use crate::types::{JsonLineEvent, QueryResult};
 
 /// Run Codex non-interactively (`codex exec <prompt>`).
 ///
 /// This is the primary command for programmatic use. It supports the full
-/// range of exec flags: model selection, sandbox policy, approval policy,
-/// images, config overrides, feature flags, JSON output, and more.
+/// range of exec flags: model selection, sandbox policy, images, config
+/// overrides, feature flags, JSON output, and more.
 ///
 /// # Example
 ///
@@ -339,6 +339,17 @@ impl ExecCommand {
         let output = exec::run_codex_with_retry(codex, args, self.retry_policy.as_ref()).await?;
         parse_json_lines(&output.stdout)
     }
+
+    /// Execute the command and return a typed [`QueryResult`].
+    ///
+    /// Assembles the final result text, ids, and cost from the JSONL event
+    /// stream. Use [`execute_json_lines`](ExecCommand::execute_json_lines) for
+    /// the raw event stream. Requires the `json` feature.
+    #[cfg(feature = "json")]
+    pub async fn execute_json(&self, codex: &Codex) -> Result<QueryResult> {
+        let events = self.execute_json_lines(codex).await?;
+        Ok(QueryResult::from_events(events))
+    }
 }
 
 impl CodexCommand for ExecCommand {
@@ -636,6 +647,16 @@ impl ExecResumeCommand {
 
         let output = exec::run_codex_with_retry(codex, args, self.retry_policy.as_ref()).await?;
         parse_json_lines(&output.stdout)
+    }
+
+    /// Execute the resume command and return a typed [`QueryResult`].
+    ///
+    /// Assembles the final result text, ids, and cost from the JSONL event
+    /// stream. Requires the `json` feature.
+    #[cfg(feature = "json")]
+    pub async fn execute_json(&self, codex: &Codex) -> Result<QueryResult> {
+        let events = self.execute_json_lines(codex).await?;
+        Ok(QueryResult::from_events(events))
     }
 
     /// Stream JSONL events from the resume command, invoking `handler` for

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -3,7 +3,12 @@
 use std::path::PathBuf;
 
 /// Errors returned by `codex-wrapper` operations.
+///
+/// This enum is `#[non_exhaustive]`: match arms must include a `_` catch-all so
+/// new variants can be added without a breaking change. This mirrors
+/// `claude-wrapper`'s `Error` for cross-crate consistency.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     /// The `codex` binary was not found in PATH.
     #[error("codex binary not found in PATH")]

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -154,6 +154,64 @@ impl JsonLineEvent {
     }
 }
 
+/// A typed summary of a completed `codex exec` run, assembled from the JSONL
+/// event stream.
+///
+/// This mirrors the shape of `claude-wrapper`'s `QueryResult` so a downstream
+/// abstraction can treat both wrappers uniformly. The full parsed event stream
+/// is retained in [`events`](QueryResult::events) as an escape hatch for fields
+/// not surfaced here.
+#[cfg(feature = "json")]
+#[derive(Debug, Clone)]
+pub struct QueryResult {
+    /// Final assistant text from the terminal `completed` event.
+    ///
+    /// Empty if no `completed` event carried a `result.text` value.
+    pub result: String,
+    /// The `session_id` captured from the event stream, if any.
+    pub session_id: Option<String>,
+    /// The `thread_id` captured from the event stream, if any.
+    ///
+    /// This is Codex's native identifier for resuming a conversation.
+    pub thread_id: Option<String>,
+    /// Total cost in USD from the `completed` event, if reported.
+    pub cost_usd: Option<f64>,
+    /// The full parsed event stream this result was assembled from.
+    pub events: Vec<JsonLineEvent>,
+}
+
+#[cfg(feature = "json")]
+impl QueryResult {
+    /// Assemble a [`QueryResult`] from a parsed JSONL event stream.
+    ///
+    /// `result` and `cost_usd` are taken from the last `completed` event;
+    /// `session_id` and `thread_id` are the first occurrences in the stream.
+    #[must_use]
+    pub fn from_events(events: Vec<JsonLineEvent>) -> Self {
+        let completed = events.iter().rev().find(|e| e.is_completed());
+        let result = completed
+            .and_then(JsonLineEvent::result_text)
+            .unwrap_or_default()
+            .to_string();
+        let cost_usd = completed.and_then(JsonLineEvent::cost_usd);
+        let session_id = events
+            .iter()
+            .find_map(JsonLineEvent::session_id)
+            .map(str::to_string);
+        let thread_id = events
+            .iter()
+            .find_map(JsonLineEvent::thread_id)
+            .map(str::to_string);
+        Self {
+            result,
+            session_id,
+            thread_id,
+            cost_usd,
+            events,
+        }
+    }
+}
+
 /// Parsed semantic version of the Codex CLI (`major.minor.patch`).
 ///
 /// Supports comparison and ordering for version-gating logic.
@@ -332,5 +390,37 @@ mod tests {
     fn json_line_event_content_text_none_when_missing() {
         let event: JsonLineEvent = serde_json::from_str(r#"{"type":"message.delta"}"#).unwrap();
         assert_eq!(event.content_text(), None);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn query_result_from_events() {
+        let events: Vec<JsonLineEvent> = vec![
+            serde_json::from_str(
+                r#"{"type":"thread.started","session_id":"sess_1","thread_id":"thread_1"}"#,
+            )
+            .unwrap(),
+            serde_json::from_str(r#"{"type":"message.created","role":"assistant"}"#).unwrap(),
+            serde_json::from_str(r#"{"type":"completed","result":{"text":"done","cost":0.02}}"#)
+                .unwrap(),
+        ];
+        let result = QueryResult::from_events(events);
+        assert_eq!(result.result, "done");
+        assert_eq!(result.session_id.as_deref(), Some("sess_1"));
+        assert_eq!(result.thread_id.as_deref(), Some("thread_1"));
+        assert_eq!(result.cost_usd, Some(0.02));
+        assert_eq!(result.events.len(), 3);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn query_result_from_events_no_completed() {
+        let events: Vec<JsonLineEvent> =
+            vec![serde_json::from_str(r#"{"type":"message.created"}"#).unwrap()];
+        let result = QueryResult::from_events(events);
+        assert_eq!(result.result, "");
+        assert_eq!(result.cost_usd, None);
+        assert!(result.session_id.is_none());
+        assert!(result.thread_id.is_none());
     }
 }


### PR DESCRIPTION
Part of #41 (P2). Aligns the `codex-wrapper` API with `claude-wrapper` so a downstream project can target either through one trait.

## Motivation

`claude-wrapper` returns a typed `QueryResult` from `execute_json()` and has a `#[non_exhaustive]` `Error`. `codex-wrapper` only returned `Vec<JsonLineEvent>` and a closed `Error`. This PR closes those two gaps, which are the ones a shared `AgentClient`-style trait actually needs. The client builders already share `binary`/`env`/`timeout`/`retry`/`working_dir`, and the command traits are already shape-identical.

## Changes

- Add `QueryResult` (json feature): a typed view of a completed exec run, assembled from the JSONL event stream. Fields chosen to share a common subset with `claude-wrapper`'s `QueryResult`:
  - `result: String` (final assistant text)
  - `session_id: Option<String>`, `thread_id: Option<String>` (codex's native ids)
  - `cost_usd: Option<f64>`
  - `events: Vec<JsonLineEvent>` (full stream, escape hatch)
  - `QueryResult::from_events(...)` constructor built on the existing `JsonLineEvent` accessors, so it stays consistent with the already-shipped event contract.
- Add `ExecCommand::execute_json()` and `ExecResumeCommand::execute_json()` returning `QueryResult` (keeps `execute_json_lines()` for the raw stream).
- Make `Error` `#[non_exhaustive]` to match `claude-wrapper` and allow new variants without a break.

## Not in this PR

- Schema is derived from the same `JsonLineEvent` accessors the crate already ships (validated against the test fixture, not a live 0.145.0 run). A live-run schema check is a small follow-up.
- Builder method parity (`verbose`/`debug` are Claude-CLI globals with no codex equivalent; a `tested_cli_version_range` mirror is deferred).
- `Session` still returns `Vec<JsonLineEvent>`; a `QueryResult`-returning path can follow.

## Verification

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`
