### PR TITLE
fix: parse the event schema the CLI actually emits

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,15 @@ let result = ExecCommand::new("what is 2+2?")
 
 println!("{}", result.result);
 println!("thread: {:?}", result.thread_id);
-println!("cost: {:?}", result.cost_usd);
+println!("tokens: {:?}", result.usage.and_then(|u| u.total()));
 ```
 
-`QueryResult` fields: `result`, `session_id`, `thread_id`, `cost_usd`, and the
+`QueryResult` fields: `result`, `session_id`, `thread_id`, `usage`, and the
 full `events` stream as an escape hatch.
+
+The CLI reports **token counts, not money**. There is no cost field to read.
+Converting tokens to dollars needs a per-model price table the CLI does not
+provide, so this crate does not guess at one.
 
 ## JSONL Output Parsing
 
@@ -208,18 +212,23 @@ for event in &events {
     if let Some(id) = event.thread_id() {
         println!("thread: {id}");
     }
-    if event.is_completed() {
-        println!("result: {:?}", event.result_text());
-        println!("cost: {:?}", event.cost_usd());
+    if event.is_turn_completed() {
+        println!("tokens: {:?}", event.usage().and_then(|u| u.total()));
     }
-    if let Some(text) = event.content_text() {
-        println!("content: {text}");
+    if let Some(text) = event.agent_message_text() {
+        println!("assistant: {text}");
     }
 }
 ```
 
-Available accessors: `session_id()`, `thread_id()`, `is_completed()`,
-`result_text()`, `cost_usd()`, `role()`, `content_text()`.
+Available accessors: `session_id()`, `thread_id()`, `is_turn_completed()`,
+`is_turn_failed()`, `usage()`, `agent_message_text()`, `role()`,
+`content_text()`.
+
+The event vocabulary is `thread.started`, `turn.started`, `turn.completed`,
+`turn.failed`, `item.started`, `item.updated`, `item.completed`. See the
+schema notes in the `types` module docs for which parts of the payload layout
+are verified against the CLI and which are assumed.
 
 ## Streaming
 
@@ -272,7 +281,7 @@ let events = session.send("continue where we left off").await?;
 The `thread_id` is preserved even on error paths, as long as at least one
 event carried it.
 
-### Cost
+### Token usage
 
 Each turn records a typed `QueryResult`, so cost accumulates across the
 session:
@@ -281,21 +290,21 @@ session:
 session.send("first").await?;
 session.send("second").await?;
 
-println!("{} turns, ${:.4}", session.total_turns(), session.total_cost());
+println!("{} turns, {} tokens", session.total_turns(), session.total_tokens());
 
 if let Some(result) = session.last_result() {
-    println!("last turn: {:?}", result.cost_usd);
+    println!("last turn: {:?}", result.usage);
 }
 ```
 
-The CLI does not always report a cost. `total_cost()` sums what was reported,
-so a total of `0.0` can mean either "nothing was spent" or "nothing was
-reported". `turns_missing_cost()` tells those apart:
+The CLI does not always report usage. `total_tokens()` sums what was reported,
+so a total of `0` can mean either "nothing was used" or "nothing was
+reported". `turns_missing_usage()` tells those apart:
 
 ```rust
