### PR TITLE
feat: report the installed CLI against a CI-backed tested-version range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The CLI version this wrapper is tested against. Bump deliberately,
-        # with the drift the bump surfaces fixed in the same change.
-        codex: ["0.145.0"]
+        # The CLI versions this wrapper is tested against. These are the two
+        # ends of the range declared by TESTED_CLI_VERSION_MIN and
+        # TESTED_CLI_VERSION_MAX in src/version.rs, and a test asserts the two
+        # stay in step. Bump deliberately, fixing any drift in the same change.
+        codex: ["0.145.0", "0.146.0"]
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -381,6 +381,42 @@ FeaturesEnableCommand::new("web-search").execute(&codex).await?;
 FeaturesDisableCommand::new("web-search").execute(&codex).await?;
 ```
 
+## CLI Version
+
+This wrapper is tested against a declared range of `codex-cli` versions. Both
+ends of the range run the flag-contract check in CI, so the range reflects what
+is actually verified rather than what is hoped.
+
+```rust
+use codex_wrapper::{CliVersionStatus, TESTED_CLI_VERSION_MIN, TESTED_CLI_VERSION_MAX};
+
+// Report, do not fail. Warns via `tracing` when outside the range.
+match codex.cli_version_status().await? {
+    CliVersionStatus::Tested => {}
+    CliVersionStatus::NewerUntested { found, tested_max } => {
+        eprintln!("codex {found} is newer than tested ({tested_max})");
+    }
+    CliVersionStatus::OlderThanMinimum { found, minimum } => {
+        eprintln!("codex {found} is older than tested ({minimum})");
+    }
+}
+```
+
+Most CLI releases break nothing, so this reports by default rather than
+refusing to run. When you do want a hard gate:
+
+```rust
+// Returns Error::UntestedCliVersion when outside the range.
+let version = codex.ensure_tested_cli_version().await?;
+```
+
+This is a method rather than a builder option because `build()` is synchronous
+and never spawns the binary.
+
+Override the range with `CodexBuilder::tested_cli_version_range(min, max)` if
+you have validated a different one yourself. `check_version(&minimum)` remains
+available for a plain minimum-version gate.
+
 ## Error Handling
 
 All commands return `Result<T>`, with errors typed via `thiserror`:

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -1,6 +1,6 @@
 # codex-wrapper
 
-A type-safe Codex CLI wrapper for Rust
+A type-safe Codex CLI wrapper for Rust.
 
 [![Crates.io](https://img.shields.io/crates/v/codex-wrapper.svg)](https://crates.io/crates/codex-wrapper)
 [![Documentation](https://docs.rs/codex-wrapper/badge.svg)](https://docs.rs/codex-wrapper)
@@ -9,8 +9,9 @@ A type-safe Codex CLI wrapper for Rust
 
 ## Overview
 
-`codex-wrapper` provides a type-safe builder-pattern interface for invoking the
-`codex` CLI programmatically. It follows the same design philosophy as
+`codex-wrapper` provides a builder-pattern interface for invoking the
+[Codex CLI](https://github.com/openai/codex) programmatically. It follows
+the same design philosophy as
 [`claude-wrapper`](https://crates.io/crates/claude-wrapper) and
 [`docker-wrapper`](https://crates.io/crates/docker-wrapper): each CLI
 subcommand is a builder struct that produces typed output.
@@ -20,6 +21,9 @@ subcommand is a builder struct that produces typed output.
 ```bash
 cargo add codex-wrapper
 ```
+
+Requires the `codex` CLI to be installed and available in `PATH` (or
+configured via `Codex::builder().binary()`).
 
 ## Quick Start
 
@@ -51,6 +55,8 @@ timeout, retry policy). Command builders hold per-invocation options and call
 Configure once, reuse across commands:
 
 ```rust
+use codex_wrapper::{Codex, RetryPolicy};
+
 let codex = Codex::builder()
     .env("OPENAI_API_KEY", "sk-...")
     .timeout_secs(300)
@@ -69,7 +75,7 @@ Options:
 
 ### Command Builders
 
-Each CLI subcommand is a separate builder. Available commands:
+Each CLI subcommand is a separate builder:
 
 | Command | CLI Equivalent | Description |
 |---------|---------------|-------------|
