### PR TITLE
feat: session cost accumulation and streaming turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,50 @@ let events = session.send("continue where we left off").await?;
 The `thread_id` is preserved even on error paths, as long as at least one
 event carried it.
 
+### Cost
+
+Each turn records a typed `QueryResult`, so cost accumulates across the
+session:
+
+```rust
+session.send("first").await?;
+session.send("second").await?;
+
+println!("{} turns, ${:.4}", session.total_turns(), session.total_cost());
+
+if let Some(result) = session.last_result() {
+    println!("last turn: {:?}", result.cost_usd);
+}
+```
+
+The CLI does not always report a cost. `total_cost()` sums what was reported,
+so a total of `0.0` can mean either "nothing was spent" or "nothing was
+reported". `turns_missing_cost()` tells those apart:
+
+```rust
+if session.turns_missing_cost() > 0 {
+    eprintln!("cost is an undercount: {} turns reported none",
+              session.turns_missing_cost());
+}
+```
+
+### Streaming turns
+
+`stream()` is the streaming equivalent of `send()`. Events reach the handler as
+the CLI emits them, and the session still captures `thread_id`, history, and
+cost, so a streaming turn and a buffered turn leave identical state:
+
+```rust
+session.stream("summarize this repo", |event| {
+    println!("{}", event.event_type);
+}).await?;
+
+assert_eq!(session.total_turns(), 1);
+```
+
+`stream_execute()` and `stream_execute_resume()` take a fully configured
+command, mirroring `execute()` and `execute_resume()`.
+
 ## Code Review
 
 ```rust

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -1,6 +1,6 @@
 # codex-wrapper
 
-A type-safe Codex CLI wrapper for Rust
+A type-safe Codex CLI wrapper for Rust.
 
 [![Crates.io](https://img.shields.io/crates/v/codex-wrapper.svg)](https://crates.io/crates/codex-wrapper)
 [![Documentation](https://docs.rs/codex-wrapper/badge.svg)](https://docs.rs/codex-wrapper)
@@ -9,8 +9,9 @@ A type-safe Codex CLI wrapper for Rust
 
 ## Overview
 
-`codex-wrapper` provides a type-safe builder-pattern interface for invoking the
-`codex` CLI programmatically. It follows the same design philosophy as
+`codex-wrapper` provides a builder-pattern interface for invoking the
+[Codex CLI](https://github.com/openai/codex) programmatically. It follows
+the same design philosophy as
 [`claude-wrapper`](https://crates.io/crates/claude-wrapper) and
 [`docker-wrapper`](https://crates.io/crates/docker-wrapper): each CLI
 subcommand is a builder struct that produces typed output.
@@ -20,6 +21,9 @@ subcommand is a builder struct that produces typed output.
 ```bash
 cargo add codex-wrapper
 ```
+
+Requires the `codex` CLI to be installed and available in `PATH` (or
+configured via `Codex::builder().binary()`).
 
 ## Quick Start
 
@@ -51,6 +55,8 @@ timeout, retry policy). Command builders hold per-invocation options and call
 Configure once, reuse across commands:
 
 ```rust
+use codex_wrapper::{Codex, RetryPolicy};
+
 let codex = Codex::builder()
     .env("OPENAI_API_KEY", "sk-...")
     .timeout_secs(300)
@@ -69,7 +75,7 @@ Options:
 
 ### Command Builders
 
-Each CLI subcommand is a separate builder. Available commands:
+Each CLI subcommand is a separate builder:
 
 | Command | CLI Equivalent | Description |
 |---------|---------------|-------------|
@@ -109,11 +115,13 @@ Each CLI subcommand is a separate builder. Available commands:
 | `VersionCommand` | `codex --version` | Get CLI version |
 | `RawCommand` | *(any)* | Escape hatch for arbitrary args |
 
-## ExecCommand: The Workhorse
+## ExecCommand
 
 Full coverage of `codex exec` options:
 
 ```rust
+use codex_wrapper::{ExecCommand, SandboxMode};
+
 let output = ExecCommand::new("fix the failing tests")
     .model("o3")
     .sandbox(SandboxMode::WorkspaceWrite)
@@ -124,8 +132,6 @@ let output = ExecCommand::new("fix the failing tests")
     .await?;
 ```
 
