### PR TITLE
fix: correct sandbox command for codex-cli 0.145.0, add real integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,10 +322,13 @@ McpRemoveCommand::new("old-server").execute(&codex).await?;
 
 Run commands inside the Codex sandbox:
 
-```rust
-use codex_wrapper::{SandboxCommand, SandboxPlatform};
+The platform is auto-detected (Seatbelt on macOS, and so on); as of
+`codex-cli` 0.145.0 the old `<macos|linux|windows>` positional was removed.
 
-let output = SandboxCommand::new(SandboxPlatform::MacOs, "ls")
+```rust
+use codex_wrapper::SandboxCommand;
+
+let output = SandboxCommand::new("ls")
     .arg("-la")
     .execute(&codex)
     .await?;
@@ -436,13 +439,13 @@ let output = RawCommand::new("cloud")
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `json` | Yes | JSONL output parsing via `serde_json` -- enables `execute_json_lines()`, `stream()`, `Session`, `JsonLineEvent` and typed accessors |
+| `json` | Yes | JSONL output parsing via `serde_json` -- enables `execute_json_lines()`, `execute_json()`, `stream()`, `Session`, `QueryResult`, `JsonLineEvent` and typed accessors |
 
 To disable default features:
 
 ```toml
 [dependencies]
-codex-wrapper = { version = "0.1", default-features = false }
+codex-wrapper = { version = "0.2", default-features = false }
 ```
 
 ## Testing

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -233,10 +233,12 @@ McpRemoveCommand::new("old-server").execute(&codex).await?;
 
 ## Sandbox Execution
 