@@ -109,11 +115,13 @@ Each CLI subcommand is a separate builder. Available commands:
 | `VersionCommand` | `codex --version` | Get CLI version |
 | `RawCommand` | *(any)* | Escape hatch for arbitrary args |
 
-## ExecCommand: The Workhorse
+## ExecCommand
 
 Full coverage of `codex exec` options:
 
 ```rust
+use codex_wrapper::{ExecCommand, SandboxMode};
+
 let output = ExecCommand::new("fix the failing tests")
     .model("o3")
     .sandbox(SandboxMode::WorkspaceWrite)
@@ -124,8 +132,6 @@ let output = ExecCommand::new("fix the failing tests")
     .await?;
 ```
 
-All ExecCommand options:
-
 | Method | CLI Flag | Description |
 |--------|----------|-------------|
 | `model()` | `--model` | Model to use |
@@ -135,13 +141,12 @@ All ExecCommand options:
 | `full_auto()` | `--sandbox workspace-write` | Deprecated shim; `sandbox()` wins |
 | `approval_policy()` | `-c approval_policy=` | When the model asks for approval |
 | `search()` / `search_mode()` | `-c web_search=` | Web search mode |
-| `dangerously_bypass_approvals_and_sandbox()` | `--dangerously-bypass-approvals-and-sandbox` | Skip all safety |
-| `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `cd()` | `--cd` | Working directory |
 | `skip_git_repo_check()` | `--skip-git-repo-check` | Run outside git repo |
 | `add_dir()` | `--add-dir` | Additional writable dirs |
 | `ignore_user_config()` | `--ignore-user-config` | Ignore user-level config |
 | `ignore_rules()` | `--ignore-rules` | Ignore project rules files |
+| `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `ephemeral()` | `--ephemeral` | Don't persist session |
 | `output_schema()` | `--output-schema` | JSON Schema for response |
 | `color()` | `--color` | Color output mode |
@@ -156,26 +161,34 @@ All ExecCommand options:
 
 ## Typed Result
 
-Use `execute_json()` for a typed `QueryResult` summarizing the run (final
-`result` text, `session_id`, `thread_id`, `cost_usd`, and the full `events`
-stream). It mirrors `claude-wrapper`'s `QueryResult` so a downstream abstraction
-can treat both wrappers uniformly:
+Use `execute_json()` for a typed `QueryResult` summarizing the run, assembled
+from the JSONL event stream. This mirrors `claude-wrapper`'s `QueryResult` so a
+downstream abstraction can treat both wrappers uniformly:
 
 ```rust
+use codex_wrapper::ExecCommand;
+
 let result = ExecCommand::new("what is 2+2?")
     .ephemeral()
     .execute_json(&codex)
     .await?;
 
 println!("{}", result.result);
+println!("thread: {:?}", result.thread_id);
+println!("cost: {:?}", result.cost_usd);
 ```
+
+`QueryResult` fields: `result`, `session_id`, `thread_id`, `cost_usd`, and the
+full `events` stream as an escape hatch.
 
 ## JSONL Output Parsing
 
 Use `execute_json_lines()` to parse the raw structured events from `--json`
-mode:
+mode. Available on both `ExecCommand` and `ExecResumeCommand`:
 
 ```rust
+use codex_wrapper::ExecCommand;
+
 let events = ExecCommand::new("what is 2+2?")
     .ephemeral()
     .execute_json_lines(&codex)
@@ -186,12 +199,84 @@ for event in &events {
 }
 ```
 