-All ExecCommand options:
-
 | Method | CLI Flag | Description |
 |--------|----------|-------------|
 | `model()` | `--model` | Model to use |
@@ -135,13 +141,12 @@ All ExecCommand options:
 | `full_auto()` | `--sandbox workspace-write` | Deprecated shim; `sandbox()` wins |
 | `approval_policy()` | `-c approval_policy=` | When the model asks for approval |
 | `search()` / `search_mode()` | `-c web_search=` | Web search mode |
-| `dangerously_bypass_approvals_and_sandbox()` | `--dangerously-bypass-approvals-and-sandbox` | Skip all safety |
-| `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `cd()` | `--cd` | Working directory |
 | `skip_git_repo_check()` | `--skip-git-repo-check` | Run outside git repo |
 | `add_dir()` | `--add-dir` | Additional writable dirs |
 | `ignore_user_config()` | `--ignore-user-config` | Ignore user-level config |
 | `ignore_rules()` | `--ignore-rules` | Ignore project rules files |
+| `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `ephemeral()` | `--ephemeral` | Don't persist session |
 | `output_schema()` | `--output-schema` | JSON Schema for response |
 | `color()` | `--color` | Color output mode |
@@ -156,26 +161,34 @@ All ExecCommand options:
 
 ## Typed Result
 
-Use `execute_json()` for a typed `QueryResult` summarizing the run (final
-`result` text, `session_id`, `thread_id`, `cost_usd`, and the full `events`
-stream). It mirrors `claude-wrapper`'s `QueryResult` so a downstream abstraction
-can treat both wrappers uniformly:
+Use `execute_json()` for a typed `QueryResult` summarizing the run, assembled
+from the JSONL event stream. This mirrors `claude-wrapper`'s `QueryResult` so a
+downstream abstraction can treat both wrappers uniformly:
 
 ```rust
+use codex_wrapper::ExecCommand;
+
 let result = ExecCommand::new("what is 2+2?")
     .ephemeral()
     .execute_json(&codex)
     .await?;
 
 println!("{}", result.result);
+println!("thread: {:?}", result.thread_id);
+println!("cost: {:?}", result.cost_usd);
 ```
+
+`QueryResult` fields: `result`, `session_id`, `thread_id`, `cost_usd`, and the
+full `events` stream as an escape hatch.
 
 ## JSONL Output Parsing
 
 Use `execute_json_lines()` to parse the raw structured events from `--json`
-mode:
+mode. Available on both `ExecCommand` and `ExecResumeCommand`:
 
 ```rust
+use codex_wrapper::ExecCommand;
+
 let events = ExecCommand::new("what is 2+2?")
     .ephemeral()
     .execute_json_lines(&codex)
@@ -186,12 +199,128 @@ for event in &events {
 }
 ```
 
