### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0](https://github.com/joshrotenberg/codex-wrapper/compare/v0.2.0...v0.3.0) - 2026-08-07
+
+### Added
+
+- make the run's own process group opt-out ([#109](https://github.com/joshrotenberg/codex-wrapper/pull/109))
+- kill the whole process group on cancellation ([#106](https://github.com/joshrotenberg/codex-wrapper/pull/106))
+- per-run MCP server config via -c overrides ([#105](https://github.com/joshrotenberg/codex-wrapper/pull/105))
+- typed accessors for stream items, and record the absent deltas ([#104](https://github.com/joshrotenberg/codex-wrapper/pull/104))
+- gate the safety-bypass flags behind an explicit opt-in ([#103](https://github.com/joshrotenberg/codex-wrapper/pull/103))
+- *(history)* read-side access to on-disk codex session logs ([#102](https://github.com/joshrotenberg/codex-wrapper/pull/102))
+- *(config)* read-side access to ~/.codex/config.toml ([#101](https://github.com/joshrotenberg/codex-wrapper/pull/101))
+- *(auth)* detect which auth strategy the codex CLI will use ([#100](https://github.com/joshrotenberg/codex-wrapper/pull/100))
+- classify command failures into typed error variants ([#99](https://github.com/joshrotenberg/codex-wrapper/pull/99))
+- *(budget)* cumulative token budget tracking across turns ([#98](https://github.com/joshrotenberg/codex-wrapper/pull/98))
+- tracing spans around command execution ([#97](https://github.com/joshrotenberg/codex-wrapper/pull/97))
+- to_command_string() for previewing the argv a builder will spawn ([#93](https://github.com/joshrotenberg/codex-wrapper/pull/93))
+- add ReviewCommand::execute_json, and correct the item schema against real output ([#79](https://github.com/joshrotenberg/codex-wrapper/pull/79))
+- session cost accumulation and streaming turns ([#72](https://github.com/joshrotenberg/codex-wrapper/pull/72))
+- report the installed CLI against a CI-backed tested-version range ([#71](https://github.com/joshrotenberg/codex-wrapper/pull/71))
+- add missing ignore and output-schema flags to exec resume and exec review ([#68](https://github.com/joshrotenberg/codex-wrapper/pull/68))
+
+### Fixed
+
+- [**breaking**] deliver the prompt for ExecCommand::from_stdin ([#96](https://github.com/joshrotenberg/codex-wrapper/pull/96))
+- kill spawned codex processes when the future is dropped ([#77](https://github.com/joshrotenberg/codex-wrapper/pull/77))
+- parse the event schema the CLI actually emits ([#74](https://github.com/joshrotenberg/codex-wrapper/pull/74))
+- stop emitting invalid approval, search, and full-auto arguments ([#64](https://github.com/joshrotenberg/codex-wrapper/pull/64))
+
+### Other
+
+- lint every target without default features ([#108](https://github.com/joshrotenberg/codex-wrapper/pull/108))
+- add an examples/ directory ([#95](https://github.com/joshrotenberg/codex-wrapper/pull/95))
+- add LICENSE-MIT and LICENSE-APACHE ([#91](https://github.com/joshrotenberg/codex-wrapper/pull/91))
+- record why codex review is not wrapped, and guard the decision ([#69](https://github.com/joshrotenberg/codex-wrapper/pull/69))
+- check emitted flags and config keys against the installed CLI ([#67](https://github.com/joshrotenberg/codex-wrapper/pull/67))
+
 ## [0.2.0] - 2026-07-24
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-wrapper"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "libc",
  "serde",

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-wrapper"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `codex-wrapper`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `codex-wrapper` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Session is no longer UnwindSafe, in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/session.rs:88
  type Session is no longer RefUnwindSafe, in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/session.rs:88
  type Session is no longer UnwindSafe, in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/session.rs:88
  type Session is no longer RefUnwindSafe, in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/session.rs:88

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TurnRecord.result in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/session.rs:42
  field TurnRecord.result in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/session.rs:42
  field QueryResult.usage in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/types.rs:420
  field QueryResult.usage in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/types.rs:420

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ApprovalPolicy::OnRequest 2 -> 1 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/types.rs:95
  variant ApprovalPolicy::Never 3 -> 2 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/types.rs:97
  variant ApprovalPolicy::OnRequest 2 -> 1 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/types.rs:95
  variant ApprovalPolicy::Never 3 -> 2 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/types.rs:97
  variant Error::CommandFailed 1 -> 5 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:68
  variant Error::Io 2 -> 6 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:78
  variant Error::Timeout 3 -> 7 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:87
  variant Error::Json 4 -> 12 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:139
  variant Error::VersionMismatch 5 -> 13 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:147
  variant Error::CommandFailed 1 -> 5 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:68
  variant Error::Io 2 -> 6 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:78
  variant Error::Timeout 3 -> 7 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:87
  variant Error::Json 4 -> 12 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:139
  variant Error::VersionMismatch 5 -> 13 in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/error.rs:147

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ApprovalPolicy::OnFailure, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:41
  variant ApprovalPolicy::OnFailure, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:41

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/inherent_method_missing.ron

Failed in:
  ResumeCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/resume.rs:167
  ResumeCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/resume.rs:174
  ResumeCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/resume.rs:167
  ResumeCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/resume.rs:174
  ReviewCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/review.rs:122
  ReviewCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/review.rs:134
  ReviewCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/review.rs:122
  ReviewCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/review.rs:134
  ExecResumeCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:593
  ExecResumeCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:609
  ExecResumeCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:593
  ExecResumeCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:609
  ExecCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:181
  ExecCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:222
  ExecCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:181
  ExecCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:222
  ForkCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/fork.rs:165
  ForkCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/fork.rs:172
  ForkCommand::dangerously_bypass_approvals_and_sandbox, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/fork.rs:165
  ForkCommand::dangerously_bypass_hook_trust, previously in file /tmp/.tmpdRayba/codex-wrapper/src/command/fork.rs:172
  JsonLineEvent::is_completed, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:112
  JsonLineEvent::result_text, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:118
  JsonLineEvent::cost_usd, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:127
  JsonLineEvent::is_completed, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:112
  JsonLineEvent::result_text, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:118
  JsonLineEvent::cost_usd, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:127

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  codex_wrapper::command::exec::ExecCommand::from_stdin takes 0 parameters in /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:98, but now takes 1 parameters in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/command/exec.rs:159
  codex_wrapper::ExecCommand::from_stdin takes 0 parameters in /tmp/.tmpdRayba/codex-wrapper/src/command/exec.rs:98, but now takes 1 parameters in /tmp/.tmpDIQy6g/codex-wrapper/crates/codex-wrapper/src/command/exec.rs:159

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field cost_usd of struct QueryResult, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:178
  field cost_usd of struct QueryResult, previously in file /tmp/.tmpdRayba/codex-wrapper/src/types.rs:178
  field events of struct TurnRecord, previously in file /tmp/.tmpdRayba/codex-wrapper/src/session.rs:38
  field events of struct TurnRecord, previously in file /tmp/.tmpdRayba/codex-wrapper/src/session.rs:38
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/joshrotenberg/codex-wrapper/compare/v0.2.0...v0.3.0) - 2026-08-07

### Added

- make the run's own process group opt-out ([#109](https://github.com/joshrotenberg/codex-wrapper/pull/109))
- kill the whole process group on cancellation ([#106](https://github.com/joshrotenberg/codex-wrapper/pull/106))
- per-run MCP server config via -c overrides ([#105](https://github.com/joshrotenberg/codex-wrapper/pull/105))
- typed accessors for stream items, and record the absent deltas ([#104](https://github.com/joshrotenberg/codex-wrapper/pull/104))
- gate the safety-bypass flags behind an explicit opt-in ([#103](https://github.com/joshrotenberg/codex-wrapper/pull/103))
- *(history)* read-side access to on-disk codex session logs ([#102](https://github.com/joshrotenberg/codex-wrapper/pull/102))
- *(config)* read-side access to ~/.codex/config.toml ([#101](https://github.com/joshrotenberg/codex-wrapper/pull/101))
- *(auth)* detect which auth strategy the codex CLI will use ([#100](https://github.com/joshrotenberg/codex-wrapper/pull/100))
- classify command failures into typed error variants ([#99](https://github.com/joshrotenberg/codex-wrapper/pull/99))
- *(budget)* cumulative token budget tracking across turns ([#98](https://github.com/joshrotenberg/codex-wrapper/pull/98))
- tracing spans around command execution ([#97](https://github.com/joshrotenberg/codex-wrapper/pull/97))
- to_command_string() for previewing the argv a builder will spawn ([#93](https://github.com/joshrotenberg/codex-wrapper/pull/93))
- add ReviewCommand::execute_json, and correct the item schema against real output ([#79](https://github.com/joshrotenberg/codex-wrapper/pull/79))
- session cost accumulation and streaming turns ([#72](https://github.com/joshrotenberg/codex-wrapper/pull/72))
- report the installed CLI against a CI-backed tested-version range ([#71](https://github.com/joshrotenberg/codex-wrapper/pull/71))
- add missing ignore and output-schema flags to exec resume and exec review ([#68](https://github.com/joshrotenberg/codex-wrapper/pull/68))

### Fixed

- [**breaking**] deliver the prompt for ExecCommand::from_stdin ([#96](https://github.com/joshrotenberg/codex-wrapper/pull/96))
- kill spawned codex processes when the future is dropped ([#77](https://github.com/joshrotenberg/codex-wrapper/pull/77))
- parse the event schema the CLI actually emits ([#74](https://github.com/joshrotenberg/codex-wrapper/pull/74))
- stop emitting invalid approval, search, and full-auto arguments ([#64](https://github.com/joshrotenberg/codex-wrapper/pull/64))

### Other

- lint every target without default features ([#108](https://github.com/joshrotenberg/codex-wrapper/pull/108))
- add an examples/ directory ([#95](https://github.com/joshrotenberg/codex-wrapper/pull/95))
- add LICENSE-MIT and LICENSE-APACHE ([#91](https://github.com/joshrotenberg/codex-wrapper/pull/91))
- record why codex review is not wrapped, and guard the decision ([#69](https://github.com/joshrotenberg/codex-wrapper/pull/69))
- check emitted flags and config keys against the installed CLI ([#67](https://github.com/joshrotenberg/codex-wrapper/pull/67))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).