-Event types include `thread.started`, `turn.started`, `item.completed`,
-`turn.completed`, and more.
+### Typed Accessors
+
+`JsonLineEvent` provides convenience methods for common fields:
+
+```rust
+for event in &events {
+    if let Some(id) = event.thread_id() {
+        println!("thread: {id}");
+    }
+    if event.is_completed() {
+        println!("result: {:?}", event.result_text());
+        println!("cost: {:?}", event.cost_usd());
+    }
+    if let Some(text) = event.content_text() {
+        println!("content: {text}");
+    }
+}
+```
+
+Available accessors: `session_id()`, `thread_id()`, `is_completed()`,
+`result_text()`, `cost_usd()`, `role()`, `content_text()`.
+
+## Streaming
+
+Stream JSONL events via a callback as they arrive, instead of buffering
+all output:
+
+```rust
+use codex_wrapper::{Codex, ExecCommand, JsonLineEvent};
+
+let codex = Codex::builder().build()?;
+
+ExecCommand::new("explain this codebase")
+    .ephemeral()
+    .stream(&codex, |event: JsonLineEvent| {
+        println!("{}: {:?}", event.event_type, event.extra);
+    })
+    .await?;
+```
+
+Also available on `ExecResumeCommand::stream()`. The child process's stderr
+is drained concurrently; timeout handling mirrors the buffered exec path.
+
+## Multi-Turn Sessions
+
+`Session` manages conversation state across turns automatically. The first
+call dispatches via `ExecCommand`; subsequent calls use `ExecResumeCommand`
+with the captured `thread_id`:
+
+```rust
+use std::sync::Arc;
+use codex_wrapper::{Codex, Session};
+
+let codex = Arc::new(Codex::builder().build()?);
+let mut session = Session::new(codex);
+
+let events = session.send("create a hello world program").await?;
+println!("turn 1: {} events", events.len());
+
+let events = session.send("now add error handling").await?;
+println!("turn 2: {} events, thread_id={:?}", events.len(), session.id());
+```
+
+You can also resume an existing session by thread ID:
+
+```rust
+let mut session = Session::resume(codex, "thread_abc123");
+let events = session.send("continue where we left off").await?;
+```
+
+The `thread_id` is preserved even on error paths, as long as at least one
+event carried it.
 
 ## Code Review
 
 ```rust
+use codex_wrapper::ReviewCommand;
+
 // Review uncommitted changes
 let output = ReviewCommand::new()
     .uncommitted()
@@ -210,6 +295,8 @@ let output = ReviewCommand::new()
 ## MCP Server Management
 
 ```rust
+use codex_wrapper::{McpListCommand, McpAddCommand, McpRemoveCommand};
+
 // List servers
 let output = McpListCommand::new().execute(&codex).await?;
 
@@ -235,20 +322,25 @@ McpRemoveCommand::new("old-server").execute(&codex).await?;
 
 ## Sandbox Execution
 
-Run commands inside the Codex sandbox. The platform is auto-detected
-(Seatbelt on macOS, and so on); the `<macos|linux|windows>` positional was
-removed in `codex-cli` 0.145.0.
+Run commands inside the Codex sandbox:
+
+The platform is auto-detected (Seatbelt on macOS, and so on); as of
+`codex-cli` 0.145.0 the old `<macos|linux|windows>` positional was removed.
 
 ```rust
+use codex_wrapper::SandboxCommand;
+
 let output = SandboxCommand::new("ls")
     .arg("-la")
     .execute(&codex)
     .await?;
 ```
 
-## Session Management
+## Session Resume and Fork
 
 ```rust
+use codex_wrapper::{ResumeCommand, ForkCommand};
+
 // Resume the most recent interactive session
 ResumeCommand::new()
     .last()
@@ -267,6 +359,8 @@ ForkCommand::new()
 ## Shell Completions
 
 ```rust
+use codex_wrapper::{CompletionCommand, Shell};
+
 let output = CompletionCommand::new()
     .shell(Shell::Zsh)
     .execute(&codex)
@@ -277,6 +371,8 @@ std::fs::write("_codex", &output.stdout)?;
 ## Feature Flags
 
 ```rust
+use codex_wrapper::{FeaturesListCommand, FeaturesEnableCommand, FeaturesDisableCommand};
+
 // List all feature flags
 FeaturesListCommand::new().execute(&codex).await?;
 
@@ -285,23 +381,48 @@ FeaturesEnableCommand::new("web-search").execute(&codex).await?;
 FeaturesDisableCommand::new("web-search").execute(&codex).await?;
 ```
 
-## Escape Hatch: RawCommand
+## CLI Version
 
