### PR TITLE
feat: close exec-adjacent flag drift on fork, resume, mcp add, login

### DIFF
--- a/crates/codex-wrapper/src/command/fork.rs
+++ b/crates/codex-wrapper/src/command/fork.rs
@@ -26,6 +26,11 @@ pub struct ForkCommand {
     approval_policy: Option<ApprovalPolicy>,
     full_auto: bool,
     dangerously_bypass_approvals_and_sandbox: bool,
+    dangerously_bypass_hook_trust: bool,
+    strict_config: bool,
+    no_alt_screen: bool,
+    remote: Option<String>,
+    remote_auth_token_env: Option<String>,
     cd: Option<String>,
     search: bool,
     add_dirs: Vec<String>,
@@ -51,6 +56,11 @@ impl ForkCommand {
             approval_policy: None,
             full_auto: false,
             dangerously_bypass_approvals_and_sandbox: false,
+            dangerously_bypass_hook_trust: false,
+            strict_config: false,
+            no_alt_screen: false,
+            remote: None,
+            remote_auth_token_env: None,
             cd: None,
             search: false,
             add_dirs: Vec::new(),
@@ -157,6 +167,42 @@ impl ForkCommand {
         self
     }
 
+    /// Bypass the hook trust prompt (`--dangerously-bypass-hook-trust`).
+    #[must_use]
+    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+        self.dangerously_bypass_hook_trust = true;
+        self
+    }
+
+    /// Error on unrecognized config keys (`--strict-config`).
+    #[must_use]
+    pub fn strict_config(mut self) -> Self {
+        self.strict_config = true;
+        self
+    }
+
+    /// Do not use the terminal alternate screen (`--no-alt-screen`).
+    #[must_use]
+    pub fn no_alt_screen(mut self) -> Self {
+        self.no_alt_screen = true;
+        self
+    }
+
+    /// Connect the TUI to a remote app server endpoint (`--remote <ADDR>`).
+    #[must_use]
+    pub fn remote(mut self, addr: impl Into<String>) -> Self {
+        self.remote = Some(addr.into());
+        self
+    }
+
+    /// Env var holding the bearer token for the remote app server
+    /// (`--remote-auth-token-env <ENV_VAR>`).
+    #[must_use]
+    pub fn remote_auth_token_env(mut self, env_var: impl Into<String>) -> Self {
+        self.remote_auth_token_env = Some(env_var.into());
+        self
+    }
+
     #[must_use]
     pub fn cd(mut self, dir: impl Into<String>) -> Self {
         self.cd = Some(dir.into());
@@ -240,6 +286,23 @@ impl CodexCommand for ForkCommand {
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
         }
+        if self.dangerously_bypass_hook_trust {
+            args.push("--dangerously-bypass-hook-trust".into());
+        }
+        if self.strict_config {
+            args.push("--strict-config".into());
+        }
+        if self.no_alt_screen {
+            args.push("--no-alt-screen".into());
+        }
+        if let Some(remote) = &self.remote {
+            args.push("--remote".into());
+            args.push(remote.clone());
+        }
+        if let Some(env_var) = &self.remote_auth_token_env {
+            args.push("--remote-auth-token-env".into());
+            args.push(env_var.clone());
+        }
         if let Some(cd) = &self.cd {
             args.push("--cd".into());
             args.push(cd.clone());
@@ -296,5 +359,31 @@ mod tests {
             .search()
             .args();
         assert_eq!(args, vec!["fork", "--full-auto", "--search", "abc-123"]);
+    }
+
+    #[test]
+    fn fork_new_flags_args() {
+        let args = ForkCommand::new()
+            .last()
+            .strict_config()
+            .dangerously_bypass_hook_trust()
+            .no_alt_screen()
+            .remote("ws://host:9000")
+            .remote_auth_token_env("CODEX_TOKEN")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "fork",
+                "--last",
+                "--dangerously-bypass-hook-trust",
+                "--strict-config",
+                "--no-alt-screen",
+                "--remote",
+                "ws://host:9000",
+                "--remote-auth-token-env",
+                "CODEX_TOKEN",
+            ]
+        );
     }
 }

--- a/crates/codex-wrapper/src/command/login.rs
+++ b/crates/codex-wrapper/src/command/login.rs
@@ -9,6 +9,7 @@ pub struct LoginCommand {
     enabled_features: Vec<String>,
     disabled_features: Vec<String>,
     with_api_key: bool,
+    with_access_token: bool,
     device_auth: bool,
 }
 
@@ -42,6 +43,13 @@ impl LoginCommand {
         self
     }
 