-Event types include `thread.started`, `turn.started`, `item.completed`,
-`turn.completed`, and more.
+### Typed Accessors
+
+`JsonLineEvent` provides convenience methods for common fields:
+
+```rust
+for event in &events {
+    if let Some(id) = event.thread_id() {
+        println!("thread: {id}");
+    }
+    if event.is_completed() {
+        println!("result: {:?}", event.result_text());
+        println!("cost: {:?}", event.cost_usd());
+    }
+    if let Some(text) = event.content_text() {
+        println!("content: {text}");
+    }
+}
+```
+
+Available accessors: `session_id()`, `thread_id()`, `is_completed()`,
+`result_text()`, `cost_usd()`, `role()`, `content_text()`.
+
+## Streaming
+
+Stream JSONL events via a callback as they arrive, instead of buffering
+all output:
+
+```rust
+use codex_wrapper::{Codex, ExecCommand, JsonLineEvent};
+
+let codex = Codex::builder().build()?;
+
+ExecCommand::new("explain this codebase")
+    .ephemeral()
+    .stream(&codex, |event: JsonLineEvent| {
+        println!("{}: {:?}", event.event_type, event.extra);
+    })
+    .await?;
+```
+
+Also available on `ExecResumeCommand::stream()`. The child process's stderr
+is drained concurrently; timeout handling mirrors the buffered exec path.
+
+## Multi-Turn Sessions
+
+`Session` manages conversation state across turns automatically. The first
+call dispatches via `ExecCommand`; subsequent calls use `ExecResumeCommand`
+with the captured `thread_id`:
+
+```rust
+use std::sync::Arc;
+use codex_wrapper::{Codex, Session};
+
+let codex = Arc::new(Codex::builder().build()?);
+let mut session = Session::new(codex);
+
+let events = session.send("create a hello world program").await?;
+println!("turn 1: {} events", events.len());
+
+let events = session.send("now add error handling").await?;
+println!("turn 2: {} events, thread_id={:?}", events.len(), session.id());
+```
+
+You can also resume an existing session by thread ID:
+
+```rust
+let mut session = Session::resume(codex, "thread_abc123");
+let events = session.send("continue where we left off").await?;
+```
+
+The `thread_id` is preserved even on error paths, as long as at least one
+event carried it.
+
+### Cost
+
+Each turn records a typed `QueryResult`, so cost accumulates across the
+session:
+
+```rust
+session.send("first").await?;
+session.send("second").await?;
+
+println!("{} turns, ${:.4}", session.total_turns(), session.total_cost());
+
+if let Some(result) = session.last_result() {
+    println!("last turn: {:?}", result.cost_usd);
+}
+```
+
+The CLI does not always report a cost. `total_cost()` sums what was reported,
+so a total of `0.0` can mean either "nothing was spent" or "nothing was
+reported". `turns_missing_cost()` tells those apart:
+
+```rust
+if session.turns_missing_cost() > 0 {
+    eprintln!("cost is an undercount: {} turns reported none",
+              session.turns_missing_cost());
+}
+```
+
+### Streaming turns
+
+`stream()` is the streaming equivalent of `send()`. Events reach the handler as
+the CLI emits them, and the session still captures `thread_id`, history, and
+cost, so a streaming turn and a buffered turn leave identical state:
+
+```rust
+session.stream("summarize this repo", |event| {
+    println!("{}", event.event_type);
+}).await?;
+
+assert_eq!(session.total_turns(), 1);
+```
+
+`stream_execute()` and `stream_execute_resume()` take a fully configured
+command, mirroring `execute()` and `execute_resume()`.
 
 ## Code Review
 
 ```rust
+use codex_wrapper::ReviewCommand;
+
 // Review uncommitted changes
 let output = ReviewCommand::new()
     .uncommitted()
@@ -210,6 +339,8 @@ let output = ReviewCommand::new()
 ## MCP Server Management
 
 ```rust
+use codex_wrapper::{McpListCommand, McpAddCommand, McpRemoveCommand};
+
 // List servers
 let output = McpListCommand::new().execute(&codex).await?;
 
@@ -235,20 +366,25 @@ McpRemoveCommand::new("old-server").execute(&codex).await?;
 
 ## Sandbox Execution
 
-Run commands inside the Codex sandbox. The platform is auto-detected
-(Seatbelt on macOS, and so on); the `<macos|linux|windows>` positional was
-removed in `codex-cli` 0.145.0.
+Run commands inside the Codex sandbox:
+
+The platform is auto-detected (Seatbelt on macOS, and so on); as of
+`codex-cli` 0.145.0 the old `<macos|linux|windows>` positional was removed.
 
 ```rust
+use codex_wrapper::SandboxCommand;
+
 let output = SandboxCommand::new("ls")
     .arg("-la")
     .execute(&codex)
     .await?;
 ```
 
-## Session Management
+## Session Resume and Fork
 
 ```rust
+use codex_wrapper::{ResumeCommand, ForkCommand};
+
 // Resume the most recent interactive session
 ResumeCommand::new()
     .last()
@@ -267,6 +403,8 @@ ForkCommand::new()
 ## Shell Completions
 
 ```rust