-For subcommands or flags not yet covered by typed builders:
+This wrapper is tested against a declared range of `codex-cli` versions. Both
+ends of the range run the flag-contract check in CI, so the range reflects what
+is actually verified rather than what is hoped.
 
 ```rust
-let output = RawCommand::new("cloud")
-    .arg("--json")
-    .execute(&codex)
-    .await?;
+use codex_wrapper::{CliVersionStatus, TESTED_CLI_VERSION_MIN, TESTED_CLI_VERSION_MAX};
+
+// Report, do not fail. Warns via `tracing` when outside the range.
+match codex.cli_version_status().await? {
+    CliVersionStatus::Tested => {}
+    CliVersionStatus::NewerUntested { found, tested_max } => {
+        eprintln!("codex {found} is newer than tested ({tested_max})");
+    }
+    CliVersionStatus::OlderThanMinimum { found, minimum } => {
+        eprintln!("codex {found} is older than tested ({minimum})");
+    }
+}
 ```
+
+Most CLI releases break nothing, so this reports by default rather than
+refusing to run. When you do want a hard gate:
+
+```rust
+// Returns Error::UntestedCliVersion when outside the range.
+let version = codex.ensure_tested_cli_version().await?;
+```
+
+This is a method rather than a builder option because `build()` is synchronous
+and never spawns the binary.
+
+Override the range with `CodexBuilder::tested_cli_version_range(min, max)` if
+you have validated a different one yourself. `check_version(&minimum)` remains
+available for a plain minimum-version gate.
 
 ## Error Handling
 
 All commands return `Result<T>`, with errors typed via `thiserror`:
 
 ```rust
-use codex_wrapper::Error;
+use codex_wrapper::{ExecCommand, Error};
 
 match ExecCommand::new("test").execute(&codex).await {
     Ok(output) => println!("{}", output.stdout),
@@ -319,7 +440,7 @@ match ExecCommand::new("test").execute(&codex).await {
 Configure automatic retries for transient failures:
 
 ```rust
-use codex_wrapper::RetryPolicy;
+use codex_wrapper::{Codex, ExecCommand, RetryPolicy};
 use std::time::Duration;
 
 let policy = RetryPolicy::new()
@@ -339,12 +460,31 @@ let output = ExecCommand::new("flaky task")
     .await?;
 ```
 
-## Features
+## Escape Hatch: RawCommand
 
-Optional Cargo features (enabled by default):
+For subcommands or flags not yet covered by typed builders:
 
-- `json` -- JSONL output parsing via `serde_json` (`execute_json_lines()`,
-  `execute_json()`, `QueryResult`, `JsonLineEvent`)
+```rust
+use codex_wrapper::RawCommand;
+
+let output = RawCommand::new("cloud")
+    .arg("--json")
+    .execute(&codex)
+    .await?;
+```
+
+## Cargo Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `json` | Yes | JSONL output parsing via `serde_json` -- enables `execute_json_lines()`, `execute_json()`, `stream()`, `Session`, `QueryResult`, `JsonLineEvent` and typed accessors |
+
+To disable default features:
+
+```toml
+[dependencies]
+codex-wrapper = { version = "0.2", default-features = false }
+```
 
 ## Testing
 
@@ -352,6 +492,11 @@ Optional Cargo features (enabled by default):
 cargo test --lib --all-features           # Unit tests (no CLI required)
 cargo test --test integration -- --ignored # Integration tests (requires codex in PATH)
 ```
+
+## CI and Release
+
+GitHub Actions workflows handle CI (Linux, macOS, Windows), dependency
+audits, changelog automation, and `release-plz`-driven crates.io releases.
 
 ## License
 

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -52,6 +52,19 @@ pub enum Error {
         found: crate::version::CliVersion,
         minimum: crate::version::CliVersion,
     },
+
+    /// The installed CLI is outside the wrapper's tested-against range.
+    ///
+    /// Only returned by
+    /// [`Codex::ensure_tested_cli_version`](crate::Codex::ensure_tested_cli_version).
+    /// The default path reports drift as a
+    /// [`CliVersionStatus`](crate::CliVersionStatus) rather than an error.
+    #[error("CLI version {found} is outside the tested range {tested_min}..={tested_max}")]
+    UntestedCliVersion {
+        found: crate::version::CliVersion,
+        tested_min: crate::version::CliVersion,
+        tested_max: crate::version::CliVersion,
+    },
 }
 
 impl From<std::io::Error> for Error {

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -192,7 +192,9 @@ pub use retry::{BackoffStrategy, RetryPolicy};
 #[cfg(feature = "json")]
 pub use session::{Session, TurnRecord};
 pub use types::*;
-pub use version::{CliVersion, VersionParseError};
+pub use version::{
+    CliVersion, CliVersionStatus, TESTED_CLI_VERSION_MAX, TESTED_CLI_VERSION_MIN, VersionParseError,
+};
 
 /// Shared Codex CLI client configuration.
 ///
@@ -219,6 +221,7 @@ pub struct Codex {
     pub(crate) global_args: Vec<String>,
     pub(crate) timeout: Option<Duration>,
     pub(crate) retry_policy: Option<RetryPolicy>,
+    pub(crate) tested_cli_version_range: (CliVersion, CliVersion),
 }
 
 impl Codex {
@@ -272,6 +275,79 @@ impl Codex {
             })
         }
     }