+    /// Read an access token from stdin (`--with-access-token`).
+    #[must_use]
+    pub fn with_access_token(mut self) -> Self {
+        self.with_access_token = true;
+        self
+    }
+
     #[must_use]
     pub fn device_auth(mut self) -> Self {
         self.device_auth = true;
@@ -62,6 +70,9 @@ impl CodexCommand for LoginCommand {
         );
         if self.with_api_key {
             args.push("--with-api-key".into());
+        }
+        if self.with_access_token {
+            args.push("--with-access-token".into());
         }
         if self.device_auth {
             args.push("--device-auth".into());
@@ -176,6 +187,14 @@ mod tests {
         assert_eq!(
             LoginCommand::new().with_api_key().args(),
             vec!["login", "--with-api-key"]
+        );
+    }
+
+    #[test]
+    fn login_with_access_token_args() {
+        assert_eq!(
+            LoginCommand::new().with_access_token().args(),
+            vec!["login", "--with-access-token"]
         );
     }
 

--- a/crates/codex-wrapper/src/command/mcp.rs
+++ b/crates/codex-wrapper/src/command/mcp.rs
@@ -131,6 +131,8 @@ enum McpAddTransport {
     Http {
         url: String,
         bearer_token_env_var: Option<String>,
+        oauth_client_id: Option<String>,
+        oauth_resource: Option<String>,
     },
 }
 
@@ -169,8 +171,31 @@ impl McpAddCommand {
             transport: McpAddTransport::Http {
                 url: url.into(),
                 bearer_token_env_var: None,
+                oauth_client_id: None,
+                oauth_resource: None,
             },
         }
+    }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
     }
 
     #[must_use]
@@ -197,6 +222,31 @@ impl McpAddCommand {
         } = &mut self.transport
         {
             *bearer_token_env_var = Some(env_var.into());
+        }
+        self
+    }
+
+    /// OAuth client id for an HTTP MCP server (`--oauth-client-id`).
+    ///
+    /// No-op on stdio transports.
+    #[must_use]
+    pub fn oauth_client_id(mut self, client_id: impl Into<String>) -> Self {
+        if let McpAddTransport::Http {
+            oauth_client_id, ..
+        } = &mut self.transport
+        {
+            *oauth_client_id = Some(client_id.into());
+        }
+        self
+    }
+
+    /// OAuth resource for an HTTP MCP server (`--oauth-resource`).
+    ///
+    /// No-op on stdio transports.
+    #[must_use]
+    pub fn oauth_resource(mut self, resource: impl Into<String>) -> Self {
+        if let McpAddTransport::Http { oauth_resource, .. } = &mut self.transport {
+            *oauth_resource = Some(resource.into());
         }
         self
     }
@@ -230,12 +280,22 @@ impl CodexCommand for McpAddCommand {
             McpAddTransport::Http {
                 url,
                 bearer_token_env_var,
+                oauth_client_id,
+                oauth_resource,
             } => {
                 args.push("--url".into());
                 args.push(url.clone());
                 if let Some(env_var) = bearer_token_env_var {
                     args.push("--bearer-token-env-var".into());
                     args.push(env_var.clone());
+                }
+                if let Some(client_id) = oauth_client_id {
+                    args.push("--oauth-client-id".into());
+                    args.push(client_id.clone());
+                }
+                if let Some(resource) = oauth_resource {
+                    args.push("--oauth-resource".into());
+                    args.push(resource.clone());
                 }
             }
         }
@@ -407,5 +467,42 @@ mod tests {
                 "TOKEN",
             ]
         );
+    }
+
+    #[test]
+    fn mcp_http_add_oauth_and_config_args() {
+        let args = McpAddCommand::http("server", "https://example.com/mcp")
+            .config("foo=bar")
+            .enable("beta")
+            .oauth_client_id("client-123")
+            .oauth_resource("https://api.example.com")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "mcp",
+                "add",
+                "-c",
+                "foo=bar",
+                "--enable",
+                "beta",
+                "server",
+                "--url",
+                "https://example.com/mcp",
+                "--oauth-client-id",
+                "client-123",
+                "--oauth-resource",
+                "https://api.example.com",
+            ]
+        );
+    }
+
+    #[test]
+    fn mcp_stdio_add_oauth_is_noop() {
+        // OAuth options only apply to HTTP transports.
+        let args = McpAddCommand::stdio("server", "uvx")
+            .oauth_client_id("ignored")
+            .args();
+        assert_eq!(args, vec!["mcp", "add", "server", "--", "uvx"]);
     }
 }

