### PR TITLE
feat: add plugin command group

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ Each CLI subcommand is a separate builder:
 | `UnarchiveCommand` | `codex unarchive` | Restore an archived session |
 | `DoctorCommand` | `codex doctor` | Diagnose local install health |
 | `UpdateCommand` | `codex update` | Update Codex to the latest version |
+| `PluginAddCommand` | `codex plugin add` | Install a plugin |
+| `PluginListCommand` | `codex plugin list` | List available plugins |
+| `PluginRemoveCommand` | `codex plugin remove` | Remove an installed plugin |
+| `PluginMarketplaceAddCommand` | `codex plugin marketplace add` | Add a marketplace source |
+| `PluginMarketplaceListCommand` | `codex plugin marketplace list` | List marketplace sources |
+| `PluginMarketplaceUpgradeCommand` | `codex plugin marketplace upgrade` | Refresh Git marketplaces |
+| `PluginMarketplaceRemoveCommand` | `codex plugin marketplace remove` | Remove a marketplace source |
 | `CompletionCommand` | `codex completion` | Generate shell completions |
 | `FeaturesListCommand` | `codex features list` | List feature flags |
 | `FeaturesEnableCommand` | `codex features enable` | Enable a feature |

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -95,6 +95,13 @@ Each CLI subcommand is a separate builder. Available commands:
 | `UnarchiveCommand` | `codex unarchive` | Restore an archived session |
 | `DoctorCommand` | `codex doctor` | Diagnose local install health |
 | `UpdateCommand` | `codex update` | Update Codex to the latest version |
+| `PluginAddCommand` | `codex plugin add` | Install a plugin |
+| `PluginListCommand` | `codex plugin list` | List available plugins |
+| `PluginRemoveCommand` | `codex plugin remove` | Remove an installed plugin |
+| `PluginMarketplaceAddCommand` | `codex plugin marketplace add` | Add a marketplace source |
+| `PluginMarketplaceListCommand` | `codex plugin marketplace list` | List marketplace sources |
+| `PluginMarketplaceUpgradeCommand` | `codex plugin marketplace upgrade` | Refresh Git marketplaces |
+| `PluginMarketplaceRemoveCommand` | `codex plugin marketplace remove` | Remove a marketplace source |
 | `CompletionCommand` | `codex completion` | Generate shell completions |
 | `FeaturesListCommand` | `codex features list` | List feature flags |
 | `FeaturesEnableCommand` | `codex features enable` | Enable a feature |

--- a/crates/codex-wrapper/src/command/mod.rs
+++ b/crates/codex-wrapper/src/command/mod.rs
@@ -13,6 +13,7 @@ pub mod fork;
 pub mod login;
 pub mod mcp;
 pub mod mcp_server;
+pub mod plugin;
 pub mod raw;
 pub mod resume;
 pub mod review;