+
+    /// The tested-against CLI version range this client reports on.
+    ///
+    /// Defaults to [`TESTED_CLI_VERSION_MIN`] and [`TESTED_CLI_VERSION_MAX`];
+    /// override with [`CodexBuilder::tested_cli_version_range`].
+    #[must_use]
+    pub fn tested_cli_version_range(&self) -> (CliVersion, CliVersion) {
+        self.tested_cli_version_range
+    }
+
+    /// Classify the installed CLI against the tested-against range.
+    ///
+    /// Emits a `tracing::warn!` when outside the range, and returns the typed
+    /// status either way. This reports; it does not fail. Most CLI releases
+    /// break nothing, so refusing to run against an unrecognized version is
+    /// worse than saying so. Use
+    /// [`ensure_tested_cli_version`](Self::ensure_tested_cli_version) when you
+    /// do want a hard gate.
+    ///
+    /// Intended for one-shot use at startup rather than before every command:
+    /// it spawns `codex --version`.
+    pub async fn cli_version_status(&self) -> Result<CliVersionStatus> {
+        let (min, max) = self.tested_cli_version_range;
+        let status = self.cli_version().await?.status_within(&min, &max);
+        warn_on_drift(&status);
+        Ok(status)
+    }
+
+    /// Like [`cli_version_status`](Self::cli_version_status), but returns
+    /// [`Error::UntestedCliVersion`] when the installed CLI is outside the
+    /// tested range.
+    ///
+    /// This is the opt-in hard gate. It is a method rather than a
+    /// [`CodexBuilder`] option because [`CodexBuilder::build`] is synchronous
+    /// and never spawns the binary; enforcing a version there would mean
+    /// running a subprocess inside a constructor.
+    pub async fn ensure_tested_cli_version(&self) -> Result<CliVersion> {
+        let (min, max) = self.tested_cli_version_range;
+        let found = self.cli_version().await?;
+        match found.status_within(&min, &max) {
+            CliVersionStatus::Tested => Ok(found),
+            status => {
+                warn_on_drift(&status);
+                Err(Error::UntestedCliVersion {
+                    found,
+                    tested_min: min,
+                    tested_max: max,
+                })
+            }
+        }
+    }
+}
+
+fn warn_on_drift(status: &CliVersionStatus) {
+    match status {
+        CliVersionStatus::Tested => {}
+        CliVersionStatus::NewerUntested { found, tested_max } => {
+            tracing::warn!(
+                found = %found,
+                tested_max = %tested_max,
+                "codex CLI is newer than this wrapper's tested-against range; \
+                 semantics may have drifted"
+            );
+        }
+        CliVersionStatus::OlderThanMinimum { found, minimum } => {
+            tracing::warn!(
+                found = %found,
+                minimum = %minimum,
+                "codex CLI is older than this wrapper's tested-against range; \
+                 some emitted arguments are likely to be rejected"
+            );
+        }
+    }
 }
 
 /// Builder for creating a [`Codex`] client.
