### PR TITLE
feat: add doctor and update commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Each CLI subcommand is a separate builder:
 | `ArchiveCommand` | `codex archive` | Archive a saved session |
 | `DeleteCommand` | `codex delete` | Permanently delete a session |
 | `UnarchiveCommand` | `codex unarchive` | Restore an archived session |
+| `DoctorCommand` | `codex doctor` | Diagnose local install health |
+| `UpdateCommand` | `codex update` | Update Codex to the latest version |
 | `CompletionCommand` | `codex completion` | Generate shell completions |
 | `FeaturesListCommand` | `codex features list` | List feature flags |
 | `FeaturesEnableCommand` | `codex features enable` | Enable a feature |

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -93,6 +93,8 @@ Each CLI subcommand is a separate builder. Available commands:
 | `ArchiveCommand` | `codex archive` | Archive a saved session |
 | `DeleteCommand` | `codex delete` | Permanently delete a session |
 | `UnarchiveCommand` | `codex unarchive` | Restore an archived session |
+| `DoctorCommand` | `codex doctor` | Diagnose local install health |
+| `UpdateCommand` | `codex update` | Update Codex to the latest version |
 | `CompletionCommand` | `codex completion` | Generate shell completions |
 | `FeaturesListCommand` | `codex features list` | List feature flags |
 | `FeaturesEnableCommand` | `codex features enable` | Enable a feature |

