### PR TITLE
fix: stop emitting invalid approval, search, and full-auto arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ let output = ExecCommand::new("fix the failing tests")
 | `sandbox()` | `--sandbox` | Sandbox policy |
 | `strict_config()` | `--strict-config` | Error on unknown config keys |
 | `profile()` | `--profile` | Config profile |
-| `full_auto()` | `--full-auto` | Auto sandbox + approval (hidden in 0.145.0) |
+| `full_auto()` | `--sandbox workspace-write` | Deprecated shim; `sandbox()` wins |
+| `approval_policy()` | `-c approval_policy=` | When the model asks for approval |
+| `search()` / `search_mode()` | `-c web_search=` | Web search mode |
 | `cd()` | `--cd` | Working directory |
 | `skip_git_repo_check()` | `--skip-git-repo-check` | Run outside git repo |
 | `add_dir()` | `--add-dir` | Additional writable dirs |

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -132,7 +132,9 @@ All ExecCommand options:
 | `sandbox()` | `--sandbox` | Sandbox policy |
 | `strict_config()` | `--strict-config` | Error on unknown config keys |
 | `profile()` | `--profile` | Config profile |
-| `full_auto()` | `--full-auto` | Auto sandbox + approval (hidden in 0.145.0) |
+| `full_auto()` | `--sandbox workspace-write` | Deprecated shim; `sandbox()` wins |
+| `approval_policy()` | `-c approval_policy=` | When the model asks for approval |
+| `search()` / `search_mode()` | `-c web_search=` | Web search mode |
 | `dangerously_bypass_approvals_and_sandbox()` | `--dangerously-bypass-approvals-and-sandbox` | Skip all safety |
 | `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `cd()` | `--cd` | Working directory |

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -4,9 +4,42 @@ use crate::command::CodexCommand;
 use crate::error::Error;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
-use crate::types::{Color, SandboxMode};
+use crate::types::{ApprovalPolicyConfig, Color, SandboxMode, WebSearchMode};
 #[cfg(feature = "json")]
 use crate::types::{JsonLineEvent, QueryResult};
+
+/// Push the typed config-key overrides shared by the exec-family builders.
+///
+/// `codex-cli` 0.145.0 removed `--ask-for-approval` and `--search` from the
+/// exec family; both settings moved to `-c` config keys. These are pushed
+/// before any caller-supplied [`config`](ExecCommand::config) strings because
+/// `-c` is last-wins, so a raw override still beats the typed setter.
+pub(crate) fn push_typed_config(
+    args: &mut Vec<String>,
+    approval_policy: Option<ApprovalPolicyConfig>,
+    web_search: Option<WebSearchMode>,
+) {
+    if let Some(policy) = approval_policy {
+        args.push("-c".into());
+        args.push(format!("approval_policy=\"{}\"", policy.as_config_value()));
+    }
+    if let Some(mode) = web_search {
+        args.push("-c".into());
+        args.push(format!("web_search=\"{}\"", mode.as_config_value()));
+    }
+}
+
+/// Resolve the sandbox mode, folding in the deprecated `full_auto` shim.
+///
+/// `--full-auto` is hidden on the exec family (and rejected outright by `fork`
+/// and `resume`); the CLI's own advice is `--sandbox workspace-write`. An
+/// explicit `sandbox()` call is more specific and wins.
+pub(crate) fn effective_sandbox(
+    sandbox: Option<SandboxMode>,
+    full_auto: bool,
+) -> Option<SandboxMode> {
+    sandbox.or(full_auto.then_some(SandboxMode::WorkspaceWrite))
+}
 
 /// Run Codex non-interactively (`codex exec <prompt>`).
 ///
@@ -34,6 +67,8 @@ use crate::types::{JsonLineEvent, QueryResult};
 #[derive(Debug, Clone)]
 pub struct ExecCommand {
     prompt: Option<String>,
+    approval_policy: Option<ApprovalPolicyConfig>,
+    web_search: Option<WebSearchMode>,
     config_overrides: Vec<String>,
     enabled_features: Vec<String>,
     disabled_features: Vec<String>,
@@ -66,6 +101,8 @@ impl ExecCommand {
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
             prompt: Some(prompt.into()),
+            approval_policy: None,
+            web_search: None,
             config_overrides: Vec::new(),
             enabled_features: Vec::new(),
             disabled_features: Vec::new(),
@@ -101,10 +138,54 @@ impl ExecCommand {
 
     /// Override a config key (`-c key=value`).
     ///
-    /// May be called multiple times to set several keys.
+    /// May be called multiple times to set several keys. Because `-c` is
+    /// last-wins, a key set here overrides the same key set by
+    /// [`approval_policy`](Self::approval_policy) or
+    /// [`search_mode`](Self::search_mode).
     #[must_use]
     pub fn config(mut self, key_value: impl Into<String>) -> Self {
         self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Set when the model asks for approval (`-c approval_policy="<value>"`).
+    ///
+    /// `codex-cli` 0.145.0 removed `--ask-for-approval` from `codex exec`; the
+    /// config key is the supported equivalent. Accepts an
+    /// [`ApprovalPolicy`](crate::ApprovalPolicy) directly, or an
+    /// [`ApprovalPolicyConfig`] for the two values the flag never took.
+    ///
+    /// ```
+    /// use codex_wrapper::{ApprovalPolicyConfig, CodexCommand, ExecCommand};
+    ///
+    /// let args = ExecCommand::new("hi")
+    ///     .approval_policy(ApprovalPolicyConfig::Never)
+    ///     .args();
+    /// assert!(args.windows(2).any(|w| w == ["-c", "approval_policy=\"never\""]));
+    /// ```
+    #[must_use]
+    pub fn approval_policy(mut self, policy: impl Into<ApprovalPolicyConfig>) -> Self {
+        self.approval_policy = Some(policy.into());
+        self
+    }
+
+    /// Enable live web search.
+    ///
+    /// Shorthand for `search_mode(WebSearchMode::Live)`, which is what the
+    /// removed `--search` flag meant.
+    #[must_use]
+    pub fn search(self) -> Self {
+        self.search_mode(WebSearchMode::Live)
+    }
+
+    /// Set the web search mode (`-c web_search="<value>"`).
+    ///
+    /// `codex-cli` 0.145.0 removed `--search` from `codex exec`; the config
+    /// key is the supported equivalent, and it is an enum rather than the
+    /// flag's boolean.
+    #[must_use]
+    pub fn search_mode(mut self, mode: WebSearchMode) -> Self {
+        self.web_search = Some(mode);
         self
     }
 