@@ -286,9 +362,21 @@ pub struct CodexBuilder {
     global_args: Vec<String>,
     timeout: Option<Duration>,
     retry_policy: Option<RetryPolicy>,
+    tested_cli_version_range: Option<(CliVersion, CliVersion)>,
 }
 
 impl CodexBuilder {
+    /// Override the tested-against CLI version range.
+    ///
+    /// Defaults to the range this crate declares and verifies in CI. Set this
+    /// only when you have validated a different range yourself; widening it
+    /// does not make the wrapper work against versions it was not tested on.
+    #[must_use]
+    pub fn tested_cli_version_range(mut self, min: CliVersion, max: CliVersion) -> Self {
+        self.tested_cli_version_range = Some((min, max));
+        self
+    }
+
     /// Set an explicit path to the `codex` binary (skips `PATH` lookup).
     #[must_use]
     pub fn binary(mut self, path: impl Into<PathBuf>) -> Self {
@@ -391,6 +479,10 @@ impl CodexBuilder {
             global_args: self.global_args,
             timeout: self.timeout,
             retry_policy: self.retry_policy,
+            tested_cli_version_range: self.tested_cli_version_range.unwrap_or((
+                version::TESTED_CLI_VERSION_MIN,
+                version::TESTED_CLI_VERSION_MAX,
+            )),
         })
     }
 }
@@ -433,6 +525,43 @@ mod tests {
                 "--disable",
                 "bar"
             ]
+        );
+    }
+
+    #[test]
+    fn client_defaults_to_the_crate_tested_range() {
+        let codex = Codex::builder().binary("/bin/echo").build().unwrap();
+        assert_eq!(
+            codex.tested_cli_version_range(),
+            (
+                version::TESTED_CLI_VERSION_MIN,
+                version::TESTED_CLI_VERSION_MAX
+            )
+        );
+    }
+
+    #[test]
+    fn builder_can_override_the_tested_range() {
+        let min = CliVersion::new(1, 0, 0);
+        let max = CliVersion::new(2, 0, 0);
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .tested_cli_version_range(min, max)
+            .build()
+            .unwrap();
+        assert_eq!(codex.tested_cli_version_range(), (min, max));
+    }
+
+    #[test]
+    fn untested_version_error_names_both_bounds() {
+        let err = Error::UntestedCliVersion {
+            found: CliVersion::new(0, 200, 0),
+            tested_min: CliVersion::new(0, 145, 0),
+            tested_max: CliVersion::new(0, 146, 0),
+        };
+        assert_eq!(
+            err.to_string(),
+            "CLI version 0.200.0 is outside the tested range 0.145.0..=0.146.0"
         );
     }
 }

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -327,7 +327,7 @@ impl QueryResult {
 /// Parsed semantic version of the Codex CLI (`major.minor.patch`).
 ///
 /// Supports comparison and ordering for version-gating logic.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CliVersion {
     pub major: u32,
     pub minor: u32,
@@ -354,6 +354,82 @@ impl CliVersion {
     #[must_use]
     pub fn satisfies_minimum(&self, minimum: &CliVersion) -> bool {
         self >= minimum
+    }
+
+    /// Classify this version against a tested-against range.
+    ///
+    /// ```
+    /// use codex_wrapper::{CliVersion, CliVersionStatus};
+    ///
+    /// let min = CliVersion::new(0, 145, 0);
+    /// let max = CliVersion::new(0, 146, 0);
+    ///
+    /// assert!(CliVersion::new(0, 145, 3).status_within(&min, &max).is_tested());
+    /// assert!(!CliVersion::new(0, 200, 0).status_within(&min, &max).is_tested());
+    /// ```
+    #[must_use]
+    pub fn status_within(&self, min: &CliVersion, max: &CliVersion) -> CliVersionStatus {
+        if self < min {
+            CliVersionStatus::OlderThanMinimum {
+                found: *self,
+                minimum: *min,
+            }
+        } else if self > max {
+            CliVersionStatus::NewerUntested {
+                found: *self,
+                tested_max: *max,
+            }
+        } else {
+            CliVersionStatus::Tested
+        }
+    }
+}
+
+/// Classification of an installed CLI version against a tested range.
+///
+/// Returned by [`CliVersion::status_within`] and
+/// [`Codex::cli_version_status`](crate::Codex::cli_version_status). Mirrors
+/// `claude-wrapper`'s enum of the same name so a downstream abstraction can
+/// treat both wrappers uniformly.
+///
+/// There is deliberately no `Unparseable` variant: unparseable output is an
+/// error from [`Codex::cli_version`](crate::Codex::cli_version), not a status,
+/// and modeling it twice would fork this shape away from the sibling crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CliVersionStatus {
+    /// Within the tested-against range.
+    Tested,
+    /// Newer than the highest tested version.
+    ///
+    /// The wrapper should still generally work; semantics may have drifted.
+    NewerUntested {
+        /// The installed CLI version.
+        found: CliVersion,
+        /// Highest version this wrapper is tested against.
+        tested_max: CliVersion,
+    },
+    /// Older than the lowest tested version.
+    ///
+    /// Incorrect behavior is likely rather than merely possible: the arguments
+    /// this wrapper emits target the newer CLI, and older releases reject some
+    /// of them outright.
+    OlderThanMinimum {
+        /// The installed CLI version.
+        found: CliVersion,
+        /// Lowest version this wrapper is tested against.
+        minimum: CliVersion,
+    },
+}
+
+impl CliVersionStatus {
+    /// True only for [`Tested`](Self::Tested).
+    ///
+    /// For callers branching on "should I run?" without matching every
+    /// variant.
+    #[must_use]
+    pub fn is_tested(self) -> bool {
+        matches!(self, Self::Tested)
     }
 }
 