-Run commands inside the Codex sandbox:
+Run commands inside the Codex sandbox. The platform is auto-detected
+(Seatbelt on macOS, and so on); the `<macos|linux|windows>` positional was
+removed in `codex-cli` 0.145.0.
 
 ```rust
-let output = SandboxCommand::new(SandboxPlatform::MacOs, "ls")
+let output = SandboxCommand::new("ls")
     .arg("-la")
     .execute(&codex)
     .await?;

--- a/crates/codex-wrapper/src/command/sandbox.rs
+++ b/crates/codex-wrapper/src/command/sandbox.rs
@@ -1,48 +1,42 @@
-/// Run commands within a Codex-provided sandbox.
-///
-/// Wraps `codex sandbox <macos|linux|windows> -- <command> [args...]`.
+//! Run commands within a Codex-provided sandbox (`codex sandbox`).
+//!
+//! As of `codex-cli` 0.145.0 the platform is auto-detected (Seatbelt on macOS,
+//! and so on); the old `codex sandbox <macos|linux|windows>` positional was
+//! removed. The command to run is passed after a `--` separator.
+
 use crate::Codex;
 use crate::command::CodexCommand;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 
-/// Target sandbox platform.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SandboxPlatform {
-    /// macOS Seatbelt sandbox.
-    MacOs,
-    /// Linux sandbox (bubblewrap by default).
-    Linux,
-    /// Windows restricted token sandbox.
-    Windows,
-}
-
-impl SandboxPlatform {
-    pub(crate) fn as_arg(self) -> &'static str {
-        match self {
-            Self::MacOs => "macos",
-            Self::Linux => "linux",
-            Self::Windows => "windows",
-        }
-    }
-}
-
 /// Run a command within a Codex-provided sandbox.
+///
+/// Wraps `codex sandbox [OPTIONS] -- <command> [args...]`.
 #[derive(Debug, Clone)]
 pub struct SandboxCommand {
-    platform: SandboxPlatform,
     command: String,
     command_args: Vec<String>,
+    config_overrides: Vec<String>,
+    enabled_features: Vec<String>,
+    disabled_features: Vec<String>,
+    permission_profile: Option<String>,
+    profile: Option<String>,
+    cd: Option<String>,
 }
 
 impl SandboxCommand {
-    /// Create a sandbox command for the given platform and command.
+    /// Create a sandbox command for the given program.
     #[must_use]
-    pub fn new(platform: SandboxPlatform, command: impl Into<String>) -> Self {
+    pub fn new(command: impl Into<String>) -> Self {
         Self {
-            platform,
             command: command.into(),
             command_args: Vec::new(),
+            config_overrides: Vec::new(),
+            enabled_features: Vec::new(),
+            disabled_features: Vec::new(),
+            permission_profile: None,
+            profile: None,
+            cd: None,
         }
     }
 
@@ -59,18 +53,83 @@ impl SandboxCommand {
         self.command_args.extend(args.into_iter().map(Into::into));
         self
     }
+
+    /// Override a config key (`-c key=value`). May be called multiple times.
+    #[must_use]
+    pub fn config(mut self, key_value: impl Into<String>) -> Self {
+        self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Enable an optional feature flag (`--enable <feature>`).
+    #[must_use]
+    pub fn enable(mut self, feature: impl Into<String>) -> Self {
+        self.enabled_features.push(feature.into());
+        self
+    }
+
+    /// Disable an optional feature flag (`--disable <feature>`).
+    #[must_use]
+    pub fn disable(mut self, feature: impl Into<String>) -> Self {
+        self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Named permissions profile to apply (`-P, --permission-profile <NAME>`).
+    #[must_use]
+    pub fn permission_profile(mut self, name: impl Into<String>) -> Self {
+        self.permission_profile = Some(name.into());
+        self
+    }
+
+    /// Named config profile to layer on top of the base config
+    /// (`-p, --profile <NAME>`).
+    #[must_use]
+    pub fn profile(mut self, name: impl Into<String>) -> Self {
+        self.profile = Some(name.into());
+        self
+    }
+
+    /// Working directory for profile resolution and command execution
+    /// (`-C, --cd <DIR>`).
+    #[must_use]
+    pub fn cd(mut self, dir: impl Into<String>) -> Self {
+        self.cd = Some(dir.into());
+        self
+    }
 }
 
 impl CodexCommand for SandboxCommand {
     type Output = CommandOutput;
 
     fn args(&self) -> Vec<String> {
-        let mut args = vec![
-            "sandbox".into(),
-            self.platform.as_arg().into(),
-            "--".into(),
-            self.command.clone(),
-        ];
+        let mut args = vec!["sandbox".to_string()];
+        for value in &self.config_overrides {
+            args.push("-c".into());
+            args.push(value.clone());
+        }
+        for value in &self.enabled_features {
+            args.push("--enable".into());
+            args.push(value.clone());
+        }
+        for value in &self.disabled_features {
+            args.push("--disable".into());
+            args.push(value.clone());
+        }
+        if let Some(name) = &self.permission_profile {
+            args.push("--permission-profile".into());
+            args.push(name.clone());
+        }
+        if let Some(name) = &self.profile {
+            args.push("--profile".into());
+            args.push(name.clone());
+        }
+        if let Some(dir) = &self.cd {
+            args.push("--cd".into());
+            args.push(dir.clone());
+        }
+        args.push("--".into());
+        args.push(self.command.clone());
         args.extend(self.command_args.clone());
         args
     }
@@ -86,20 +145,29 @@ mod tests {
     use crate::command::CodexCommand;
 
     #[test]
-    fn sandbox_macos_args() {
-        let cmd = SandboxCommand::new(SandboxPlatform::MacOs, "ls").arg("-la");
-        assert_eq!(
-            CodexCommand::args(&cmd),
-            vec!["sandbox", "macos", "--", "ls", "-la"]
-        );
+    fn sandbox_basic_args() {
+        let cmd = SandboxCommand::new("ls").arg("-la");
+        assert_eq!(CodexCommand::args(&cmd), vec!["sandbox", "--", "ls", "-la"]);
     }
 
     #[test]
-    fn sandbox_linux_args() {
-        let cmd = SandboxCommand::new(SandboxPlatform::Linux, "cat").arg("/etc/hosts");
+    fn sandbox_args_with_options() {
+        let cmd = SandboxCommand::new("cat")
+            .permission_profile("readonly")
+            .cd("/tmp")
+            .args(["/etc/hosts"]);
         assert_eq!(
             CodexCommand::args(&cmd),
-            vec!["sandbox", "linux", "--", "cat", "/etc/hosts"]
+            vec![
+                "sandbox",
+                "--permission-profile",
+                "readonly",
+                "--cd",
+                "/tmp",
+                "--",
+                "cat",
+                "/etc/hosts",
+            ]
         );
     }
 }

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -182,7 +182,7 @@ pub use command::plugin::{
 pub use command::raw::RawCommand;
 pub use command::resume::ResumeCommand;
 pub use command::review::ReviewCommand;
-pub use command::sandbox::{SandboxCommand, SandboxPlatform};
+pub use command::sandbox::SandboxCommand;
 pub use command::session_mgmt::{ArchiveCommand, DeleteCommand, UnarchiveCommand};
 pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;

--- a/crates/codex-wrapper/tests/integration.rs
+++ b/crates/codex-wrapper/tests/integration.rs
@@ -7,9 +7,11 @@
 //! ```
 
 use codex_wrapper::{
-    ApplyCommand, Codex, CodexCommand, CompletionCommand, ExecCommand, ExecResumeCommand,
-    FeaturesListCommand, ForkCommand, LoginStatusCommand, McpListCommand, McpServerCommand,
-    ResumeCommand, ReviewCommand, SandboxCommand, SandboxPlatform, Shell, VersionCommand,
+    ApplyCommand, ArchiveCommand, Codex, CodexCommand, CompletionCommand, DeleteCommand,
+    DoctorCommand, ExecCommand, ExecResumeCommand, FeaturesListCommand, ForkCommand,
+    LoginStatusCommand, McpListCommand, McpServerCommand, PluginListCommand,
+    PluginMarketplaceListCommand, ResumeCommand, ReviewCommand, SandboxCommand, Shell,
+    UnarchiveCommand, VersionCommand,
 };
 
 fn codex() -> Codex {
@@ -154,7 +156,7 @@ async fn mcp_list_json() {
 #[ignore]
 async fn sandbox_echo() {
     let codex = codex();
-    let output = SandboxCommand::new(SandboxPlatform::MacOs, "echo")
+    let output = SandboxCommand::new("echo")
         .arg("sandbox-test")
         .execute(&codex)
         .await
@@ -198,6 +200,23 @@ async fn exec_json_lines() {
     assert!(
         types.contains(&"thread.started"),
         "expected thread.started event, got: {types:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn exec_query_result() {
+    let codex = codex();
+    let result = ExecCommand::new("respond with just the word 'pong'")
+        .ephemeral()
+        .execute_json(&codex)
+        .await
+        .unwrap();
+    // The completed event should populate the typed result and a thread id.
+    assert!(!result.events.is_empty(), "expected a non-empty event stream");
+    assert!(
+        result.thread_id.is_some(),
+        "expected a thread_id from the stream"
     );
 }
 
@@ -273,6 +292,82 @@ async fn apply_bogus_task_fails() {
     let codex = codex();
     let result = ApplyCommand::new("not-a-real-task").execute(&codex).await;
     assert!(result.is_err(), "applying a bogus task should fail");
+}
+
+// ---------------------------------------------------------------------------
+// Doctor
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn doctor_json() {
+    let codex = codex();
+    let output = DoctorCommand::new().json().execute(&codex).await.unwrap();
+    assert!(output.success);
+    let value: serde_json::Value =
+        serde_json::from_str(&output.stdout).expect("doctor --json should emit valid JSON");
+    assert!(
+        value.get("codexVersion").is_some(),
+        "expected codexVersion field, got: {value}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn plugin_list() {
+    let codex = codex();
+    let output = PluginListCommand::new().execute(&codex).await.unwrap();
+    assert!(output.success);
+}
+
+#[tokio::test]
+#[ignore]
+async fn plugin_marketplace_list() {
+    let codex = codex();
+    let output = PluginMarketplaceListCommand::new()
+        .execute(&codex)
+        .await
+        .unwrap();
+    assert!(output.success);
+}
+
+// ---------------------------------------------------------------------------
+// Session lifecycle (bogus session ids should fail, not panic)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+async fn archive_bogus_session_fails() {
+    let codex = codex();
+    let result = ArchiveCommand::new("00000000-0000-0000-0000-000000000000")
+        .execute(&codex)
+        .await;
+    assert!(result.is_err(), "archiving a bogus session should fail");
+}
+
+#[tokio::test]
+#[ignore]
+async fn unarchive_bogus_session_fails() {
+    let codex = codex();
+    let result = UnarchiveCommand::new("00000000-0000-0000-0000-000000000000")
+        .execute(&codex)
+        .await;
+    assert!(result.is_err(), "unarchiving a bogus session should fail");
+}
+
+#[tokio::test]
+#[ignore]
+async fn delete_bogus_session_fails() {
+    let codex = codex();
+    let result = DeleteCommand::new("00000000-0000-0000-0000-000000000000")
+        .force()
+        .execute(&codex)
+        .await;
+    assert!(result.is_err(), "deleting a bogus session should fail");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/codex-wrapper/tests/integration.rs
+++ b/crates/codex-wrapper/tests/integration.rs
@@ -213,7 +213,10 @@ async fn exec_query_result() {
         .await
         .unwrap();
     // The completed event should populate the typed result and a thread id.
-    assert!(!result.events.is_empty(), "expected a non-empty event stream");
+    assert!(
+        !result.events.is_empty(),
+        "expected a non-empty event stream"
+    );
     assert!(
         result.thread_id.is_some(),
         "expected a thread_id from the stream"


### PR DESCRIPTION
Part of #41. Validates the wrapper against a real `codex-cli 0.145.0` and fixes a drift bug the live tests caught.

## Sandbox drift fix (breaking)

Running the integration suite against the real binary surfaced that `codex sandbox` changed in 0.145.0: the `<macos|linux|windows>` platform positional was removed. The old `SandboxCommand::new(SandboxPlatform::MacOs, "echo")` produced `codex sandbox macos -- echo ...`, which the CLI now interprets as running a program named `macos` (`execvp() of 'macos' failed`).

- `SandboxCommand::new(command)` now takes just the program; the platform is auto-detected by the CLI.
- Removed the now-obsolete `SandboxPlatform` enum (breaking).
- Added the real options the subcommand gained: `permission_profile()` (`-P`), `profile()` (`-p`), `cd()` (`-C`), and `config()`/`enable()`/`disable()` passthrough.
- Command is passed after `--`.

## Integration tests

The existing suite was old-command-only. Ran it against the real 0.145.0 binary (logged in via ChatGPT) and:

- Fixed `sandbox_echo` for the new form.
- Added tests for this session's new commands: `doctor_json` (parses the report and checks `codexVersion`), `plugin_list`, `plugin_marketplace_list`, and `archive`/`unarchive`/`delete` bogus-session failure cases.
- Added `exec_query_result` covering the P2 `execute_json()` -> `QueryResult` path.

All 28 integration tests pass locally against real codex 0.145.0, including the API-backed `exec_simple`, `exec_json_lines`, and `exec_query_result` (which confirm the JSONL schema and `QueryResult` assembly hold on the live binary). They remain `#[ignore]` so CI does not require a codex binary or auth; run with `cargo test --test integration -- --ignored`.

## Docs

- Updated both READMEs for the new sandbox API.
- Bumped the README dependency snippet from `0.1` to `0.2` and refreshed the json-feature description.

## Verification

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] `cargo test` (unit + doctests)
- [x] `cargo test --test integration -- --ignored` (28 pass against real 0.145.0)
