### PR TITLE
docs: record why codex review is not wrapped, and guard the decision

### DIFF
--- a/crates/codex-wrapper/src/command/review.rs
+++ b/crates/codex-wrapper/src/command/review.rs
@@ -9,6 +9,40 @@ use crate::exec::{self, CommandOutput};
 use crate::types::JsonLineEvent;
 use crate::types::{ApprovalPolicyConfig, SandboxMode, WebSearchMode};
 
+/// Run a code review non-interactively (`codex exec review`).
+///
+/// # Why not `codex review`
+///
+/// `codex-cli` exposes review at two paths, `codex review` and
+/// `codex exec review`. They are the same command: same `[PROMPT]` positional,
+/// same non-interactive behavior, and a byte-identical error when no review
+/// scope is given.
+///
+/// They are not equally capable. As of 0.145.0, top-level `codex review`
+/// accepts a strict subset of the flags, missing ten that `codex exec review`
+/// has:
+///
+/// ```text
+/// --dangerously-bypass-approvals-and-sandbox   --json
+/// --dangerously-bypass-hook-trust              --output-schema <FILE>
+/// --ephemeral                                  --skip-git-repo-check
+/// --ignore-rules                               -m, --model <MODEL>
+/// --ignore-user-config                         -o, --output-last-message <FILE>
+/// ```
+///
+/// Nothing is available on `codex review` that is not also on
+/// `codex exec review`, and the missing flags are rejected outright rather
+/// than silently ignored.
+///
+/// `--json` is the decisive one: [`execute_json_lines`](Self::execute_json_lines)
+/// and [`execute_json`](Self::execute_json) both depend on it, so a builder
+/// targeting the top-level path could not offer typed output at all. This
+/// wrapper therefore targets `codex exec review` only. Use
+/// [`RawCommand`](crate::RawCommand) if you need the literal `codex review`
+/// invocation.
+///
+/// `tests/contract.rs` asserts the subset relationship still holds, so if the
+/// two surfaces ever diverge the other way, CI reports it.
 #[derive(Debug, Clone)]
 pub struct ReviewCommand {
     prompt: Option<String>,

--- a/crates/codex-wrapper/src/command/review.rs
+++ b/crates/codex-wrapper/src/command/review.rs
@@ -34,10 +34,10 @@ use crate::types::{ApprovalPolicyConfig, SandboxMode, WebSearchMode};
 /// `codex exec review`, and the missing flags are rejected outright rather
 /// than silently ignored.
 ///
-/// `--json` is the decisive one: [`execute_json_lines`](Self::execute_json_lines)
-/// and [`execute_json`](Self::execute_json) both depend on it, so a builder
-/// targeting the top-level path could not offer typed output at all. This
-/// wrapper therefore targets `codex exec review` only. Use
+/// `--json` is the decisive one:
+/// [`execute_json_lines`](Self::execute_json_lines) depends on it, so a
+/// builder targeting the top-level path could not offer structured output at
+/// all. This wrapper therefore targets `codex exec review` only. Use
 /// [`RawCommand`](crate::RawCommand) if you need the literal `codex review`
 /// invocation.
 ///

--- a/crates/codex-wrapper/tests/contract.rs
+++ b/crates/codex-wrapper/tests/contract.rs
@@ -568,3 +568,42 @@ fn harness_refuses_to_probe_free_form_config_keys() {
         "harness probed a free-form config key instead of refusing"
     );
 }
+
+/// `codex review` and `codex exec review` are the same command reached two
+/// ways, but the top-level path accepts a strict subset of the flags. #56
+/// decided to wrap only `codex exec review` on that basis, chiefly because
+/// top-level `codex review` has no `--json` and so could not support typed
+/// output.
+///
+/// If the top-level path ever gains a flag `codex exec review` lacks, that
+/// reasoning no longer holds and the decision needs revisiting. This is the
+/// reverse-direction check the rest of this suite does not do, applied to the
+/// one place a documented decision depends on it.
+#[test]
+#[ignore]
+fn top_level_review_remains_a_subset_of_exec_review() {
+    let top_level = help_flags(&["review".to_string()]);
+    let exec_review = help_flags(&["exec".to_string(), "review".to_string()]);
+
+    let only_on_top_level: Vec<&String> = top_level.difference(&exec_review).collect();
+    assert!(
+        only_on_top_level.is_empty(),
+        "`codex review` ({}) now accepts flags `codex exec review` does not: {:?}\n\n\
+         #56 chose to wrap only `codex exec review` because the top-level path was a \
+         strict subset. Re-evaluate that decision, and update the rationale on \
+         `ReviewCommand`.",
+        cli_version(),
+        only_on_top_level
+    );
+
+    // Guard the premise too: if the sets became identical, the "strict subset"
+    // rationale in ReviewCommand's docs would be wrong even though the
+    // assertion above still passes.
+    assert!(
+        exec_review.difference(&top_level).next().is_some(),
+        "`codex review` and `codex exec review` now accept the same flags ({}); \
+         the rationale on `ReviewCommand` says the top-level path is strictly \
+         narrower and needs updating",
+        cli_version()
+    );
+}


### PR DESCRIPTION
Closes #56.

## The diff, which decides this

#56 asked whether `codex review` and `codex exec review` are one command by two paths or two surfaces. Diffed against `codex-cli` 0.145.0:

**Only on `codex exec review`** (10 flags):

```
--dangerously-bypass-approvals-and-sandbox
--dangerously-bypass-hook-trust
--ephemeral
--ignore-rules
--ignore-user-config
--json
--output-schema <FILE>
--skip-git-repo-check
-m, --model <MODEL>
-o, --output-last-message <FILE>
```

**Only on `codex review`**: nothing.

**Shared** (9 flags): `--base`, `--commit`, `--enable`, `--disable`, `--strict-config`, `--title`, `--uncommitted`, `-c/--config`, `-h/--help`.

Top-level `codex review` is a strict subset.

## Same command underneath

Both take the same positional (`[PROMPT]`, "Custom review instructions. If `-` is used, read from stdin"), both are described as non-interactive, and both emit a byte-identical error for the no-scope case:

```
$ codex review
Error: Specify --uncommitted, --base, --commit, or provide custom review instructions
$ codex exec review
Error: Specify --uncommitted, --base, --commit, or provide custom review instructions
```

The narrower surface is real, not an alias with hidden extras. `codex review` rejects the flags it does not list:

```
$ codex review --uncommitted --json
error: unexpected argument '--json' found
$ codex review --uncommitted --model o3
error: unexpected argument '--model' found
```

## Decision: do not wrap it

Adding a `TopLevelReviewCommand` would ship a builder that is strictly worse at everything this crate exists to do. It cannot pass `--json`, which `execute_json_lines()` and `execute_json()` both depend on, so the typed-output path would be unavailable on it. It also cannot set the model, request an output schema, or run ephemerally.

There is no task for which a caller should prefer it. Two builders emitting different argv for the same behavior is exactly what #56 said to avoid.

`RawCommand` remains available for anyone who needs the literal invocation.

## What this PR does instead

1. Documents the finding on `ReviewCommand`, so the next person to notice `codex review` in `--help` finds the answer instead of re-deriving it.
2. Adds a contract-check guard asserting `codex review`'s flag set stays a subset of `codex exec review`'s. If that ever inverts, the decision needs revisiting and CI will say so rather than the gap sitting unnoticed. This is the reverse-direction check #67 does not otherwise do, applied where a specific decision depends on it.

No API change.