--- a/crates/codex-wrapper/src/version.rs
+++ b/crates/codex-wrapper/src/version.rs
@@ -1,3 +1,125 @@
 //! Version parsing and comparison utilities.
+//!
+//! Beyond parsing, this module declares the range of `codex-cli` versions this
+//! wrapper is tested against, and classifies an installed binary against it
+//! via [`CliVersionStatus`].
+//!
+//! The range is not an assertion of intent. Both bounds are exercised by the
+//! contract check in `tests/contract.rs`, which runs against each of them in
+//! CI and fails if any flag or config key the builders emit has stopped being
+//! accepted. Bumping these constants means adding that version to the CI
+//! matrix and fixing whatever drift the check reports.
 
-pub use crate::types::{CliVersion, VersionParseError};
+pub use crate::types::{CliVersion, CliVersionStatus, VersionParseError};
+
+/// Lowest `codex-cli` version this wrapper is tested against.
+///
+/// Older versions are not merely untested: 0.145.0 removed
+/// `--ask-for-approval` and `--search` from the exec family in favor of
+/// config keys (#53), so the arguments this wrapper emits are not accepted by
+/// earlier releases.
+pub const TESTED_CLI_VERSION_MIN: CliVersion = CliVersion {
+    major: 0,
+    minor: 145,
+    patch: 0,
+};
+
+/// Highest `codex-cli` version this wrapper is tested against.
+pub const TESTED_CLI_VERSION_MAX: CliVersion = CliVersion {
+    major: 0,
+    minor: 146,
+    patch: 0,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tested_range_is_ordered() {
+        assert!(
+            TESTED_CLI_VERSION_MIN <= TESTED_CLI_VERSION_MAX,
+            "tested range is inverted: {TESTED_CLI_VERSION_MIN}..={TESTED_CLI_VERSION_MAX}"
+        );
+    }
+
+    /// The declared range is only meaningful if CI actually runs the contract
+    /// check against both ends of it. Bumping one without the other would
+    /// leave the crate claiming coverage it does not have, which is the exact
+    /// failure mode this range exists to prevent.
+    #[test]
+    fn tested_range_matches_the_ci_contract_matrix() {
+        let ci = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../.github/workflows/ci.yml"
+        );
+        let Ok(contents) = std::fs::read_to_string(ci) else {
+            // Not in a repo checkout (vendored or packaged source). Nothing to
+            // cross-check against.
+            return;
+        };
+
+        let matrix = contents
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("codex: ["))
+            .expect("ci.yml should declare a `codex:` matrix for the contract job")
+            .trim_end_matches(']')
+            .split(',')
+            .map(|v| v.trim().trim_matches('"').to_string())
+            .collect::<Vec<_>>();
+
+        for bound in [TESTED_CLI_VERSION_MIN, TESTED_CLI_VERSION_MAX] {
+            assert!(
+                matrix.contains(&bound.to_string()),
+                "`{bound}` is a declared bound of the tested range but is not in \
+                 ci.yml's contract matrix {matrix:?}; the range would claim \
+                 coverage CI does not provide"
+            );
+        }
+    }
+
+    #[test]
+    fn status_within_classifies_each_case() {
+        let min = CliVersion::new(0, 145, 0);
+        let max = CliVersion::new(0, 146, 0);
+
+        assert_eq!(min.status_within(&min, &max), CliVersionStatus::Tested);
+        assert_eq!(max.status_within(&min, &max), CliVersionStatus::Tested);
+        assert_eq!(
+            CliVersion::new(0, 145, 7).status_within(&min, &max),
+            CliVersionStatus::Tested
+        );
+
+        assert_eq!(
+            CliVersion::new(0, 144, 9).status_within(&min, &max),
+            CliVersionStatus::OlderThanMinimum {
+                found: CliVersion::new(0, 144, 9),
+                minimum: min,
+            }
+        );
+        assert_eq!(
+            CliVersion::new(0, 147, 0).status_within(&min, &max),
+            CliVersionStatus::NewerUntested {
+                found: CliVersion::new(0, 147, 0),
+                tested_max: max,
+            }
+        );
+    }
+
+    #[test]
+    fn is_tested_is_true_only_for_tested() {
+        let min = CliVersion::new(0, 145, 0);
+        let max = CliVersion::new(0, 146, 0);
+        assert!(min.status_within(&min, &max).is_tested());
+        assert!(
+            !CliVersion::new(0, 1, 0)
+                .status_within(&min, &max)
+                .is_tested()
+        );
+        assert!(
+            !CliVersion::new(9, 0, 0)
+                .status_within(&min, &max)
+                .is_tested()
+        );
+    }
+}