+use codex_wrapper::{CompletionCommand, Shell};
+
 let output = CompletionCommand::new()
     .shell(Shell::Zsh)
     .execute(&codex)
@@ -277,6 +415,8 @@ std::fs::write("_codex", &output.stdout)?;
 ## Feature Flags
 
 ```rust
+use codex_wrapper::{FeaturesListCommand, FeaturesEnableCommand, FeaturesDisableCommand};
+
 // List all feature flags
 FeaturesListCommand::new().execute(&codex).await?;
 
@@ -285,23 +425,12 @@ FeaturesEnableCommand::new("web-search").execute(&codex).await?;
 FeaturesDisableCommand::new("web-search").execute(&codex).await?;
 ```
 
-## Escape Hatch: RawCommand
-
-For subcommands or flags not yet covered by typed builders:
-
-```rust
-let output = RawCommand::new("cloud")
-    .arg("--json")
-    .execute(&codex)
-    .await?;
-```
-
 ## Error Handling
 
 All commands return `Result<T>`, with errors typed via `thiserror`:
 
 ```rust
-use codex_wrapper::Error;
+use codex_wrapper::{ExecCommand, Error};
 
 match ExecCommand::new("test").execute(&codex).await {
     Ok(output) => println!("{}", output.stdout),
@@ -319,7 +448,7 @@ match ExecCommand::new("test").execute(&codex).await {
 Configure automatic retries for transient failures:
 
 ```rust
-use codex_wrapper::RetryPolicy;
+use codex_wrapper::{Codex, ExecCommand, RetryPolicy};
 use std::time::Duration;
 
 let policy = RetryPolicy::new()
@@ -339,12 +468,31 @@ let output = ExecCommand::new("flaky task")
     .await?;
 ```
 
-## Features
+## Escape Hatch: RawCommand
 
-Optional Cargo features (enabled by default):
+For subcommands or flags not yet covered by typed builders:
 
-- `json` -- JSONL output parsing via `serde_json` (`execute_json_lines()`,
-  `execute_json()`, `QueryResult`, `JsonLineEvent`)
+```rust
+use codex_wrapper::RawCommand;
+
+let output = RawCommand::new("cloud")
+    .arg("--json")
+    .execute(&codex)
+    .await?;
+```
+
+## Cargo Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `json` | Yes | JSONL output parsing via `serde_json` -- enables `execute_json_lines()`, `execute_json()`, `stream()`, `Session`, `QueryResult`, `JsonLineEvent` and typed accessors |
+
+To disable default features:
+
+```toml
+[dependencies]
+codex-wrapper = { version = "0.2", default-features = false }
+```
 
 ## Testing
 
@@ -352,6 +500,11 @@ Optional Cargo features (enabled by default):
 cargo test --lib --all-features           # Unit tests (no CLI required)
 cargo test --test integration -- --ignored # Integration tests (requires codex in PATH)
 ```
+
+## CI and Release
+
+GitHub Actions workflows handle CI (Linux, macOS, Windows), dependency
+audits, changelog automation, and `release-plz`-driven crates.io releases.
 
 ## License
 

--- a/crates/codex-wrapper/src/session.rs
+++ b/crates/codex-wrapper/src/session.rs
@@ -481,6 +481,10 @@ mod tests {
     }
 
     /// Build a session backed by the fake-codex script the streaming tests use.