--- a/crates/codex-wrapper/src/command/plugin.rs
+++ b/crates/codex-wrapper/src/command/plugin.rs
@@ -1,0 +1,798 @@
+//! Manage Codex plugins (`codex plugin`).
+//!
+//! Covers the direct plugin operations (`add`, `list`, `remove`) and the
+//! nested marketplace-source management commands (`plugin marketplace add /
+//! list / upgrade / remove`).
+//!
+//! Plugin selectors follow the CLI's `PLUGIN@MARKETPLACE` form; the
+//! [`marketplace`](PluginAddCommand::marketplace) builder covers the
+//! `PLUGIN` + `-m MARKETPLACE` alternative.
+
+use crate::Codex;
+use crate::command::CodexCommand;
+use crate::error::Result;
+use crate::exec::{self, CommandOutput};
+
+/// Append the `-c`/`--enable`/`--disable` passthrough shared by every builder.
+fn push_config(
+    args: &mut Vec<String>,
+    config_overrides: &[String],
+    enabled: &[String],
+    disabled: &[String],
+) {
+    for value in config_overrides {
+        args.push("-c".into());
+        args.push(value.clone());
+    }
+    for value in enabled {
+        args.push("--enable".into());
+        args.push(value.clone());
+    }
+    for value in disabled {
+        args.push("--disable".into());
+        args.push(value.clone());
+    }
+}
+
+/// Install a plugin from a configured marketplace snapshot
+/// (`codex plugin add <PLUGIN[@MARKETPLACE]>`).
+#[derive(Debug, Clone)]
+pub struct PluginAddCommand {
+    selector: String,
+    marketplace: Option<String>,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginAddCommand {
+    /// Create an add command for a plugin selector (`PLUGIN` or
+    /// `PLUGIN@MARKETPLACE`).
+    #[must_use]
+    pub fn new(selector: impl Into<String>) -> Self {
+        Self {
+            selector: selector.into(),
+            marketplace: None,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Marketplace name to use when the selector omits `@MARKETPLACE` (`-m`).
+    #[must_use]
+    pub fn marketplace(mut self, name: impl Into<String>) -> Self {
+        self.marketplace = Some(name.into());
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl CodexCommand for PluginAddCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["plugin".to_string(), "add".to_string()];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if let Some(name) = &self.marketplace {
+            args.push("--marketplace".into());
+            args.push(name.clone());
+        }
+        args.push(self.selector.clone());
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+/// List plugins available from configured marketplace snapshots
+/// (`codex plugin list`).
+#[derive(Debug, Clone)]
+pub struct PluginListCommand {
+    marketplace: Option<String>,
+    json: bool,
+    available: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginListCommand {
+    /// Create a plugin list command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            marketplace: None,
+            json: false,
+            available: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Only list plugins from this configured marketplace name (`-m`).
+    #[must_use]
+    pub fn marketplace(mut self, name: impl Into<String>) -> Self {
+        self.marketplace = Some(name.into());
+        self
+    }
+
+    /// Output the plugin list as JSON (`--json`).
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    /// Include uninstalled marketplace plugins in the JSON output
+    /// (`--available`).
+    #[must_use]
+    pub fn available(mut self) -> Self {
+        self.available = true;
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl Default for PluginListCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for PluginListCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["plugin".to_string(), "list".to_string()];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if let Some(name) = &self.marketplace {
+            args.push("--marketplace".into());
+            args.push(name.clone());
+        }
+        if self.json {
+            args.push("--json".into());
+        }
+        if self.available {
+            args.push("--available".into());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+/// Remove an installed plugin from local config and cache
+/// (`codex plugin remove <PLUGIN[@MARKETPLACE]>`).
+#[derive(Debug, Clone)]
+pub struct PluginRemoveCommand {
+    selector: String,
+    marketplace: Option<String>,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginRemoveCommand {
+    /// Create a remove command for a plugin selector (`PLUGIN` or
+    /// `PLUGIN@MARKETPLACE`).
+    #[must_use]
+    pub fn new(selector: impl Into<String>) -> Self {
+        Self {
+            selector: selector.into(),
+            marketplace: None,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Marketplace name to use when the selector omits `@MARKETPLACE` (`-m`).
+    #[must_use]
+    pub fn marketplace(mut self, name: impl Into<String>) -> Self {
+        self.marketplace = Some(name.into());
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl CodexCommand for PluginRemoveCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec!["plugin".to_string(), "remove".to_string()];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if let Some(name) = &self.marketplace {
+            args.push("--marketplace".into());
+            args.push(name.clone());
+        }
+        args.push(self.selector.clone());
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+/// Add a local or Git marketplace source
+/// (`codex plugin marketplace add <SOURCE>`).
+#[derive(Debug, Clone)]
+pub struct PluginMarketplaceAddCommand {
+    source: String,
+    git_ref: Option<String>,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginMarketplaceAddCommand {
+    /// Create a marketplace-add command for a source (local path,
+    /// `owner/repo[@ref]`, HTTPS Git URL, or SSH Git URL).
+    #[must_use]
+    pub fn new(source: impl Into<String>) -> Self {
+        Self {
+            source: source.into(),
+            git_ref: None,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Git ref to fetch for Git marketplace sources (`--ref`).
+    #[must_use]
+    pub fn git_ref(mut self, git_ref: impl Into<String>) -> Self {
+        self.git_ref = Some(git_ref.into());
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl CodexCommand for PluginMarketplaceAddCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![
+            "plugin".to_string(),
+            "marketplace".to_string(),
+            "add".to_string(),
+        ];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if let Some(git_ref) = &self.git_ref {
+            args.push("--ref".into());
+            args.push(git_ref.clone());
+        }
+        args.push(self.source.clone());
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+/// List configured plugin marketplaces (`codex plugin marketplace list`).
+#[derive(Debug, Clone)]
+pub struct PluginMarketplaceListCommand {
+    json: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginMarketplaceListCommand {
+    /// Create a marketplace list command.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            json: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Output the marketplace list as JSON (`--json`).
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl Default for PluginMarketplaceListCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for PluginMarketplaceListCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![
+            "plugin".to_string(),
+            "marketplace".to_string(),
+            "list".to_string(),
+        ];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if self.json {
+            args.push("--json".into());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+/// Refresh configured Git marketplace snapshots
+/// (`codex plugin marketplace upgrade [MARKETPLACE_NAME]`).
+///
+/// Omit the name to upgrade all configured Git marketplaces.
+#[derive(Debug, Clone)]
+pub struct PluginMarketplaceUpgradeCommand {
+    name: Option<String>,
+    json: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginMarketplaceUpgradeCommand {
+    /// Create a marketplace upgrade command (upgrades all Git marketplaces
+    /// unless [`name`](PluginMarketplaceUpgradeCommand::name) is set).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            name: None,
+            json: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Upgrade only this configured marketplace name.
+    #[must_use]
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Output the upgrade result as JSON (`--json`).
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl Default for PluginMarketplaceUpgradeCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexCommand for PluginMarketplaceUpgradeCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![
+            "plugin".to_string(),
+            "marketplace".to_string(),
+            "upgrade".to_string(),
+        ];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if self.json {
+            args.push("--json".into());
+        }
+        if let Some(name) = &self.name {
+            args.push(name.clone());
+        }
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+/// Remove a configured marketplace source by name
+/// (`codex plugin marketplace remove <MARKETPLACE_NAME>`).
+#[derive(Debug, Clone)]
+pub struct PluginMarketplaceRemoveCommand {
+    name: String,
+    json: bool,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    retry_policy: Option<crate::retry::RetryPolicy>,
+}
+
+impl PluginMarketplaceRemoveCommand {
+    /// Create a marketplace remove command for the given marketplace name.
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            json: false,
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            retry_policy: None,
+        }
+    }
+
+    /// Output the remove result as JSON (`--json`).
+    #[must_use]
+    pub fn json(mut self) -> Self {
+        self.json = true;
+        self
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Override the retry policy for this command.
+    #[must_use]
+    pub fn retry(mut self, policy: crate::retry::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+}
+
+impl CodexCommand for PluginMarketplaceRemoveCommand {
+    type Output = CommandOutput;
+
+    fn args(&self) -> Vec<String> {
+        let mut args = vec![
+            "plugin".to_string(),
+            "marketplace".to_string(),
+            "remove".to_string(),
+        ];
+        push_config(
+            &mut args,
+            &self.config_overrides,
+            &self.enabled_features,
+            &self.disabled_features,
+        );
+        if self.json {
+            args.push("--json".into());
+        }
+        args.push(self.name.clone());
+        args
+    }
+
+    async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plugin_add_args() {
+        let args = PluginAddCommand::new("hello@official").args();
+        assert_eq!(args, vec!["plugin", "add", "hello@official"]);
+    }
+
+    #[test]
+    fn plugin_add_args_with_marketplace_and_config() {
+        let args = PluginAddCommand::new("hello")
+            .marketplace("official")
+            .config("foo=bar")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "plugin",
+                "add",
+                "-c",
+                "foo=bar",
+                "--marketplace",
+                "official",
+                "hello",
+            ]
+        );
+    }
+
+    #[test]
+    fn plugin_list_args() {
+        let args = PluginListCommand::new().json().available().args();
+        assert_eq!(args, vec!["plugin", "list", "--json", "--available"]);
+    }
+
+    #[test]
+    fn plugin_remove_args() {
+        let args = PluginRemoveCommand::new("hello")
+            .marketplace("official")
+            .args();
+        assert_eq!(
+            args,
+            vec!["plugin", "remove", "--marketplace", "official", "hello"]
+        );
+    }
+
+    #[test]
+    fn marketplace_add_args() {
+        let args = PluginMarketplaceAddCommand::new("owner/repo")
+            .git_ref("main")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "plugin",
+                "marketplace",
+                "add",
+                "--ref",
+                "main",
+                "owner/repo",
+            ]
+        );
+    }
+
+    #[test]
+    fn marketplace_list_args() {
+        let args = PluginMarketplaceListCommand::new().json().args();
+        assert_eq!(args, vec!["plugin", "marketplace", "list", "--json"]);
+    }
+
+    #[test]
+    fn marketplace_upgrade_args_all() {
+        let args = PluginMarketplaceUpgradeCommand::new().args();
+        assert_eq!(args, vec!["plugin", "marketplace", "upgrade"]);
+    }
+
+    #[test]
+    fn marketplace_upgrade_args_named() {
+        let args = PluginMarketplaceUpgradeCommand::new()
+            .name("official")
+            .args();
+        assert_eq!(args, vec!["plugin", "marketplace", "upgrade", "official"]);
+    }
+
+    #[test]
+    fn marketplace_remove_args() {
+        let args = PluginMarketplaceRemoveCommand::new("official")
+            .json()
+            .args();
+        assert_eq!(
+            args,
+            vec!["plugin", "marketplace", "remove", "--json", "official"]
+        );
+    }
+}

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -109,6 +109,13 @@
 //! | [`UnarchiveCommand`] | `codex unarchive` |
 //! | [`DoctorCommand`] | `codex doctor` |
 //! | [`UpdateCommand`] | `codex update` |
+//! | [`PluginAddCommand`] | `codex plugin add` |
+//! | [`PluginListCommand`] | `codex plugin list` |
+//! | [`PluginRemoveCommand`] | `codex plugin remove` |
+//! | [`PluginMarketplaceAddCommand`] | `codex plugin marketplace add` |
+//! | [`PluginMarketplaceListCommand`] | `codex plugin marketplace list` |
+//! | [`PluginMarketplaceUpgradeCommand`] | `codex plugin marketplace upgrade` |
+//! | [`PluginMarketplaceRemoveCommand`] | `codex plugin marketplace remove` |
 //! | [`FeaturesListCommand`] | `codex features list` |
 //! | [`FeaturesEnableCommand`] | `codex features enable` |
 //! | [`FeaturesDisableCommand`] | `codex features disable` |
@@ -168,6 +175,10 @@ pub use command::mcp::{
     McpRemoveCommand,
 };
 pub use command::mcp_server::McpServerCommand;
+pub use command::plugin::{
+    PluginAddCommand, PluginListCommand, PluginMarketplaceAddCommand, PluginMarketplaceListCommand,
+    PluginMarketplaceRemoveCommand, PluginMarketplaceUpgradeCommand, PluginRemoveCommand,
+};
 pub use command::raw::RawCommand;
 pub use command::resume::ResumeCommand;
 pub use command::review::ReviewCommand;


### PR DESCRIPTION
Part of #41 (P3). Wraps the `codex plugin` command group, new in `codex-cli` 0.145.0. (`codex cloud` is held separately in #47 due to its experimental status.)

## Commands

Direct plugin operations:

| Builder | CLI | Args |
|---|---|---|
| `PluginAddCommand::new(selector)` | `codex plugin add <PLUGIN[@MARKETPLACE]>` | `marketplace()` (`-m`) |
| `PluginListCommand::new()` | `codex plugin list` | `marketplace()`, `json()`, `available()` |
| `PluginRemoveCommand::new(selector)` | `codex plugin remove <PLUGIN[@MARKETPLACE]>` | `marketplace()` (`-m`) |

Marketplace source management (`codex plugin marketplace ...`):

| Builder | CLI | Args |
|---|---|---|
| `PluginMarketplaceAddCommand::new(source)` | `... marketplace add <SOURCE>` | `git_ref()` (`--ref`) |
| `PluginMarketplaceListCommand::new()` | `... marketplace list` | `json()` |
| `PluginMarketplaceUpgradeCommand::new()` | `... marketplace upgrade [NAME]` | `name()`, `json()` |
| `PluginMarketplaceRemoveCommand::new(name)` | `... marketplace remove <NAME>` | `json()` |

Every builder also carries `config()` / `enable()` / `disable()` passthrough and `retry()`. All flags and the `--enable` acceptance on every subcommand were verified against the 0.145.0 binary.

## Notes

- The plugin subcommand `--help` output falls through to top-level help; the real per-subcommand surface comes from `codex plugin help <sub>`. Flags were confirmed by probing the parser directly.
- `--ref` is exposed as `git_ref()` to avoid the Rust `ref` keyword.
- Selectors use the CLI's `PLUGIN@MARKETPLACE` form; `marketplace()` covers the `PLUGIN` + `-m MARKETPLACE` alternative.
- Builders return `CommandOutput`; `--json` stdout is left for the caller to parse.

## Changes

- New module `command/plugin.rs` with the seven builders and a shared config-passthrough helper.
- Register the module and re-export all seven types.
- Add the group to the command table in the crate docs and both READMEs.
- Arg-order unit tests.

## Verification

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test`