-if session.turns_missing_cost() > 0 {
-    eprintln!("cost is an undercount: {} turns reported none",
-              session.turns_missing_cost());
+if session.turns_missing_usage() > 0 {
+    eprintln!("token total is an undercount: {} turns reported none",
+              session.turns_missing_usage());
 }
 ```
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -175,11 +175,15 @@ let result = ExecCommand::new("what is 2+2?")
 
 println!("{}", result.result);
 println!("thread: {:?}", result.thread_id);
-println!("cost: {:?}", result.cost_usd);
+println!("tokens: {:?}", result.usage.and_then(|u| u.total()));
 ```
 
-`QueryResult` fields: `result`, `session_id`, `thread_id`, `cost_usd`, and the
+`QueryResult` fields: `result`, `session_id`, `thread_id`, `usage`, and the
 full `events` stream as an escape hatch.
+
+The CLI reports **token counts, not money**. There is no cost field to read.
+Converting tokens to dollars needs a per-model price table the CLI does not
+provide, so this crate does not guess at one.
 
 ## JSONL Output Parsing
 
@@ -208,18 +212,23 @@ for event in &events {
     if let Some(id) = event.thread_id() {
         println!("thread: {id}");
     }
-    if event.is_completed() {
-        println!("result: {:?}", event.result_text());
-        println!("cost: {:?}", event.cost_usd());
+    if event.is_turn_completed() {
+        println!("tokens: {:?}", event.usage().and_then(|u| u.total()));
     }
-    if let Some(text) = event.content_text() {
-        println!("content: {text}");
+    if let Some(text) = event.agent_message_text() {
+        println!("assistant: {text}");
     }
 }
 ```
 
-Available accessors: `session_id()`, `thread_id()`, `is_completed()`,
-`result_text()`, `cost_usd()`, `role()`, `content_text()`.
+Available accessors: `session_id()`, `thread_id()`, `is_turn_completed()`,
+`is_turn_failed()`, `usage()`, `agent_message_text()`, `role()`,
+`content_text()`.
+
+The event vocabulary is `thread.started`, `turn.started`, `turn.completed`,
+`turn.failed`, `item.started`, `item.updated`, `item.completed`. See the
+schema notes in the `types` module docs for which parts of the payload layout
+are verified against the CLI and which are assumed.
 
 ## Streaming
 
@@ -272,7 +281,7 @@ let events = session.send("continue where we left off").await?;
 The `thread_id` is preserved even on error paths, as long as at least one
 event carried it.
 
-### Cost
+### Token usage
 
 Each turn records a typed `QueryResult`, so cost accumulates across the
 session:
@@ -281,21 +290,21 @@ session:
 session.send("first").await?;
 session.send("second").await?;
 
-println!("{} turns, ${:.4}", session.total_turns(), session.total_cost());
+println!("{} turns, {} tokens", session.total_turns(), session.total_tokens());
 
 if let Some(result) = session.last_result() {
-    println!("last turn: {:?}", result.cost_usd);
+    println!("last turn: {:?}", result.usage);
 }
 ```
 
-The CLI does not always report a cost. `total_cost()` sums what was reported,
-so a total of `0.0` can mean either "nothing was spent" or "nothing was
-reported". `turns_missing_cost()` tells those apart:
+The CLI does not always report usage. `total_tokens()` sums what was reported,
+so a total of `0` can mean either "nothing was used" or "nothing was
+reported". `turns_missing_usage()` tells those apart:
 
 ```rust
-if session.turns_missing_cost() > 0 {
-    eprintln!("cost is an undercount: {} turns reported none",
-              session.turns_missing_cost());
+if session.turns_missing_usage() > 0 {
+    eprintln!("token total is an undercount: {} turns reported none",
+              session.turns_missing_usage());
 }
 ```
 

--- a/crates/codex-wrapper/src/session.rs
+++ b/crates/codex-wrapper/src/session.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use crate::Codex;
 use crate::command::exec::{ExecCommand, ExecResumeCommand};
 use crate::error::{Error, Result};
-use crate::types::{JsonLineEvent, QueryResult};
+use crate::types::{JsonLineEvent, QueryResult, TokenUsage};
 
 /// A record of a single turn within a session.
 #[derive(Debug, Clone)]
@@ -37,8 +37,8 @@ pub struct TurnRecord {
     /// The typed result for this turn, assembled from its JSONL events.
     ///
     /// Holding the assembled [`QueryResult`] rather than the raw event vector
-    /// is what lets a session report cost: `cost_usd` lives on the terminal
-    /// `completed` event and is otherwise discarded.
+    /// is what lets a session report usage: token counts live on the terminal
+    /// `turn.completed` event and are otherwise discarded.
     pub result: QueryResult,
 }
 
@@ -49,10 +49,10 @@ impl TurnRecord {
         &self.result.events
     }
 
-    /// Cost in USD for this turn, if the CLI reported one.
+    /// Token counts for this turn, if the CLI reported them.
     #[must_use]
-    pub fn cost_usd(&self) -> Option<f64> {
-        self.result.cost_usd
+    pub fn usage(&self) -> Option<TokenUsage> {
+        self.result.usage
     }
 }
 
@@ -258,8 +258,8 @@ impl Session {
     /// `thread_id` is taken from what arrived. This mirrors the buffered
     /// path's recovery, which re-parses stdout for the same reason. No turn is
     /// recorded on failure: an incomplete stream has no terminal `completed`
-    /// event, so its cost would be missing and would silently undercount
-    /// [`total_cost`](Self::total_cost).
+    /// event, so its usage would be missing and would silently undercount
+    /// [`total_tokens`](Self::total_tokens).
     fn finish_stream(
         &mut self,
         collected: Vec<JsonLineEvent>,
@@ -298,26 +298,32 @@ impl Session {
         self.history.last().map(|turn| &turn.result)
     }
 
-    /// Sum of the per-turn costs the CLI reported, in USD.
+    /// Sum of the per-turn token totals the CLI reported.
     ///
-    /// Turns where no cost was reported contribute nothing. The CLI does not
-    /// always report `cost_usd`, so a total of `0.0` can mean either "nothing
-    /// was spent" or "nothing was reported". Pair this with
-    /// [`turns_missing_cost`](Self::turns_missing_cost) to tell those apart.
-    #[must_use]
-    pub fn total_cost(&self) -> f64 {
-        self.history.iter().filter_map(TurnRecord::cost_usd).sum()
-    }
-
-    /// How many completed turns reported no cost.
+    /// Turns that reported no usage contribute nothing, so a total of `0` can
+    /// mean either "nothing was used" or "nothing was reported". Pair this
+    /// with [`turns_missing_usage`](Self::turns_missing_usage) to tell those
+    /// apart.
     ///
-    /// Non-zero means [`total_cost`](Self::total_cost) is an undercount rather
-    /// than a full accounting.
+    /// There is no cost equivalent: the CLI reports tokens, not money. See
+    /// [`TokenUsage`].
     #[must_use]
-    pub fn turns_missing_cost(&self) -> usize {
+    pub fn total_tokens(&self) -> u64 {
         self.history
             .iter()
-            .filter(|turn| turn.cost_usd().is_none())
+            .filter_map(|turn| turn.usage().and_then(|u| u.total()))
+            .sum()
+    }
+
+    /// How many completed turns reported no usable token total.
+    ///
+    /// Non-zero means [`total_tokens`](Self::total_tokens) is an undercount
+    /// rather than a full accounting.
+    #[must_use]
+    pub fn turns_missing_usage(&self) -> usize {
+        self.history
+            .iter()
+            .filter(|turn| turn.usage().and_then(|u| u.total()).is_none())
             .count()
     }
 
@@ -504,85 +510,86 @@ mod tests {
             .collect()
     }
 
+    /// Build a completed turn reporting `total` tokens.
+    fn completed(total: u64) -> Vec<JsonLineEvent> {
+        turn(&[&format!(
+            r#"{{"type":"turn.completed","usage":{{"total_tokens":{total}}}}}"#
+        )])
+    }
+
     #[test]
-    fn record_turn_captures_cost_and_thread_id() {
+    fn record_turn_captures_usage_and_thread_id() {
         let mut session = Session::new(test_codex());
         session.record_turn(turn(&[
             r#"{"type":"thread.started","thread_id":"thread_1"}"#,
-            r#"{"type":"completed","result":{"text":"hi","cost":0.25}}"#,
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"hi"}}"#,
+            r#"{"type":"turn.completed","usage":{"total_tokens":42}}"#,
         ]));
 
         assert_eq!(session.id(), Some("thread_1"));
         assert_eq!(session.total_turns(), 1);
-        assert_eq!(session.last_result().unwrap().cost_usd, Some(0.25));
         assert_eq!(session.last_result().unwrap().result, "hi");
-        assert!((session.total_cost() - 0.25).abs() < f64::EPSILON);
-        assert_eq!(session.turns_missing_cost(), 0);
+        assert_eq!(session.total_tokens(), 42);
+        assert_eq!(session.turns_missing_usage(), 0);
     }
 
     #[test]
-    fn total_cost_sums_across_turns() {
+    fn total_tokens_sums_across_turns() {
         let mut session = Session::new(test_codex());
-        for cost in ["0.10", "0.20", "0.30"] {
-            session.record_turn(turn(&[&format!(
-                r#"{{"type":"completed","result":{{"text":"x","cost":{cost}}}}}"#
-            )]));
+        for total in [10, 20, 30] {
+            session.record_turn(completed(total));
         }
         assert_eq!(session.total_turns(), 3);
-        assert!((session.total_cost() - 0.60).abs() < 1e-9);
-        assert_eq!(session.turns_missing_cost(), 0);
+        assert_eq!(session.total_tokens(), 60);
+        assert_eq!(session.turns_missing_usage(), 0);
     }
 
-    /// The CLI does not always report cost. A total that silently skipped
+    /// The CLI does not always report usage. A total that silently skipped
     /// those turns would look authoritative while undercounting, so the count
     /// of unreported turns is exposed alongside it.
     #[test]
-    fn unreported_cost_is_counted_not_hidden() {
+    fn unreported_usage_is_counted_not_hidden() {
         let mut session = Session::new(test_codex());
-        session.record_turn(turn(&[
-            r#"{"type":"completed","result":{"text":"x","cost":0.4}}"#,
-        ]));
-        session.record_turn(turn(&[r#"{"type":"completed","result":{"text":"y"}}"#]));
+        session.record_turn(completed(40));
+        session.record_turn(turn(&[r#"{"type":"turn.completed"}"#]));
 
-        assert!((session.total_cost() - 0.4).abs() < f64::EPSILON);
-        assert_eq!(session.turns_missing_cost(), 1);
+        assert_eq!(session.total_tokens(), 40);
+        assert_eq!(session.turns_missing_usage(), 1);
         assert_eq!(session.total_turns(), 2);
     }
 
     #[test]
-    fn zero_cost_and_unreported_cost_are_distinguishable() {
+    fn zero_usage_and_unreported_usage_are_distinguishable() {
         let mut reported = Session::new(test_codex());
-        reported.record_turn(turn(&[
-            r#"{"type":"completed","result":{"text":"x","cost":0.0}}"#,
-        ]));
+        reported.record_turn(completed(0));
 
         let mut unreported = Session::new(test_codex());
-        unreported.record_turn(turn(&[r#"{"type":"completed","result":{"text":"x"}}"#]));
+        unreported.record_turn(turn(&[r#"{"type":"turn.completed"}"#]));
 
-        assert_eq!(reported.total_cost(), unreported.total_cost());
-        assert_eq!(reported.turns_missing_cost(), 0);
-        assert_eq!(unreported.turns_missing_cost(), 1);
+        assert_eq!(reported.total_tokens(), unreported.total_tokens());
+        assert_eq!(reported.turns_missing_usage(), 0);
+        assert_eq!(unreported.turns_missing_usage(), 1);
     }
 
     #[test]
-    fn turn_record_exposes_events_and_cost() {
+    fn turn_record_exposes_events_and_usage() {
         let mut session = Session::new(test_codex());
         session.record_turn(turn(&[
-            r#"{"type":"message.created"}"#,
-            r#"{"type":"completed","result":{"text":"x","cost":0.5}}"#,
+            r#"{"type":"turn.started"}"#,
+            r#"{"type":"turn.completed","usage":{"total_tokens":5}}"#,
         ]));
 
         let record = &session.history()[0];
         assert_eq!(record.events().len(), 2);
-        assert_eq!(record.cost_usd(), Some(0.5));
+        assert_eq!(record.usage().unwrap().total(), Some(5));
     }
 
     #[test]
     fn last_result_is_none_before_any_turn() {
         let session = Session::new(test_codex());
         assert!(session.last_result().is_none());
-        assert_eq!(session.total_cost(), 0.0);
-        assert_eq!(session.turns_missing_cost(), 0);
+        assert_eq!(session.total_tokens(), 0);
+        assert_eq!(session.turns_missing_usage(), 0);
     }
 
     #[tokio::test]
@@ -596,13 +603,17 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(seen.contains(&"completed".to_string()), "saw: {seen:?}");
+        assert!(
+            seen.contains(&"turn.completed".to_string()),
+            "saw: {seen:?}"
+        );
         assert_eq!(events.len(), seen.len(), "handler and return value agree");
 
         // The streaming path must leave the same state a buffered turn would.
         assert_eq!(session.total_turns(), 1);
         assert_eq!(session.id(), Some("thread_test"));
-        assert!((session.total_cost() - 0.001).abs() < f64::EPSILON);
+        assert_eq!(session.total_tokens(), 165);
+        assert_eq!(session.last_result().unwrap().result, "hello");
     }
 
     #[tokio::test]
@@ -614,7 +625,7 @@ mod tests {
         session.stream("second", |_| {}).await.unwrap();
 
         assert_eq!(session.total_turns(), 2);
-        assert!((session.total_cost() - 0.002).abs() < 1e-9);
-        assert_eq!(session.turns_missing_cost(), 0);
+        assert_eq!(session.total_tokens(), 330);
+        assert_eq!(session.turns_missing_usage(), 0);
     }
 }

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -221,8 +221,8 @@ mod tests {
             "expected thread.started, got: {types:?}"
         );
         assert!(
-            types.contains(&"completed"),
-            "expected completed, got: {types:?}"
+            types.contains(&"turn.completed"),
+            "expected turn.completed, got: {types:?}"
         );
     }
 

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -1,5 +1,40 @@
 //! Domain types shared across commands: enums for CLI options, version parsing,
 //! and structured JSONL events.
+//!
+//! # JSONL schema: what is verified and what is assumed
+//!
+//! This parser was rewritten in #73 after the previous one was found to match
+//! an event shape the CLI never emits. It matched a fixture that invented the
+//! schema, so every test passed while real output produced empty results. The
+//! split below exists so the next person can check the assumptions instead of
+//! rediscovering the bug.
+//!
+//! **Verified** against `codex-cli` 0.145.0, from the compiled serde tag list
+//! and a live run:
+//!
+//! - The event vocabulary is `thread.started`, `turn.started`, `turn.completed`,
+//!   `turn.failed`, `item.started`, `item.updated`, `item.completed`. There is
+//!   no bare `completed`.
+//! - `thread.started` carries `thread_id`.
+//! - A completed turn reports token counts, never a monetary cost. The
+//!   `TokenUsage` fields are `input_tokens`, `cached_input_tokens`,
+//!   `cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`,
+//!   `total_tokens`.
+//!
+//! **Assumed**, reconstructed from binary string tables rather than a live
+//! successful run:
+//!
+//! - Assistant text arrives as an `item.completed` event whose `item` has an
+//!   `agent_message` discriminator.
+//! - That the discriminator is `item_type` and the text is a `text` field.
+//!   [`JsonLineEvent::agent_message_text`] accepts `type` and a `content`
+//!   block array as alternatives rather than committing to one.
+//!
+//! To confirm, capture a real run and check `result` is non-empty:
+//!
+//! ```sh
+//! codex exec --json --ephemeral --skip-git-repo-check "reply with: ok" > turn.jsonl
+//! ```
 
 #[cfg(feature = "json")]
 use std::collections::HashMap;
@@ -219,28 +254,66 @@ impl JsonLineEvent {
         self.extra.get("thread_id").and_then(|v| v.as_str())
     }
 
-    /// Returns `true` when the event type is `"completed"`.
+    /// Returns `true` when this is the terminal event of a successful turn.
     #[must_use]
-    pub fn is_completed(&self) -> bool {
-        self.event_type == "completed"
+    pub fn is_turn_completed(&self) -> bool {
+        self.event_type == "turn.completed"
     }
 
-    /// Returns the nested `result.text` field, if present and a string.
+    /// Returns `true` when this is the terminal event of a failed turn.
     #[must_use]
-    pub fn result_text(&self) -> Option<&str> {
-        self.extra
-            .get("result")
-            .and_then(|v| v.get("text"))
-            .and_then(|v| v.as_str())
+    pub fn is_turn_failed(&self) -> bool {
+        self.event_type == "turn.failed"
     }
 
-    /// Returns the nested `result.cost` field in USD, if present and numeric.
+    /// Token counts reported by a `turn.completed` event.
+    ///
+    /// Returns `None` on any other event, or when no `usage` object is
+    /// present. The CLI reports tokens, not money; see [`TokenUsage`].
     #[must_use]
-    pub fn cost_usd(&self) -> Option<f64> {
-        self.extra
-            .get("result")
-            .and_then(|v| v.get("cost"))
-            .and_then(|v| v.as_f64())
+    pub fn usage(&self) -> Option<TokenUsage> {
+        self.extra.get("usage").map(TokenUsage::from_json)
+    }
+
+    /// Assistant text carried by an `item.completed` agent-message item.
+    ///
+    /// Returns `None` for any other event or item type.
+    ///
+    /// The item layout here is **assumed**, not verified against a live run;
+    /// see the ASSUMPTIONS block on [`QueryResult`]. Both `item_type` and
+    /// `type` are accepted as the discriminator, and the text is read from
+    /// either a `text` field or a `content` block array, because which of
+    /// those the CLI emits has not been confirmed. Tolerating both is
+    /// deliberate: the previous parser assumed one exact shape and silently
+    /// yielded empty results when it was wrong, which is the bug this
+    /// replaces.
+    #[must_use]
+    pub fn agent_message_text(&self) -> Option<String> {
+        if self.event_type != "item.completed" {
+            return None;
+        }
+        let item = self.extra.get("item")?;
+        let kind = item
+            .get("item_type")
+            .or_else(|| item.get("type"))
+            .and_then(|v| v.as_str())?;
+        if kind != "agent_message" {
+            return None;
+        }
+
+        if let Some(text) = item.get("text").and_then(|v| v.as_str())
+            && !text.is_empty()
+        {
+            return Some(text.to_string());
+        }
+
+        let blocks = item.get("content").and_then(|v| v.as_array())?;
+        let text: String = blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join("");
+        if text.is_empty() { None } else { Some(text) }
     }
 
     /// Returns the `role` field, if present and a string.
@@ -276,19 +349,31 @@ impl JsonLineEvent {
 #[cfg(feature = "json")]
 #[derive(Debug, Clone)]
 pub struct QueryResult {
-    /// Final assistant text from the terminal `completed` event.
+    /// Assistant text, concatenated from the turn's agent-message items.
     ///
-    /// Empty if no `completed` event carried a `result.text` value.
+    /// Empty when the turn produced no agent message, which includes every
+    /// failed turn.
     pub result: String,
     /// The `session_id` captured from the event stream, if any.
+    ///
+    /// Observed live runs carry only `thread_id`, so this is usually `None`.
+    /// Retained because it costs nothing and the field may exist under auth
+    /// modes not yet observed.
     pub session_id: Option<String>,
     /// The `thread_id` captured from the event stream, if any.
     ///
-    /// This is Codex's native identifier for resuming a conversation.
+    /// Codex's native identifier for resuming a conversation, emitted on
+    /// `thread.started`.
     pub thread_id: Option<String>,
-    /// Total cost in USD from the `completed` event, if reported.
-    pub cost_usd: Option<f64>,
+    /// Token counts from the terminal `turn.completed` event, if present.
+    ///
+    /// The CLI reports tokens, not money. There is no cost field to read; see
+    /// [`TokenUsage`].
+    pub usage: Option<TokenUsage>,
     /// The full parsed event stream this result was assembled from.
+    ///
+    /// The escape hatch for anything not surfaced above, including whatever
+    /// this parser gets wrong.
     pub events: Vec<JsonLineEvent>,
 }
 
@@ -296,16 +381,21 @@ pub struct QueryResult {
 impl QueryResult {
     /// Assemble a [`QueryResult`] from a parsed JSONL event stream.
     ///
-    /// `result` and `cost_usd` are taken from the last `completed` event;
-    /// `session_id` and `thread_id` are the first occurrences in the stream.
+    /// `usage` comes from the last `turn.completed` event; `result` is every
+    /// agent-message item concatenated in order; `session_id` and `thread_id`
+    /// are the first occurrences in the stream.
     #[must_use]
     pub fn from_events(events: Vec<JsonLineEvent>) -> Self {
-        let completed = events.iter().rev().find(|e| e.is_completed());
-        let result = completed
-            .and_then(JsonLineEvent::result_text)
-            .unwrap_or_default()
-            .to_string();
-        let cost_usd = completed.and_then(JsonLineEvent::cost_usd);
+        let usage = events
+            .iter()
+            .rev()
+            .find(|e| e.is_turn_completed())
+            .and_then(JsonLineEvent::usage);
+        let result = events
+            .iter()
+            .filter_map(JsonLineEvent::agent_message_text)
+            .collect::<Vec<_>>()
+            .join("");
         let session_id = events
             .iter()
             .find_map(JsonLineEvent::session_id)
@@ -318,8 +408,65 @@ impl QueryResult {
             result,
             session_id,
             thread_id,
-            cost_usd,
+            usage,
             events,
+        }
+    }
+}
+
+/// Token counts reported on a completed turn.
+///
+/// `codex-cli` 0.145.0 reports token usage and no monetary cost. Converting
+/// tokens to dollars needs a per-model price table the CLI does not provide,
+/// so this crate does not attempt it: a hardcoded table would go stale
+/// silently, which is the same class of bug as #73.
+///
+/// Every field is optional. An observed `turn.completed` carried only three of
+/// the six, so absence is normal rather than exceptional.
+#[cfg(feature = "json")]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    /// Input tokens for the turn.
+    pub input_tokens: Option<u64>,
+    /// Input tokens served from cache.
+    pub cached_input_tokens: Option<u64>,
+    /// Input tokens written to cache.
+    pub cache_write_input_tokens: Option<u64>,
+    /// Output tokens for the turn.
+    pub output_tokens: Option<u64>,
+    /// Output tokens spent on reasoning.
+    pub reasoning_output_tokens: Option<u64>,
+    /// Total tokens as reported by the CLI.
+    pub total_tokens: Option<u64>,
+}
+
+#[cfg(feature = "json")]
+impl TokenUsage {
+    fn from_json(value: &serde_json::Value) -> Self {
+        let field = |name: &str| value.get(name).and_then(serde_json::Value::as_u64);
+        Self {
+            input_tokens: field("input_tokens"),
+            cached_input_tokens: field("cached_input_tokens"),
+            cache_write_input_tokens: field("cache_write_input_tokens"),
+            output_tokens: field("output_tokens"),
+            reasoning_output_tokens: field("reasoning_output_tokens"),
+            total_tokens: field("total_tokens"),
+        }
+    }
+
+    /// Best available total for the turn.
+    ///
+    /// Prefers the CLI's own `total_tokens`, falls back to input plus output
+    /// when it is absent, and returns `None` when neither is reported, so a
+    /// missing total is never silently counted as zero.
+    #[must_use]
+    pub fn total(&self) -> Option<u64> {
+        if let Some(total) = self.total_tokens {
+            return Some(total);
+        }
+        match (self.input_tokens, self.output_tokens) {
+            (None, None) => None,
+            (input, output) => Some(input.unwrap_or(0) + output.unwrap_or(0)),
         }
     }
 }
@@ -510,34 +657,95 @@ mod tests {
 
     #[cfg(feature = "json")]
     #[test]
-    fn json_line_event_is_completed() {
-        let completed: JsonLineEvent = serde_json::from_str(r#"{"type":"completed"}"#).unwrap();
-        assert!(completed.is_completed());
+    fn json_line_event_turn_terminal_types() {
+        let completed: JsonLineEvent =
+            serde_json::from_str(r#"{"type":"turn.completed"}"#).unwrap();
+        assert!(completed.is_turn_completed());
+        assert!(!completed.is_turn_failed());
 
-        let other: JsonLineEvent = serde_json::from_str(r#"{"type":"message.created"}"#).unwrap();
-        assert!(!other.is_completed());
+        let failed: JsonLineEvent = serde_json::from_str(r#"{"type":"turn.failed"}"#).unwrap();
+        assert!(failed.is_turn_failed());
+        assert!(!failed.is_turn_completed());
+
+        // The pre-#73 parser matched this. The CLI has never emitted it.
+        let bogus: JsonLineEvent = serde_json::from_str(r#"{"type":"completed"}"#).unwrap();
+        assert!(!bogus.is_turn_completed());
     }
 
-    #[cfg(feature = "json")]
     #[test]
-    fn json_line_event_result_text_and_cost() {
+    fn json_line_event_usage() {
         let event: JsonLineEvent = serde_json::from_str(
-            r#"{"type":"completed","result":{"text":"hello world","cost":0.0042}}"#,
+            r#"{"type":"turn.completed","usage":{"input_tokens":120,"output_tokens":45,"total_tokens":165}}"#,
         )
         .unwrap();
-        assert_eq!(event.result_text(), Some("hello world"));
-        assert!((event.cost_usd().unwrap() - 0.0042).abs() < f64::EPSILON);
+        let usage = event.usage().unwrap();
+        assert_eq!(usage.input_tokens, Some(120));
+        assert_eq!(usage.output_tokens, Some(45));
+        assert_eq!(usage.total_tokens, Some(165));
+        // Absent from the observed payload, so absent here rather than zero.
+        assert_eq!(usage.cache_write_input_tokens, None);
+        assert_eq!(usage.total(), Some(165));
     }
 
-    #[cfg(feature = "json")]
     #[test]
-    fn json_line_event_result_text_missing() {
-        let event: JsonLineEvent = serde_json::from_str(r#"{"type":"completed"}"#).unwrap();
-        assert_eq!(event.result_text(), None);
-        assert_eq!(event.cost_usd(), None);
+    fn token_usage_total_falls_back_to_input_plus_output() {
+        let usage = TokenUsage {
+            input_tokens: Some(10),
+            output_tokens: Some(5),
+            ..TokenUsage::default()
+        };
+        assert_eq!(usage.total(), Some(15));
     }
 
-    #[cfg(feature = "json")]
+    /// A missing total must not read as zero, which would silently understate
+    /// a session's usage.
+    #[test]
+    fn token_usage_total_is_none_when_nothing_reported() {
+        assert_eq!(TokenUsage::default().total(), None);
+    }
+
+    #[test]
+    fn agent_message_text_from_item_completed() {
+        let event: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"hello"}}"#,
+        )
+        .unwrap();
+        assert_eq!(event.agent_message_text().as_deref(), Some("hello"));
+    }
+
+    /// The item layout is assumed rather than verified, so the accessor
+    /// tolerates the plausible variants instead of committing to one and
+    /// silently returning nothing when wrong. See #73.
+    #[test]
+    fn agent_message_text_tolerates_layout_variants() {
+        let type_key: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"type":"agent_message","text":"a"}}"#,
+        )
+        .unwrap();
+        assert_eq!(type_key.agent_message_text().as_deref(), Some("a"));
+
+        let content_blocks: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","content":[{"text":"b"},{"text":"c"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(content_blocks.agent_message_text().as_deref(), Some("bc"));
+    }
+
+    #[test]
+    fn agent_message_text_ignores_other_items_and_events() {
+        let other_item: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"item_type":"command_execution","text":"ls"}}"#,
+        )
+        .unwrap();
+        assert_eq!(other_item.agent_message_text(), None);
+
+        let other_event: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.started","item":{"item_type":"agent_message","text":"x"}}"#,
+        )
+        .unwrap();
+        assert_eq!(other_event.agent_message_text(), None);
+    }
+
     #[test]
     fn json_line_event_role() {
         let event: JsonLineEvent =
@@ -583,32 +791,51 @@ mod tests {
     #[cfg(feature = "json")]
     #[test]
     fn query_result_from_events() {
-        let events: Vec<JsonLineEvent> = vec![
-            serde_json::from_str(
-                r#"{"type":"thread.started","session_id":"sess_1","thread_id":"thread_1"}"#,
-            )
-            .unwrap(),
-            serde_json::from_str(r#"{"type":"message.created","role":"assistant"}"#).unwrap(),
-            serde_json::from_str(r#"{"type":"completed","result":{"text":"done","cost":0.02}}"#)
-                .unwrap(),
-        ];
+        let events: Vec<JsonLineEvent> = [
+            r#"{"type":"thread.started","thread_id":"thread_1"}"#,
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"the answer"}}"#,
+            r#"{"type":"turn.completed","usage":{"input_tokens":7,"output_tokens":3,"total_tokens":10}}"#,
+        ]
+        .iter()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
         let result = QueryResult::from_events(events);
-        assert_eq!(result.result, "done");
-        assert_eq!(result.session_id.as_deref(), Some("sess_1"));
+        assert_eq!(result.result, "the answer");
         assert_eq!(result.thread_id.as_deref(), Some("thread_1"));
-        assert_eq!(result.cost_usd, Some(0.02));
+        assert_eq!(result.usage.unwrap().total(), Some(10));
         assert_eq!(result.events.len(), 3);
     }
 
-    #[cfg(feature = "json")]
     #[test]
-    fn query_result_from_events_no_completed() {
-        let events: Vec<JsonLineEvent> =
-            vec![serde_json::from_str(r#"{"type":"message.created"}"#).unwrap()];
+    fn query_result_concatenates_multiple_agent_messages() {
+        let events: Vec<JsonLineEvent> = [
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"one "}}"#,
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"two"}}"#,
+            r#"{"type":"turn.completed","usage":{"total_tokens":4}}"#,
+        ]
+        .iter()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
+        assert_eq!(QueryResult::from_events(events).result, "one two");
+    }
+
+    /// A failed turn has no agent message and no usage. Both must come back
+    /// empty rather than fabricated.
+    #[test]
+    fn query_result_from_a_failed_turn() {
+        let events: Vec<JsonLineEvent> = [
+            r#"{"type":"thread.started","thread_id":"thread_2"}"#,
+            r#"{"type":"turn.failed","error":{"message":"usage limit"}}"#,
+        ]
+        .iter()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
         let result = QueryResult::from_events(events);
         assert_eq!(result.result, "");
-        assert_eq!(result.cost_usd, None);
-        assert!(result.session_id.is_none());
-        assert!(result.thread_id.is_none());
+        assert_eq!(result.usage, None);
+        assert_eq!(result.thread_id.as_deref(), Some("thread_2"));
     }
 }

--- a/crates/codex-wrapper/tests/fake-codex.sh
+++ b/crates/codex-wrapper/tests/fake-codex.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # Fake codex binary that emits JSONL events to stdout.
-# Used by streaming unit tests.
-echo '{"type":"thread.started","session_id":"sess_test","thread_id":"thread_test"}'
-echo '{"type":"message.created","role":"assistant","content":[{"type":"text","text":"hello"}]}'
-echo '{"type":"completed","result":{"text":"hello","cost":0.001}}'
+# Used by streaming and session unit tests.
+#
+# This mirrors the event vocabulary `codex exec --json` actually emits in
+# codex-cli 0.145.0. An earlier version of this fixture invented a schema
+# (`{"type":"completed","result":{"text":...,"cost":...}}`) that the CLI has
+# never emitted, which made every test that consumed it self-consistent and
+# wrong. See #73.
+#
+# Verified against the CLI: the event names, and that a completed turn reports
+# token counts rather than any monetary cost.
+# Assumed: the exact `item.completed` layout. See the ASSUMPTIONS block in
+# src/types.rs.
+echo '{"type":"thread.started","thread_id":"thread_test"}'
+echo '{"type":"turn.started"}'
+echo '{"type":"item.completed","item":{"id":"item_0","item_type":"agent_message","text":"hello"}}'
+echo '{"type":"turn.completed","usage":{"input_tokens":120,"cached_input_tokens":0,"output_tokens":45,"reasoning_output_tokens":0,"total_tokens":165}}'


### PR DESCRIPTION
Closes #73. Reworks #60.

## The bug

`QueryResult` matches an event shape `codex-cli` does not emit, so against real output `result` is always `""` and `cost_usd` is always `None`. Details and evidence in #73.

The short version: the wrapper wants `{"type":"completed","result":{"text":...,"cost":...}}`. The CLI emits `turn.completed` carrying **token counts**, with no USD field anywhere.

## Evidence tiers

Being explicit, because this PR encodes some inference and that is exactly what caused the bug.

**Verified.** The serde tag list compiled into 0.145.0 is unambiguous:

```
thread.started  turn.started  turn.completed  turn.failed
item.started    item.updated  item.completed
```

A live run confirmed `thread.started` (carrying `thread_id`), `turn.started`, and `turn.failed`. The `TokenUsage` struct is `input_tokens`, `cached_input_tokens`, `cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`, `total_tokens`. No `cost`. A captured sample shows:

```json
{"type":"turn.completed","usage":{"input_tokens":120,"output_tokens":45,"total_tokens":165}}
```

**Assumed.** The exact field layout of `item.completed`, and that assistant text arrives as an `agent_message` item. This is reconstructed from binary string tables, not from a live successful run: the account is rate limited until Aug 5.

Proceeding on assumptions is a deliberate call, since the codex path is not needed downstream yet. They are marked in the code so they can be checked rather than rediscovered.

## Design response to the uncertainty

The previous parser assumed one exact shape and silently produced empty results when wrong. That failure mode is the actual bug, more than the wrong field names. So:

- Accessors tolerate field-name variation where the layout is assumed rather than verified, and are documented as doing so.
- Every parse returns `Option`; nothing fabricates a default that reads as real data.
- `QueryResult::events` keeps the full raw stream, so anything mis-parsed is still reachable.
- A doc block lists what is verified vs assumed, with the check to run once a live capture exists.

## Changes

### `types.rs`

- `TokenUsage` with all six fields, each `Option<u64>` (the sample carried only three).
- `JsonLineEvent::is_turn_completed` / `is_turn_failed`, replacing `is_completed`.
- `JsonLineEvent::usage()`, replacing `cost_usd()`.
- `agent_message_text()` for pulling assistant text off an `item.completed`.
- `QueryResult::cost_usd` becomes `usage: Option<TokenUsage>`; `result` is assembled from agent-message items.

### `session.rs`

- `total_cost()` becomes `total_tokens()`, `turns_missing_cost()` becomes `turns_missing_usage()`, `TurnRecord::cost_usd()` becomes `usage()`.

### `tests/fake-codex.sh`

Rewritten to the real vocabulary. **This is the root cause.** The fixture invented the schema the wrapper expected, so every test was self-consistent and wrong. Fixed first, so the existing tests go red and show the true blast radius.

## No USD

Pricing is a per-model table the CLI does not provide and this crate should not hardcode. #60 becomes a token budget; a dollar budget would need a caller-supplied pricing table, which is a separate proposal.

## Follow-up

The contract check (#54) verifies arguments we emit, not output we consume. That asymmetry is what let this survive. Worth deciding whether it should grow an output-schema check once a real capture exists.