+    ///
+    /// Unix-only: the fake CLI is a bash script, matching how
+    /// [`crate::streaming`] gates its own tests.
+    #[cfg(unix)]
     fn streaming_session() -> Session {
         let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests")
@@ -582,6 +586,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn stream_delivers_events_and_records_the_turn() {
         let mut session = streaming_session();
         let mut seen = Vec::new();
@@ -601,6 +606,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn streaming_turns_accumulate_like_buffered_ones() {
         let mut session = streaming_session();
         session.stream("first", |_| {}).await.unwrap();

--- a/crates/codex-wrapper/src/session.rs
+++ b/crates/codex-wrapper/src/session.rs
@@ -29,13 +29,31 @@ use std::sync::Arc;
 use crate::Codex;
 use crate::command::exec::{ExecCommand, ExecResumeCommand};
 use crate::error::{Error, Result};
-use crate::types::JsonLineEvent;
+use crate::types::{JsonLineEvent, QueryResult};
 
 /// A record of a single turn within a session.
 #[derive(Debug, Clone)]
 pub struct TurnRecord {
+    /// The typed result for this turn, assembled from its JSONL events.
+    ///
+    /// Holding the assembled [`QueryResult`] rather than the raw event vector
+    /// is what lets a session report cost: `cost_usd` lives on the terminal
+    /// `completed` event and is otherwise discarded.
+    pub result: QueryResult,
+}
+
+impl TurnRecord {
     /// The parsed JSONL events returned by this turn.
-    pub events: Vec<JsonLineEvent>,
+    #[must_use]
+    pub fn events(&self) -> &[JsonLineEvent] {
+        &self.result.events
+    }
+
+    /// Cost in USD for this turn, if the CLI reported one.
+    #[must_use]
+    pub fn cost_usd(&self) -> Option<f64> {
+        self.result.cost_usd
+    }
 }
 
 /// Stateful multi-turn session manager.
@@ -139,9 +157,122 @@ impl Session {
         self.run_resume(cmd).await
     }
 
-    // TODO: streaming support depends on #20
-    // pub async fn stream(&mut self, prompt: impl Into<String>) -> ...
-    // pub async fn stream_execute(&mut self, cmd: ExecCommand) -> ...
+    /// Send a prompt, streaming events to `handler` as they arrive.
+    ///
+    /// The streaming equivalent of [`send`](Session::send): routes to `exec`
+    /// or `exec resume` the same way, and leaves the session in the same
+    /// state. Events are handed to `handler` as the CLI emits them and are
+    /// also retained, so `thread_id`, history, and cost are captured exactly
+    /// as they would be on the buffered path.
+    ///
+    /// Returns the full event stream for the turn.
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use codex_wrapper::{Codex, Session};
+    ///
+    /// # async fn example() -> codex_wrapper::Result<()> {
+    /// let codex = Arc::new(Codex::builder().build()?);
+    /// let mut session = Session::new(codex);
+    ///
+    /// session
+    ///     .stream("summarize this repo", |event| {
+    ///         println!("{}", event.event_type);
+    ///     })
+    ///     .await?;
+    ///
+    /// assert_eq!(session.total_turns(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn stream<F>(
+        &mut self,
+        prompt: impl Into<String>,
+        handler: F,
+    ) -> Result<Vec<JsonLineEvent>>
+    where
+        F: FnMut(JsonLineEvent),
+    {
+        let prompt = prompt.into();
+        match &self.thread_id {
+            None => {
+                self.stream_execute(ExecCommand::new(&prompt), handler)
+                    .await
+            }
+            Some(id) => {
+                let cmd = ExecResumeCommand::new()
+                    .session_id(id.clone())
+                    .prompt(prompt);
+                self.stream_execute_resume(cmd, handler).await
+            }
+        }
+    }
+
+    /// Stream an [`ExecCommand`] with full control over its options.
+    ///
+    /// The streaming equivalent of [`execute`](Session::execute).
+    pub async fn stream_execute<F>(
+        &mut self,
+        cmd: ExecCommand,
+        mut handler: F,
+    ) -> Result<Vec<JsonLineEvent>>
+    where
+        F: FnMut(JsonLineEvent),
+    {
+        let codex = Arc::clone(&self.codex);
+        let mut collected = Vec::new();
+        let outcome = cmd
+            .stream(&codex, |event| {
+                collected.push(event.clone());
+                handler(event);
+            })
+            .await;
+        self.finish_stream(collected, outcome)
+    }
+
+    /// Stream an [`ExecResumeCommand`] with full control over its options.
+    ///
+    /// The streaming equivalent of [`execute_resume`](Session::execute_resume).
+    pub async fn stream_execute_resume<F>(
+        &mut self,
+        cmd: ExecResumeCommand,
+        mut handler: F,
+    ) -> Result<Vec<JsonLineEvent>>
+    where
+        F: FnMut(JsonLineEvent),
+    {
+        let codex = Arc::clone(&self.codex);
+        let mut collected = Vec::new();
+        let outcome = cmd
+            .stream(&codex, |event| {
+                collected.push(event.clone());
+                handler(event);
+            })
+            .await;
+        self.finish_stream(collected, outcome)
+    }
+
+    /// Record a streamed turn, or salvage `thread_id` from a failed one.
+    ///
+    /// A stream that fails partway has still delivered real events, so the
+    /// `thread_id` is taken from what arrived. This mirrors the buffered
+    /// path's recovery, which re-parses stdout for the same reason. No turn is
+    /// recorded on failure: an incomplete stream has no terminal `completed`
+    /// event, so its cost would be missing and would silently undercount
+    /// [`total_cost`](Self::total_cost).
+    fn finish_stream(
+        &mut self,
+        collected: Vec<JsonLineEvent>,
+        outcome: Result<()>,
+    ) -> Result<Vec<JsonLineEvent>> {
+        match outcome {
+            Ok(()) => Ok(self.record_turn(collected)),
+            Err(e) => {
+                self.capture_thread_id(&collected);
+                Err(e)
+            }
+        }
+    }
 
     /// Returns the `thread_id` captured from the most recent turn, if any.
     #[must_use]
@@ -161,16 +292,51 @@ impl Session {
         &self.history
     }
 
+    /// The typed result of the most recent completed turn.
+    #[must_use]
+    pub fn last_result(&self) -> Option<&QueryResult> {
+        self.history.last().map(|turn| &turn.result)
+    }
+
+    /// Sum of the per-turn costs the CLI reported, in USD.
+    ///
+    /// Turns where no cost was reported contribute nothing. The CLI does not
+    /// always report `cost_usd`, so a total of `0.0` can mean either "nothing
+    /// was spent" or "nothing was reported". Pair this with
+    /// [`turns_missing_cost`](Self::turns_missing_cost) to tell those apart.
+    #[must_use]
+    pub fn total_cost(&self) -> f64 {
+        self.history.iter().filter_map(TurnRecord::cost_usd).sum()
+    }
+
+    /// How many completed turns reported no cost.
+    ///
+    /// Non-zero means [`total_cost`](Self::total_cost) is an undercount rather
+    /// than a full accounting.
+    #[must_use]
+    pub fn turns_missing_cost(&self) -> usize {
+        self.history
+            .iter()
+            .filter(|turn| turn.cost_usd().is_none())
+            .count()
+    }
+
+    /// Capture state from a completed turn and record it.
+    ///
+    /// Shared by the buffered and streaming paths so a streaming turn leaves
+    /// the session in the same state a buffered one would.
+    fn record_turn(&mut self, events: Vec<JsonLineEvent>) -> Vec<JsonLineEvent> {
+        self.capture_thread_id(&events);
+        let result = QueryResult::from_events(events);
+        let events = result.events.clone();
+        self.history.push(TurnRecord { result });
+        events
+    }
+
     /// Run an [`ExecCommand`] and record the turn.
     async fn run_exec(&mut self, cmd: ExecCommand) -> Result<Vec<JsonLineEvent>> {
         match cmd.execute_json_lines(&self.codex).await {
-            Ok(events) => {
-                self.capture_thread_id(&events);
-                self.history.push(TurnRecord {
-                    events: events.clone(),
-                });
-                Ok(events)
-            }
+            Ok(events) => Ok(self.record_turn(events)),
             Err(Error::CommandFailed {
                 stdout,
                 stderr,
@@ -194,13 +360,7 @@ impl Session {
     /// Run an [`ExecResumeCommand`] and record the turn.
     async fn run_resume(&mut self, cmd: ExecResumeCommand) -> Result<Vec<JsonLineEvent>> {
         match cmd.execute_json_lines(&self.codex).await {
-            Ok(events) => {
-                self.capture_thread_id(&events);
-                self.history.push(TurnRecord {
-                    events: events.clone(),
-                });
-                Ok(events)
-            }
+            Ok(events) => Ok(self.record_turn(events)),
             Err(Error::CommandFailed {
                 stdout,
                 stderr,
@@ -318,5 +478,137 @@ mod tests {
         let debug = format!("{session:?}");
         assert!(debug.contains("thread_dbg"));
         assert!(debug.contains("total_turns: 0"));
+    }
+
+    /// Build a session backed by the fake-codex script the streaming tests use.
+    fn streaming_session() -> Session {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex.sh");
+        Session::new(Arc::new(
+            Codex::builder()
+                .binary("/bin/bash")
+                .arg(script.to_str().unwrap())
+                .build()
+                .expect("bash must exist"),
+        ))
+    }
+
+    fn turn(json: &[&str]) -> Vec<JsonLineEvent> {
+        json.iter()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn record_turn_captures_cost_and_thread_id() {
+        let mut session = Session::new(test_codex());
+        session.record_turn(turn(&[
+            r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+            r#"{"type":"completed","result":{"text":"hi","cost":0.25}}"#,
+        ]));
+
+        assert_eq!(session.id(), Some("thread_1"));
+        assert_eq!(session.total_turns(), 1);
+        assert_eq!(session.last_result().unwrap().cost_usd, Some(0.25));
+        assert_eq!(session.last_result().unwrap().result, "hi");
+        assert!((session.total_cost() - 0.25).abs() < f64::EPSILON);
+        assert_eq!(session.turns_missing_cost(), 0);
+    }
+
+    #[test]
+    fn total_cost_sums_across_turns() {
+        let mut session = Session::new(test_codex());
+        for cost in ["0.10", "0.20", "0.30"] {
+            session.record_turn(turn(&[&format!(
+                r#"{{"type":"completed","result":{{"text":"x","cost":{cost}}}}}"#
+            )]));
+        }
+        assert_eq!(session.total_turns(), 3);
+        assert!((session.total_cost() - 0.60).abs() < 1e-9);
+        assert_eq!(session.turns_missing_cost(), 0);
+    }
+
+    /// The CLI does not always report cost. A total that silently skipped
+    /// those turns would look authoritative while undercounting, so the count
+    /// of unreported turns is exposed alongside it.
+    #[test]
+    fn unreported_cost_is_counted_not_hidden() {
+        let mut session = Session::new(test_codex());
+        session.record_turn(turn(&[
+            r#"{"type":"completed","result":{"text":"x","cost":0.4}}"#,
+        ]));
+        session.record_turn(turn(&[r#"{"type":"completed","result":{"text":"y"}}"#]));
+
+        assert!((session.total_cost() - 0.4).abs() < f64::EPSILON);
+        assert_eq!(session.turns_missing_cost(), 1);
+        assert_eq!(session.total_turns(), 2);
+    }
+
+    #[test]
+    fn zero_cost_and_unreported_cost_are_distinguishable() {
+        let mut reported = Session::new(test_codex());
+        reported.record_turn(turn(&[
+            r#"{"type":"completed","result":{"text":"x","cost":0.0}}"#,
+        ]));
+
+        let mut unreported = Session::new(test_codex());
+        unreported.record_turn(turn(&[r#"{"type":"completed","result":{"text":"x"}}"#]));
+
+        assert_eq!(reported.total_cost(), unreported.total_cost());
+        assert_eq!(reported.turns_missing_cost(), 0);
+        assert_eq!(unreported.turns_missing_cost(), 1);
+    }
+
+    #[test]
+    fn turn_record_exposes_events_and_cost() {
+        let mut session = Session::new(test_codex());
+        session.record_turn(turn(&[
+            r#"{"type":"message.created"}"#,
+            r#"{"type":"completed","result":{"text":"x","cost":0.5}}"#,
+        ]));
+
+        let record = &session.history()[0];
+        assert_eq!(record.events().len(), 2);
+        assert_eq!(record.cost_usd(), Some(0.5));
+    }
+
+    #[test]
+    fn last_result_is_none_before_any_turn() {
+        let session = Session::new(test_codex());
+        assert!(session.last_result().is_none());
+        assert_eq!(session.total_cost(), 0.0);
+        assert_eq!(session.turns_missing_cost(), 0);
+    }
+
+    #[tokio::test]
+    async fn stream_delivers_events_and_records_the_turn() {
+        let mut session = streaming_session();
+        let mut seen = Vec::new();
+
+        let events = session
+            .stream("test prompt", |event| seen.push(event.event_type.clone()))
+            .await
+            .unwrap();
+
+        assert!(seen.contains(&"completed".to_string()), "saw: {seen:?}");
+        assert_eq!(events.len(), seen.len(), "handler and return value agree");
+
+        // The streaming path must leave the same state a buffered turn would.
+        assert_eq!(session.total_turns(), 1);
+        assert_eq!(session.id(), Some("thread_test"));
+        assert!((session.total_cost() - 0.001).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn streaming_turns_accumulate_like_buffered_ones() {
+        let mut session = streaming_session();
+        session.stream("first", |_| {}).await.unwrap();
+        // Second turn routes through exec resume, since thread_id is now set.
+        session.stream("second", |_| {}).await.unwrap();
+
+        assert_eq!(session.total_turns(), 2);
+        assert!((session.total_cost() - 0.002).abs() < 1e-9);
+        assert_eq!(session.turns_missing_cost(), 0);
     }
 }


### PR DESCRIPTION
Closes #61.

## Two gaps

### 1. Cost is parsed, then discarded

`QueryResult::cost_usd` is populated from the terminal `completed` event, and `ExecCommand::execute_json()` returns it. But `Session` records turns as `TurnRecord { events: Vec<JsonLineEvent> }` and calls `execute_json_lines()`, so the assembled result never exists and per-turn cost is thrown away.

The Elixir sibling's `SessionServer` exposes `total_cost/1` and `last_result/1`. This has neither.

### 2. Two commented-out method stubs

At `session.rs:143`:

```rust
// TODO: streaming support depends on #20
// pub async fn stream(&mut self, prompt: impl Into<String>) -> ...
// pub async fn stream_execute(&mut self, cmd: ExecCommand) -> ...
```

#20 is closed. Streaming landed: `ExecCommand::stream()` and `ExecResumeCommand::stream()` both exist. The stated blocker is gone, so these get implemented rather than deleted.

## Plan

### Cost

- `TurnRecord` changes from `{ events }` to `{ result: QueryResult }`, with `events()` and `cost_usd()` accessors so the common reads stay one call. Breaking, and 0.2.0 is already breaking.
- Turn recording switches to assembling a `QueryResult` from the events it already parses. No extra process spawn.
- `Session::last_result() -> Option<&QueryResult>`.
- `Session::total_cost() -> f64`.

**On the `Option<f64>` problem** #60 flagged: `cost_usd` is optional and may be absent depending on auth mode or model. A total that silently skips unreported turns looks authoritative while being incomplete. So `total_cost()` sums what was reported and is paired with `turns_missing_cost() -> usize`, letting a caller distinguish an incomplete total from a genuinely zero-cost one. Returning `Option<f64>` was the alternative, but `None` for "one of nine turns didn't report" throws away the eight that did.

### Streaming

- `Session::stream(prompt, handler)` and `Session::stream_execute(cmd, handler)`, plus a resume variant.
- The reason these were hard: `stream()` returns `Result<()>` and hands each event to the caller's closure, so nothing is left for the session to record. The fix is to wrap the caller's handler, cloning each event into a collector as it passes through, then assemble the `QueryResult` and update `thread_id` and history exactly as the buffered path does.
- Returns the collected events, so a streaming turn and a buffered turn leave the session in the same state.

### Not changing

`send()` keeps returning `Vec<JsonLineEvent>`. Switching it to `QueryResult` would be a wider break for something `last_result()` already provides.

## Unblocks

#60. A budget tracker needs somewhere to accumulate, and this is it.