@@ -204,11 +285,17 @@ impl ExecCommand {
         self
     }
 
-    /// Run in full-auto mode — no approval prompts (`--full-auto`).
+    /// Run in full-auto mode, emitted as `--sandbox workspace-write`.
     ///
-    /// As of `codex-cli` 0.145.0 this flag is accepted but hidden from
-    /// `codex exec --help`. It still functions but is undocumented and may be
-    /// removed in a future CLI release.
+    /// `--full-auto` is deprecated upstream. `codex-cli` 0.145.0 hides it from
+    /// `codex exec --help` and warns when it is used:
+    ///
+    /// ```text
+    /// warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.
+    /// ```
+    ///
+    /// This method emits the replacement the CLI names. An explicit
+    /// [`sandbox`](Self::sandbox) call is more specific and wins over it.
     #[must_use]
     pub fn full_auto(mut self) -> Self {
         self.full_auto = true;
@@ -358,6 +445,7 @@ impl CodexCommand for ExecCommand {
     fn args(&self) -> Vec<String> {
         let mut args = vec!["exec".to_string()];
 
+        push_typed_config(&mut args, self.approval_policy, self.web_search);
         push_repeat(&mut args, "-c", &self.config_overrides);
         push_repeat(&mut args, "--enable", &self.enabled_features);
         push_repeat(&mut args, "--disable", &self.disabled_features);
@@ -374,7 +462,7 @@ impl CodexCommand for ExecCommand {
             args.push("--local-provider".into());
             args.push(local_provider.clone());
         }
-        if let Some(sandbox) = self.sandbox {
+        if let Some(sandbox) = effective_sandbox(self.sandbox, self.full_auto) {
             args.push("--sandbox".into());
             args.push(sandbox.as_arg().into());
         }
@@ -384,9 +472,6 @@ impl CodexCommand for ExecCommand {
         if let Some(profile) = &self.profile {
             args.push("--profile".into());
             args.push(profile.clone());
-        }
-        if self.full_auto {
-            args.push("--full-auto".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
@@ -448,6 +533,8 @@ pub struct ExecResumeCommand {
     prompt: Option<String>,
     last: bool,
     all: bool,
+    approval_policy: Option<ApprovalPolicyConfig>,
+    web_search: Option<WebSearchMode>,
     config_overrides: Vec<String>,
     enabled_features: Vec<String>,
     disabled_features: Vec<String>,
@@ -473,6 +560,8 @@ impl ExecResumeCommand {
             prompt: None,
             last: false,
             all: false,
+            approval_policy: None,
+            web_search: None,
             config_overrides: Vec::new(),
             enabled_features: Vec::new(),
             disabled_features: Vec::new(),
@@ -554,10 +643,45 @@ impl ExecResumeCommand {
 
     /// Override a config key (`-c key=value`).
     ///
-    /// May be called multiple times to set several keys.
+    /// May be called multiple times to set several keys. Because `-c` is
+    /// last-wins, a key set here overrides the same key set by
+    /// [`approval_policy`](Self::approval_policy),
+    /// [`search_mode`](Self::search_mode), or [`full_auto`](Self::full_auto).
     #[must_use]
     pub fn config(mut self, key_value: impl Into<String>) -> Self {
         self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Set when the model asks for approval (`-c approval_policy="<value>"`).
+    ///
+    /// `codex-cli` 0.145.0 removed `--ask-for-approval` from the exec family;
+    /// the config key is the supported equivalent. Accepts an
+    /// [`ApprovalPolicy`](crate::ApprovalPolicy) directly, or an
+    /// [`ApprovalPolicyConfig`] for the two values the flag never took.
+    #[must_use]
+    pub fn approval_policy(mut self, policy: impl Into<ApprovalPolicyConfig>) -> Self {
+        self.approval_policy = Some(policy.into());
+        self
+    }
+
+    /// Enable live web search.
+    ///
+    /// Shorthand for `search_mode(WebSearchMode::Live)`, which is what the
+    /// removed `--search` flag meant.
+    #[must_use]
+    pub fn search(self) -> Self {
+        self.search_mode(WebSearchMode::Live)
+    }
+
+    /// Set the web search mode (`-c web_search="<value>"`).
+    ///
+    /// `codex-cli` 0.145.0 removed `--search` from the exec family; the config
+    /// key is the supported equivalent, and it is an enum rather than the
+    /// flag's boolean.
+    #[must_use]
+    pub fn search_mode(mut self, mode: WebSearchMode) -> Self {
+        self.web_search = Some(mode);
         self
     }
 
@@ -595,7 +719,11 @@ impl ExecResumeCommand {
         self
     }
 
-    /// Run in full-auto mode — no approval prompts (`--full-auto`).
+    /// Run in full-auto mode, emitted as `-c sandbox_mode="workspace-write"`.
+    ///
+    /// `--full-auto` is deprecated upstream; `codex-cli` 0.145.0 hides it and
+    /// warns to use `--sandbox workspace-write` instead. `codex exec resume`
+    /// has no `--sandbox` flag, so this sets the equivalent config key.
     #[must_use]
     pub fn full_auto(mut self) -> Self {
         self.full_auto = true;
@@ -684,6 +812,16 @@ impl CodexCommand for ExecResumeCommand {
 
     fn args(&self) -> Vec<String> {
         let mut args = vec!["exec".into(), "resume".into()];
+        push_typed_config(&mut args, self.approval_policy, self.web_search);
+        // `exec resume` has no `--sandbox` flag, so the `--full-auto`
+        // replacement has to go through the config key.
+        if self.full_auto {
+            args.push("-c".into());
+            args.push(format!(
+                "sandbox_mode=\"{}\"",
+                SandboxMode::WorkspaceWrite.as_arg()
+            ));
+        }
         push_repeat(&mut args, "-c", &self.config_overrides);
         push_repeat(&mut args, "--enable", &self.enabled_features);
         push_repeat(&mut args, "--disable", &self.disabled_features);
@@ -700,9 +838,6 @@ impl CodexCommand for ExecResumeCommand {
         }
         if self.strict_config {
             args.push("--strict-config".into());
-        }
-        if self.full_auto {
-            args.push("--full-auto".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
@@ -761,6 +896,7 @@ fn parse_json_lines(stdout: &str) -> Result<Vec<JsonLineEvent>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ApprovalPolicy;
 
     #[test]
     fn exec_args() {
@@ -857,6 +993,133 @@ mod tests {
                 "--last",
                 "--strict-config",
                 "--dangerously-bypass-hook-trust",
+            ]
+        );
+    }
+
+    /// #53: `--ask-for-approval` and `--search` were removed from `codex exec`
+    /// in codex-cli 0.145.0; the settings live on as config keys.
+    #[test]
+    fn exec_approval_and_search_emit_config_keys() {
+        let args = ExecCommand::new("hi")
+            .approval_policy(ApprovalPolicy::Never)
+            .search()
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "-c",
+                "approval_policy=\"never\"",
+                "-c",
+                "web_search=\"live\"",
+                "hi"
+            ]
+        );
+        assert!(
+            !args
+                .iter()
+                .any(|a| a == "--ask-for-approval" || a == "--search")
+        );
+    }
+
+    /// `granular` and `on-failure` are accepted by the config key but not by
+    /// the flag, which is why `ApprovalPolicyConfig` exists.
+    #[test]
+    fn exec_approval_accepts_config_only_values() {
+        let args = ExecCommand::new("hi")
+            .approval_policy(ApprovalPolicyConfig::Granular)
+            .args();
+        assert_eq!(
+            args,
+            vec!["exec", "-c", "approval_policy=\"granular\"", "hi"]
+        );
+    }
+
+    #[test]
+    fn exec_search_mode_variants() {
+        for (mode, expected) in [
+            (WebSearchMode::Disabled, "disabled"),
+            (WebSearchMode::Cached, "cached"),
+            (WebSearchMode::Indexed, "indexed"),
+            (WebSearchMode::Live, "live"),
+        ] {
+            let args = ExecCommand::new("hi").search_mode(mode).args();
+            assert_eq!(args[2], format!("web_search=\"{expected}\""));
+        }
+    }
+
+    /// `-c` is last-wins, so a raw override has to be emitted after the typed
+    /// setters for it to take effect.
+    #[test]
+    fn exec_raw_config_is_emitted_after_typed_config() {
+        let args = ExecCommand::new("hi")
+            .approval_policy(ApprovalPolicy::Never)
+            .config("approval_policy=\"untrusted\"")
+            .args();
+        let typed = args
+            .iter()
+            .position(|a| a == "approval_policy=\"never\"")
+            .unwrap();
+        let raw = args
+            .iter()
+            .position(|a| a == "approval_policy=\"untrusted\"")
+            .unwrap();
+        assert!(typed < raw, "raw override must win: {args:?}");
+    }
+
+    /// #55: `--full-auto` is hidden and deprecated on the exec family.
+    #[test]
+    fn exec_full_auto_emits_sandbox_workspace_write() {
+        let args = ExecCommand::new("hi").full_auto().args();
+        assert_eq!(args, vec!["exec", "--sandbox", "workspace-write", "hi"]);
+        assert!(!args.iter().any(|a| a == "--full-auto"));
+    }
+
+    #[test]
+    fn exec_explicit_sandbox_wins_over_full_auto() {
+        let args = ExecCommand::new("hi")
+            .full_auto()
+            .sandbox(SandboxMode::ReadOnly)
+            .args();
+        assert_eq!(args, vec!["exec", "--sandbox", "read-only", "hi"]);
+    }
+
+    /// `codex exec resume` has no `--sandbox` flag, so the replacement goes
+    /// through the config key instead.
+    #[test]
+    fn exec_resume_full_auto_emits_sandbox_config_key() {
+        let args = ExecResumeCommand::new().last().full_auto().args();
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "resume",
+                "-c",
+                "sandbox_mode=\"workspace-write\"",
+                "--last"
+            ]
+        );
+        assert!(!args.iter().any(|a| a == "--full-auto"));
+    }
+
+    #[test]
+    fn exec_resume_approval_and_search_emit_config_keys() {
+        let args = ExecResumeCommand::new()
+            .last()
+            .approval_policy(ApprovalPolicyConfig::OnFailure)
+            .search_mode(WebSearchMode::Cached)
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "resume",
+                "-c",
+                "approval_policy=\"on-failure\"",
+                "-c",
+                "web_search=\"cached\"",
+                "--last"
             ]
         );
     }

--- a/crates/codex-wrapper/src/command/fork.rs
+++ b/crates/codex-wrapper/src/command/fork.rs
@@ -3,6 +3,7 @@
 /// Wraps `codex fork [session-id] [prompt]`.
 use crate::Codex;
 use crate::command::CodexCommand;
+use crate::command::exec::effective_sandbox;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 use crate::types::{ApprovalPolicy, SandboxMode};
@@ -155,6 +156,12 @@ impl ForkCommand {
         self
     }
 
+    /// Run in full-auto mode, emitted as `--sandbox workspace-write`.
+    ///
+    /// `codex fork` rejects `--full-auto` outright in `codex-cli` 0.145.0
+    /// ("unexpected argument"), so this emits the replacement the CLI names
+    /// for the exec family. An explicit [`sandbox`](Self::sandbox) call is
+    /// more specific and wins over it.
     #[must_use]
     pub fn full_auto(mut self) -> Self {
         self.full_auto = true;
@@ -272,16 +279,13 @@ impl CodexCommand for ForkCommand {
             args.push("--profile".into());
             args.push(profile.clone());
         }
-        if let Some(sandbox) = self.sandbox {
+        if let Some(sandbox) = effective_sandbox(self.sandbox, self.full_auto) {
             args.push("--sandbox".into());
             args.push(sandbox.as_arg().into());
         }
         if let Some(policy) = self.approval_policy {
             args.push("--ask-for-approval".into());
             args.push(policy.as_arg().into());
-        }
-        if self.full_auto {
-            args.push("--full-auto".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
@@ -358,7 +362,33 @@ mod tests {
             .full_auto()
             .search()
             .args();
-        assert_eq!(args, vec!["fork", "--full-auto", "--search", "abc-123"]);
+        assert_eq!(
+            args,
+            vec![
+                "fork",
+                "--sandbox",
+                "workspace-write",
+                "--search",
+                "abc-123"
+            ]
+        );
+    }
+
+    /// `codex fork` rejects `--full-auto` outright, so it must never be
+    /// emitted. See #55.
+    #[test]
+    fn fork_full_auto_never_emits_the_flag() {
+        let args = ForkCommand::new().full_auto().args();
+        assert!(!args.iter().any(|a| a == "--full-auto"));
+    }
+
+    #[test]
+    fn fork_explicit_sandbox_wins_over_full_auto() {
+        let args = ForkCommand::new()
+            .full_auto()
+            .sandbox(SandboxMode::ReadOnly)
+            .args();
+        assert_eq!(args, vec!["fork", "--sandbox", "read-only"]);
     }
 
     #[test]

--- a/crates/codex-wrapper/src/command/resume.rs
+++ b/crates/codex-wrapper/src/command/resume.rs
@@ -3,6 +3,7 @@
 /// Wraps the top-level `codex resume` command (distinct from `codex exec resume`).
 use crate::Codex;
 use crate::command::CodexCommand;
+use crate::command::exec::effective_sandbox;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 use crate::types::{ApprovalPolicy, SandboxMode};
@@ -157,6 +158,12 @@ impl ResumeCommand {
         self
     }
 
+    /// Run in full-auto mode, emitted as `--sandbox workspace-write`.
+    ///
+    /// `codex resume` rejects `--full-auto` outright in `codex-cli` 0.145.0
+    /// ("unexpected argument"), so this emits the replacement the CLI names
+    /// for the exec family. An explicit [`sandbox`](Self::sandbox) call is
+    /// more specific and wins over it.
     #[must_use]
     pub fn full_auto(mut self) -> Self {
         self.full_auto = true;
@@ -282,16 +289,13 @@ impl CodexCommand for ResumeCommand {
             args.push("--profile".into());
             args.push(profile.clone());
         }
-        if let Some(sandbox) = self.sandbox {
+        if let Some(sandbox) = effective_sandbox(self.sandbox, self.full_auto) {
             args.push("--sandbox".into());
             args.push(sandbox.as_arg().into());
         }
         if let Some(policy) = self.approval_policy {
             args.push("--ask-for-approval".into());
             args.push(policy.as_arg().into());
-        }
-        if self.full_auto {
-            args.push("--full-auto".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
@@ -397,6 +401,30 @@ mod tests {
                 "--remote",
                 "ws://host:9000",
             ]
+        );
+    }
+
+    /// `codex resume` rejects `--full-auto` outright. See #55.
+    #[test]
+    fn resume_full_auto_emits_sandbox_workspace_write() {
+        let args = ResumeCommand::new().last().full_auto().args();
+        assert_eq!(
+            args,
+            vec!["resume", "--last", "--sandbox", "workspace-write"]
+        );
+        assert!(!args.iter().any(|a| a == "--full-auto"));
+    }
+
+    #[test]
+    fn resume_explicit_sandbox_wins_over_full_auto() {
+        let args = ResumeCommand::new()
+            .last()
+            .full_auto()
+            .sandbox(SandboxMode::DangerFullAccess)
+            .args();
+        assert_eq!(
+            args,
+            vec!["resume", "--last", "--sandbox", "danger-full-access"]
         );
     }
 }

--- a/crates/codex-wrapper/src/command/review.rs
+++ b/crates/codex-wrapper/src/command/review.rs
@@ -1,15 +1,19 @@
 use crate::Codex;
 use crate::command::CodexCommand;
+use crate::command::exec::push_typed_config;
 #[cfg(feature = "json")]
 use crate::error::Error;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
 #[cfg(feature = "json")]
 use crate::types::JsonLineEvent;
+use crate::types::{ApprovalPolicyConfig, SandboxMode, WebSearchMode};
 
 #[derive(Debug, Clone)]
 pub struct ReviewCommand {
     prompt: Option<String>,
+    approval_policy: Option<ApprovalPolicyConfig>,
+    web_search: Option<WebSearchMode>,
     config_overrides: Vec<String>,
     enabled_features: Vec<String>,
     disabled_features: Vec<String>,
@@ -34,6 +38,8 @@ impl ReviewCommand {
     pub fn new() -> Self {
         Self {
             prompt: None,
+            approval_policy: None,
+            web_search: None,
             config_overrides: Vec::new(),
             enabled_features: Vec::new(),
             disabled_features: Vec::new(),
@@ -60,9 +66,46 @@ impl ReviewCommand {
         self
     }
 
+    /// Override a config key (`-c key=value`).
+    ///
+    /// Because `-c` is last-wins, a key set here overrides the same key set by
+    /// [`approval_policy`](Self::approval_policy),
+    /// [`search_mode`](Self::search_mode), or [`full_auto`](Self::full_auto).
     #[must_use]
     pub fn config(mut self, key_value: impl Into<String>) -> Self {
         self.config_overrides.push(key_value.into());
+        self
+    }
+
+    /// Set when the model asks for approval (`-c approval_policy="<value>"`).
+    ///
+    /// `codex-cli` 0.145.0 removed `--ask-for-approval` from the exec family;
+    /// the config key is the supported equivalent. Accepts an
+    /// [`ApprovalPolicy`](crate::ApprovalPolicy) directly, or an
+    /// [`ApprovalPolicyConfig`] for the two values the flag never took.
+    #[must_use]
+    pub fn approval_policy(mut self, policy: impl Into<ApprovalPolicyConfig>) -> Self {
+        self.approval_policy = Some(policy.into());
+        self
+    }
+
+    /// Enable live web search.
+    ///
+    /// Shorthand for `search_mode(WebSearchMode::Live)`, which is what the
+    /// removed `--search` flag meant.
+    #[must_use]
+    pub fn search(self) -> Self {
+        self.search_mode(WebSearchMode::Live)
+    }
+
+    /// Set the web search mode (`-c web_search="<value>"`).
+    ///
+    /// `codex-cli` 0.145.0 removed `--search` from the exec family; the config
+    /// key is the supported equivalent, and it is an enum rather than the
+    /// flag's boolean.
+    #[must_use]
+    pub fn search_mode(mut self, mode: WebSearchMode) -> Self {
+        self.web_search = Some(mode);
         self
     }
 
@@ -124,6 +167,11 @@ impl ReviewCommand {
         self
     }
 
+    /// Run in full-auto mode, emitted as `-c sandbox_mode="workspace-write"`.
+    ///
+    /// `--full-auto` is deprecated upstream; `codex-cli` 0.145.0 hides it and
+    /// warns to use `--sandbox workspace-write` instead. `codex exec review`
+    /// has no `--sandbox` flag, so this sets the equivalent config key.
     #[must_use]
     pub fn full_auto(mut self) -> Self {
         self.full_auto = true;
@@ -199,6 +247,16 @@ impl CodexCommand for ReviewCommand {
 
     fn args(&self) -> Vec<String> {
         let mut args = vec!["exec".into(), "review".into()];
+        push_typed_config(&mut args, self.approval_policy, self.web_search);
+        // `exec review` has no `--sandbox` flag, so the `--full-auto`
+        // replacement has to go through the config key.
+        if self.full_auto {
+            args.push("-c".into());
+            args.push(format!(
+                "sandbox_mode=\"{}\"",
+                SandboxMode::WorkspaceWrite.as_arg()
+            ));
+        }
         for value in &self.config_overrides {
             args.push("-c".into());
             args.push(value.clone());
@@ -233,9 +291,6 @@ impl CodexCommand for ReviewCommand {
         if self.strict_config {
             args.push("--strict-config".into());
         }
-        if self.full_auto {
-            args.push("--full-auto".into());
-        }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());
         }
@@ -269,6 +324,7 @@ impl CodexCommand for ReviewCommand {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ApprovalPolicy;
 
     #[test]
     fn review_args() {
@@ -311,5 +367,44 @@ mod tests {
                 "--dangerously-bypass-hook-trust",
             ]
         );
+    }
+
+    #[test]
+    fn review_approval_and_search_emit_config_keys() {
+        let args = ReviewCommand::new()
+            .uncommitted()
+            .approval_policy(ApprovalPolicy::Untrusted)
+            .search()
+            .args();
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "review",
+                "-c",
+                "approval_policy=\"untrusted\"",
+                "-c",
+                "web_search=\"live\"",
+                "--uncommitted"
+            ]
+        );
+    }
+
+    /// `codex exec review` has no `--sandbox` flag, so the `--full-auto`
+    /// replacement goes through the config key. See #55.
+    #[test]
+    fn review_full_auto_emits_sandbox_config_key() {
+        let args = ReviewCommand::new().uncommitted().full_auto().args();
+        assert_eq!(
+            args,
+            vec![
+                "exec",
+                "review",
+                "-c",
+                "sandbox_mode=\"workspace-write\"",
+                "--uncommitted"
+            ]
+        );
+        assert!(!args.iter().any(|a| a == "--full-auto"));
     }
 }

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -32,13 +32,16 @@ impl SandboxMode {
 }
 
 /// When the model should ask for human approval before executing commands.
+///
+/// These are the values accepted by the `--ask-for-approval` flag on
+/// [`ForkCommand`](crate::ForkCommand) and [`ResumeCommand`](crate::ResumeCommand).
+/// The exec family sets the same setting through the `approval_policy` config
+/// key, which accepts a larger value set -- see [`ApprovalPolicyConfig`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ApprovalPolicy {
     /// Only run trusted commands without asking.
     Untrusted,
-    /// Ask on failure (deprecated -- prefer `OnRequest` or `Never`).
-    OnFailure,
     /// The model decides when to ask (default).
     #[default]
     OnRequest,
@@ -50,9 +53,118 @@ impl ApprovalPolicy {
     pub(crate) fn as_arg(self) -> &'static str {
         match self {
             Self::Untrusted => "untrusted",
-            Self::OnFailure => "on-failure",
             Self::OnRequest => "on-request",
             Self::Never => "never",
+        }
+    }
+}
+
+/// Approval policy values accepted by the `approval_policy` config key.
+///
+/// `codex-cli` 0.145.0 removed `--ask-for-approval` from the exec family; the
+/// config key is the supported equivalent. It accepts two values the flag does
+/// not ([`OnFailure`](Self::OnFailure) and [`Granular`](Self::Granular)), which
+/// is why this is a separate type from [`ApprovalPolicy`] rather than an alias.
+/// The three shared values convert implicitly:
+///
+/// ```
+/// use codex_wrapper::{ApprovalPolicy, ApprovalPolicyConfig};
+///
+/// let config: ApprovalPolicyConfig = ApprovalPolicy::Never.into();
+/// assert_eq!(config, ApprovalPolicyConfig::Never);
+/// ```
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ApprovalPolicyConfig {
+    /// Only run trusted commands without asking.
+    Untrusted,
+    /// Ask after a command fails.
+    ///
+    /// Not accepted by `--ask-for-approval`, so it has no [`ApprovalPolicy`]
+    /// counterpart.
+    OnFailure,
+    /// The model decides when to ask (default).
+    #[default]
+    OnRequest,
+    /// Ask per-operation rather than per-command.
+    ///
+    /// Not accepted by `--ask-for-approval`, so it has no [`ApprovalPolicy`]
+    /// counterpart.
+    Granular,
+    /// Never ask for approval.
+    Never,
+}
+
+impl ApprovalPolicyConfig {
+    pub(crate) fn as_config_value(self) -> &'static str {
+        match self {
+            Self::Untrusted => "untrusted",
+            Self::OnFailure => "on-failure",
+            Self::OnRequest => "on-request",
+            Self::Granular => "granular",
+            Self::Never => "never",
+        }
+    }
+}
+
+impl From<ApprovalPolicy> for ApprovalPolicyConfig {
+    fn from(policy: ApprovalPolicy) -> Self {
+        match policy {
+            ApprovalPolicy::Untrusted => Self::Untrusted,
+            ApprovalPolicy::OnRequest => Self::OnRequest,
+            ApprovalPolicy::Never => Self::Never,
+        }
+    }
+}
+
+impl TryFrom<ApprovalPolicyConfig> for ApprovalPolicy {
+    type Error = ApprovalPolicyConfig;
+
+    /// Narrow to the flag-accepted subset.
+    ///
+    /// Returns the original value as the error for
+    /// [`OnFailure`](ApprovalPolicyConfig::OnFailure) and
+    /// [`Granular`](ApprovalPolicyConfig::Granular), which `--ask-for-approval`
+    /// rejects.
+    fn try_from(config: ApprovalPolicyConfig) -> std::result::Result<Self, Self::Error> {
+        match config {
+            ApprovalPolicyConfig::Untrusted => Ok(Self::Untrusted),
+            ApprovalPolicyConfig::OnRequest => Ok(Self::OnRequest),
+            ApprovalPolicyConfig::Never => Ok(Self::Never),
+            other => Err(other),
+        }
+    }
+}
+
+/// Web search mode, set through the `web_search` config key.
+///
+/// `codex-cli` 0.145.0 removed `--search` from the exec family. The config key
+/// replacing it is an enum rather than the flag's boolean;
+/// [`Live`](Self::Live) is what `--search` meant.
+///
+/// `--search` is still a valid flag on [`ForkCommand`](crate::ForkCommand) and
+/// [`ResumeCommand`](crate::ResumeCommand), which keep their boolean setters.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WebSearchMode {
+    /// No web search.
+    #[default]
+    Disabled,
+    /// Serve results from cache only.
+    Cached,
+    /// Search a prebuilt index.
+    Indexed,
+    /// Live web search. The `--search` flag's former behavior.
+    Live,
+}
+
+impl WebSearchMode {
+    pub(crate) fn as_config_value(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::Cached => "cached",
+            Self::Indexed => "indexed",
+            Self::Live => "live",
         }
     }
 }


### PR DESCRIPTION
Closes #53. Closes #55.

Every claim below was verified against `codex-cli 0.145.0` by running the binary, not by reading help text alone. Config keys never appear in `--help`, so they were probed with `--strict-config`, which rejects unknown fields and unknown enum variants.

## What is wrong today

Three invalid-invocation bugs, all the same shape as the ones #41 P1 fixed.

### 1. `--full-auto` on `fork` and `resume` is rejected outright

```
$ codex fork --last --full-auto
error: unexpected argument '--full-auto' found
```

`fork.rs:284` and `resume.rs:294` emit it. These are broken invocations shipping today, not deprecation warnings. #55 described this as a hidden-flag risk; on these two subcommands it is already a hard failure.

On the exec family it is the softer case #55 described, accepted but hidden, and the CLI names its own replacement:

```
$ codex exec --full-auto ...
warning: `--full-auto` is deprecated; use `--sandbox workspace-write` instead.
```

### 2. `ApprovalPolicy::OnFailure` is rejected by `--ask-for-approval`

```
$ codex fork --last -a on-failure
error: invalid value 'on-failure' for '--ask-for-approval <APPROVAL_POLICY>'
```

The flag accepts `untrusted`, `on-request`, `never`. The enum has a fourth variant that only produces failures.

### 3. Approval and web search are unreachable on the exec family

#41 P1 removed `approval_policy()` and `search()` from `ExecCommand` because the flags were rejected. Removing the flags was right; the capability still exists as config keys, and dropping it left users with untyped `.config("...")` strings.

## The two value sets

The flag and the config key are not the same enum, which is why this needs two types rather than one.

| Path | Used by | Accepted values |
|---|---|---|
| `--ask-for-approval` | `fork`, `resume` | `untrusted`, `on-request`, `never` |
| `-c approval_policy=` | `exec`, `exec resume`, `exec review` | `untrusted`, `on-failure`, `on-request`, `granular`, `never` |

`granular` is new and has never been exposed by this wrapper. Probed via:

```
$ codex exec --strict-config -c approval_policy="zz" ...
Error loading config.toml: unknown variant `zz`, expected one of `untrusted`, `on-failure`, `on-request`, `granular`, `never`
```

Web search is config-key only on the exec family, and is an enum rather than a bool:

```
$ codex exec --strict-config -c web_search="bogus" ...
Error loading config.toml: unknown variant `bogus`, expected one of `disabled`, `cached`, `indexed`, `live`
```

`--search` remains a valid boolean flag on `fork` and `resume`. It is not changing.

## Plan

### types.rs

- `ApprovalPolicy`: drop `OnFailure`. It is invalid on the only two commands that still use this enum.
- Add `ApprovalPolicyConfig` with all five config-key values, plus `From<ApprovalPolicy>` so the shared three convert implicitly and `TryFrom` for the reverse.
- Add `WebSearchMode` with `Disabled`, `Cached`, `Indexed`, `Live`.

### exec family (`ExecCommand`, `ExecResumeCommand`, `ReviewCommand`)

- `approval_policy(impl Into<ApprovalPolicyConfig>)` emitting `-c approval_policy="<v>"`.
- `search()` as shorthand for `search_mode(WebSearchMode::Live)`, which is what `--search` meant.
- `search_mode(WebSearchMode)` emitting `-c web_search="<v>"`.
- Typed overrides are emitted **before** user-supplied `.config()` strings. `-c` is last-wins, verified by probing a valid-then-invalid pair and seeing only the invalid one raise, so an explicit raw override still beats the typed setter.
- `full_auto()` emits `--sandbox workspace-write`; an explicit `sandbox()` call wins.

### fork and resume

- `full_auto()` emits `--sandbox workspace-write`. Both carry `-s, --sandbox <SANDBOX_MODE>`, so the redirect is uniform across all five commands.

## Tests

Arg-emission assertions for each change, including the precedence cases: explicit `sandbox()` over `full_auto()`, and raw `.config()` over the typed setter. The existing `fork.rs:361` assertion expects `--full-auto` in the argv and is updated.

Live-binary coverage of the config keys belongs in #54, which is the general fix for this whole class. Not duplicating it here.

## Breaking

`ApprovalPolicy::OnFailure` is gone and `full_auto()` changes emitted argv on five commands. Both are corrections to invocations the CLI rejects or warns on. Lands in 0.2.0 with the rest of #41.