--- a/crates/codex-wrapper/src/command/doctor.rs
+++ b/crates/codex-wrapper/src/command/doctor.rs
@@ -1,0 +1,180 @@
+//! Diagnose the local Codex installation (`codex doctor`).
+
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Diagnose local Codex installation, config, auth, and runtime health.
+///
+/// Wraps `codex doctor`. Use [`json`](DoctorCommand::json) for a redacted
+/// machine-readable report on stdout.
+#[derive(Debug, Clone)]
+pub struct DoctorCommand {
+    json: bool,
+    summary: bool,
+    all: bool,
+    no_color: bool,
+    ascii: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl DoctorCommand {
+    /// Create a new doctor command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            json: false,
+            summary: false,
+            all: false,
+            no_color: false,
+            ascii: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Emit a redacted machine-readable report (`--json`).
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    /// Only show grouped check rows and the final count summary (`--summary`).
+    #[must_use]
+    pub fn summary(mut self) -> Self {
+        self.summary = true;
+        self
+    }
+
+    /// Expand long lists in detailed human output (`--all`).
+    #[must_use]
+    pub fn all(mut self) -> Self {
+        self.all = true;
+        self
+    }
+
+    /// Disable ANSI color in human output (`--no-color`).
+    #[must_use]
+    pub fn no_color(mut self) -> Self {
+        self.no_color = true;
+        self
+    }
+
+    /// Use ASCII status labels and separators in human output (`--ascii`).
+    #[must_use]
+    pub fn ascii(mut self) -> Self {
+        self.ascii = true;
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl Default for DoctorCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for DoctorCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["doctor".to_string()];
+        for value in &self.config_overrides {
+            args.push("-c".into());
+            args.push(value.clone());
+        }
+        for value in &self.enabled_features {
+            args.push("--enable".into());
+            args.push(value.clone());
+        }
+        for value in &self.disabled_features {
+            args.push("--disable".into());
+            args.push(value.clone());
+        }
+        if self.json {
+            args.push("--json".into());
+        }
+        if self.summary {
+            args.push("--summary".into());
+        }
+        if self.all {
+            args.push("--all".into());
+        }
+        if self.no_color {
+            args.push("--no-color".into());
+        }
+        if self.ascii {
+            args.push("--ascii".into());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doctor_args_default() {
+        let args = DoctorCommand::new().args();
+        assert_eq!(args, vec!["doctor"]);
+    }
+
+    #[test]
+    fn doctor_args_flags() {
+        let args = DoctorCommand::new().json().summary().all().args();
+        assert_eq!(args, vec!["doctor", "--json", "--summary", "--all"]);
+    }
+
+    #[test]
+    fn doctor_args_config_and_output() {
+        let args = DoctorCommand::new()
+            .config("model=o3")
+            .no_color()
+            .ascii()
+            .args();
+        assert_eq!(
+            args,
+            vec!["doctor", "-c", "model=o3", "--no-color", "--ascii"]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/command/mod.rs
+++ b/crates/codex-wrapper/src/command/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod apply;
 pub mod completion;
+pub mod doctor;
 pub mod exec;
 pub mod features;
 pub mod fork;
@@ -17,6 +18,7 @@ pub mod resume;
 pub mod review;
 pub mod sandbox;
 pub mod session_mgmt;
+pub mod update;
 pub mod version;
 
 use std::future::Future;

--- a/crates/codex-wrapper/src/command/update.rs
+++ b/crates/codex-wrapper/src/command/update.rs
@@ -1,0 +1,106 @@
+//! Update Codex to the latest version (`codex update`).
+
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Update Codex to the latest version.
+///
+/// Wraps `codex update`.
+#[derive(Debug, Clone)]
+pub struct UpdateCommand {
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl UpdateCommand {
+    /// Create a new update command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl Default for UpdateCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for UpdateCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["update".to_string()];
+        for value in &self.config_overrides {
+            args.push("-c".into());
+            args.push(value.clone());
+        }
+        for value in &self.enabled_features {
+            args.push("--enable".into());
+            args.push(value.clone());
+        }
+        for value in &self.disabled_features {
+            args.push("--disable".into());
+            args.push(value.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn update_args_default() {
+        let args = UpdateCommand::new().args();
+        assert_eq!(args, vec!["update"]);
+    }
+
+    #[test]
+    fn update_args_config() {
+        let args = UpdateCommand::new().config("foo=bar").enable("beta").args();
+        assert_eq!(args, vec!["update", "-c", "foo=bar", "--enable", "beta"]);
+    }
+}

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -107,6 +107,8 @@
 //! | [`ArchiveCommand`] | `codex archive` |
 //! | [`DeleteCommand`] | `codex delete` |
 //! | [`UnarchiveCommand`] | `codex unarchive` |
+//! | [`DoctorCommand`] | `codex doctor` |
+//! | [`UpdateCommand`] | `codex update` |
 //! | [`FeaturesListCommand`] | `codex features list` |
 //! | [`FeaturesEnableCommand`] | `codex features enable` |
 //! | [`FeaturesDisableCommand`] | `codex features disable` |
@@ -156,6 +158,7 @@ use std::time::Duration;
 pub use command::CodexCommand;
 pub use command::apply::ApplyCommand;
 pub use command::completion::{CompletionCommand, Shell};
+pub use command::doctor::DoctorCommand;
 pub use command::exec::{ExecCommand, ExecResumeCommand};
 pub use command::features::{FeaturesDisableCommand, FeaturesEnableCommand, FeaturesListCommand};
 pub use command::fork::ForkCommand;
@@ -170,6 +173,7 @@ pub use command::resume::ResumeCommand;
 pub use command::review::ReviewCommand;
 pub use command::sandbox::{SandboxCommand, SandboxPlatform};
 pub use command::session_mgmt::{ArchiveCommand, DeleteCommand, UnarchiveCommand};
+pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;
 pub use error::{Error, Result};
 pub use exec::CommandOutput;


### PR DESCRIPTION
Part of #41 (P3). Adds builders for `codex doctor` and `codex update`, new in `codex-cli` 0.145.0.

## Commands

| Builder | CLI | Options exposed |
|---|---|---|
| `DoctorCommand::new()` | `codex doctor` | `json()`, `summary()`, `all()`, `no_color()`, `ascii()`, config passthrough, `retry()` |
| `UpdateCommand::new()` | `codex update` | config passthrough, `retry()` |

`doctor` diagnoses the local install, config, auth, and runtime health; `--json` emits a redacted machine-readable report. `update` updates Codex to the latest version.

## Notes

- Flag names verified against the 0.145.0 binary (`--json`, `--summary`, `--all`, `--no-color`, `--ascii` for doctor; only `-c`/`--enable`/`--disable` for update).
- `DoctorCommand` returns `CommandOutput`; the `--json` stdout is left for the caller to parse. A typed `DoctorReport` is deferred until the schema is captured from a real run rather than guessed.

## Changes

- New modules `command/doctor.rs` and `command/update.rs`.
- Register modules and re-export `DoctorCommand` / `UpdateCommand`.
- Add both to the command table in the crate docs and READMEs.
- Arg-order unit tests.

## Verification

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`