--- a/crates/codex-wrapper/src/command/resume.rs
+++ b/crates/codex-wrapper/src/command/resume.rs
@@ -26,6 +26,12 @@ pub struct ResumeCommand {
     approval_policy: Option<ApprovalPolicy>,
     full_auto: bool,
     dangerously_bypass_approvals_and_sandbox: bool,
+    dangerously_bypass_hook_trust: bool,
+    strict_config: bool,
+    no_alt_screen: bool,
+    include_non_interactive: bool,
+    remote: Option<String>,
+    remote_auth_token_env: Option<String>,
     cd: Option<String>,
     search: bool,
     add_dirs: Vec<String>,
@@ -51,6 +57,12 @@ impl ResumeCommand {
             approval_policy: None,
             full_auto: false,
             dangerously_bypass_approvals_and_sandbox: false,
+            dangerously_bypass_hook_trust: false,
+            strict_config: false,
+            no_alt_screen: false,
+            include_non_interactive: false,
+            remote: None,
+            remote_auth_token_env: None,
             cd: None,
             search: false,
             add_dirs: Vec::new(),
@@ -157,6 +169,50 @@ impl ResumeCommand {
         self
     }
 
+    /// Bypass the hook trust prompt (`--dangerously-bypass-hook-trust`).
+    #[must_use]
+    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+        self.dangerously_bypass_hook_trust = true;
+        self
+    }
+
+    /// Error on unrecognized config keys (`--strict-config`).
+    #[must_use]
+    pub fn strict_config(mut self) -> Self {
+        self.strict_config = true;
+        self
+    }
+
+    /// Do not use the terminal alternate screen (`--no-alt-screen`).
+    #[must_use]
+    pub fn no_alt_screen(mut self) -> Self {
+        self.no_alt_screen = true;
+        self
+    }
+
+    /// Include non-interactive sessions in the picker
+    /// (`--include-non-interactive`).
+    #[must_use]
+    pub fn include_non_interactive(mut self) -> Self {
+        self.include_non_interactive = true;
+        self
+    }
+
+    /// Connect the TUI to a remote app server endpoint (`--remote <ADDR>`).
+    #[must_use]
+    pub fn remote(mut self, addr: impl Into<String>) -> Self {
+        self.remote = Some(addr.into());
+        self
+    }
+
+    /// Env var holding the bearer token for the remote app server
+    /// (`--remote-auth-token-env <ENV_VAR>`).
+    #[must_use]
+    pub fn remote_auth_token_env(mut self, env_var: impl Into<String>) -> Self {
+        self.remote_auth_token_env = Some(env_var.into());
+        self
+    }
+
     #[must_use]
     pub fn cd(mut self, dir: impl Into<String>) -> Self {
         self.cd = Some(dir.into());
@@ -240,6 +296,26 @@ impl CodexCommand for ResumeCommand {
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
         }
+        if self.dangerously_bypass_hook_trust {
+            args.push("--dangerously-bypass-hook-trust".into());
+        }
+        if self.strict_config {
+            args.push("--strict-config".into());
+        }
+        if self.no_alt_screen {
+            args.push("--no-alt-screen".into());
+        }
+        if self.include_non_interactive {
+            args.push("--include-non-interactive".into());
+        }
+        if let Some(remote) = &self.remote {
+            args.push("--remote".into());
+            args.push(remote.clone());
+        }
+        if let Some(env_var) = &self.remote_auth_token_env {
+            args.push("--remote-auth-token-env".into());
+            args.push(env_var.clone());
+        }
         if let Some(cd) = &self.cd {
             args.push("--cd".into());
             args.push(cd.clone());
@@ -297,6 +373,29 @@ mod tests {
                 "workspace-write",
                 "--search",
                 "abc-123"
+            ]
+        );
+    }
+
+    #[test]
+    fn resume_new_flags_args() {
+        let args = ResumeCommand::new()
+            .last()
+            .strict_config()
+            .include_non_interactive()
+            .no_alt_screen()
+            .remote("ws://host:9000")
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "resume",
+                "--last",
+                "--strict-config",
+                "--no-alt-screen",
+                "--include-non-interactive",
+                "--remote",
+                "ws://host:9000",
             ]
         );
     }


### PR DESCRIPTION
Part of #41 (P3, flag-drift cleanup). Closes the smaller flag gaps on already-wrapped subcommands in `codex-cli` 0.145.0. All flags verified against the binary.

## Changes

`ForkCommand` (`codex fork`) new flags:
- `strict_config()` (`--strict-config`), `dangerously_bypass_hook_trust()` (`--dangerously-bypass-hook-trust`), `no_alt_screen()` (`--no-alt-screen`), `remote()` (`--remote <ADDR>`), `remote_auth_token_env()` (`--remote-auth-token-env <ENV_VAR>`)

`ResumeCommand` (`codex resume`) new flags:
- the same five, plus `include_non_interactive()` (`--include-non-interactive`)

`McpAddCommand` (`codex mcp add`):
- Add `config()` / `enable()` / `disable()` setters. The struct already carried these fields but had no builders, so `-c` / `--enable` / `--disable` could never be emitted.
- HTTP transport: `oauth_client_id()` (`--oauth-client-id`), `oauth_resource()` (`--oauth-resource`). No-ops on stdio transports, matching `bearer_token_env_var()`.

`LoginCommand` (`codex login`):
- `with_access_token()` (`--with-access-token`, reads the token from stdin, like `--with-api-key`)

## Deliberately deferred

The low-value `-c` / `--enable` / `--disable` passthrough on `apply`, `completion`, `features`, and `logout` is left out. These globals are meaningless for those operations (e.g. `codex logout -c ...`) and would add noise for no real use. Can be revisited if a need appears.

## Verification

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test` (102 unit + doctests)