### PR DESCRIPTION
Closes #62.

## Why

This crate has been bitten by version drift twice (#41, #50, #55). It now has `check_version(minimum)`, a hard gate that either passes or errors. There is no way to ask the softer and more useful question: *is the installed CLI inside the range this wrapper is actually tested against?*

`claude-wrapper` answers that with `CliVersionStatus`, so this is also #41 P2 parity.

## The range is real here, which changes the design

`claude-wrapper` has no declared range; the caller supplies one via `ClaudeBuilder::tested_cli_version_range`, and an unset range returns `Tested` silently.

`codex-wrapper` is now in a better position. Since #67, CI pins a CLI version and a contract check verifies every emitted flag and config key against it. So the crate can declare a range that is *actually verified* rather than asserted.

That makes the range constants meaningful rather than decorative, and it means bumping them is gated on the contract check passing.

## Plan

### `version.rs`

- `TESTED_CLI_VERSION_MIN` and `TESTED_CLI_VERSION_MAX` constants.
- `CliVersionStatus`, matching `claude-wrapper`'s shape: `Tested`, `NewerUntested { found, tested_max }`, `OlderThanMinimum { found, minimum }`, plus `is_tested()`.
- `CliVersion::status_within(&min, &max)`, same method name as the sibling crate.

`CliVersion` already derives what this needs; `Ord` is implemented.

### `lib.rs`

- `Codex::cli_version_status()` classifies the installed binary against the client's range and emits a `tracing::warn!` on drift. Reports by default, does not fail: a wrapper that refuses to run against a newer CLI is worse than one that warns, since most releases break nothing.
- `CodexBuilder::tested_cli_version_range(min, max)` overrides the crate defaults.
- `Codex::ensure_tested_cli_version()` is the opt-in hard gate, returning a new `Error::UntestedCliVersion`. `Error` is `#[non_exhaustive]`, so that is additive.

### CI

Add `0.146.0` to the contract job matrix, so both ends of the declared range are verified on every PR rather than only the lower bound.

## Two deviations from the issue

**"Hard error at `build()` time" is not implementable as written.** `CodexBuilder::build()` is synchronous and never spawns the binary; it only resolves a path via `which`. Checking the version there would mean either running a subprocess inside a sync constructor or making `build()` async, both worse than the alternative. The opt-in gate is therefore `ensure_tested_cli_version()`, an explicit async call, and the docs say why.

**No `Unparseable` status variant.** The issue listed one, but `cli_version()` already returns `Result` and a parse failure surfaces as an error there. Adding a fourth variant would fork the enum shape away from `claude-wrapper` for a case the `Result` already models. Called out here rather than silently dropped.

## Verification

The declared range is only worth having if it is true. Both bounds get a contract-check run in CI, and the range constants are asserted against the contract job's matrix so the two cannot drift apart unnoticed.