### PR TITLE
fix: kill spawned codex processes when the future is dropped

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,32 @@ match ExecCommand::new("test").execute(&codex).await {
 }
 ```
 
+## Cancellation
+
+Dropping the future returned by a command kills the spawned `codex` process. That covers a
+timeout, an aborted task, and a caller that stops awaiting during a graceful shutdown:
+cancelling the future cancels the work, rather than leaving codex running and billing with no
+handle left to stop it.
+
+```rust
+use codex_wrapper::{ExecCommand, CodexCommand};
+use std::time::Duration;
+
+// The codex process is killed when the timeout drops the future.
+let result = tokio::time::timeout(
+    Duration::from_secs(30),
+    ExecCommand::new("long task").execute(&codex),
+)
+.await;
+```
+
+Two limits are worth knowing:
+
+- The kill reaps the `codex` process itself. Subprocesses codex spawned for tool use are not
+  signalled and can outlive it.
+- Reaping needs the tokio runtime to still be running. A future dropped as part of runtime
+  shutdown may not get far enough to kill the child.
+
 ## Retry Policy
 
 Configure automatic retries for transient failures:

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -488,6 +488,32 @@ match ExecCommand::new("test").execute(&codex).await {
 }
 ```
 
+## Cancellation
+
+Dropping the future returned by a command kills the spawned `codex` process. That covers a
+timeout, an aborted task, and a caller that stops awaiting during a graceful shutdown:
+cancelling the future cancels the work, rather than leaving codex running and billing with no
+handle left to stop it.
+
+```rust
+use codex_wrapper::{ExecCommand, CodexCommand};
+use std::time::Duration;
+
+// The codex process is killed when the timeout drops the future.
+let result = tokio::time::timeout(
+    Duration::from_secs(30),
+    ExecCommand::new("long task").execute(&codex),
+)
+.await;
+```
+
+Two limits are worth knowing:
+
+- The kill reaps the `codex` process itself. Subprocesses codex spawned for tool use are not
+  signalled and can outlive it.
+- Reaping needs the tokio runtime to still be running. A future dropped as part of runtime
+  shutdown may not get far enough to kill the child.
+
 ## Retry Policy
 
 Configure automatic retries for transient failures:

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -141,6 +141,11 @@ async fn run_internal(
     // Prevent child from inheriting/blocking on parent's stdin.
     cmd.stdin(std::process::Stdio::null());
 
+    // Kill the child if this future is dropped: on timeout, on caller
+    // cancellation, or on task abort. Without this, tokio detaches the child
+    // and codex keeps running with no handle left to stop it.
+    cmd.kill_on_drop(true);
+
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
     }
@@ -220,5 +225,59 @@ mod tests {
         let debug = format!("{output:?}");
         assert!(debug.contains("... (300 bytes total)"));
         assert!(!debug.contains(&long));
+    }
+
+    /// A wrapper timeout drops `run_internal`'s future. Without
+    /// `kill_on_drop`, `Error::Timeout` would mean "we stopped waiting" while
+    /// codex kept running.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timeout_kills_the_spawned_process() {
+        use crate::test_support::{PidFile, blocking_codex, wait_until_gone};
+
+        let pid_file = PidFile::new("exec-timeout");
+        let codex = blocking_codex(&pid_file)
+            .timeout(Duration::from_millis(500))
+            .build()
+            .expect("bash must exist");
+
+        let result = run_codex(&codex, vec!["exec".into(), "probe".into()]).await;
+        assert!(
+            matches!(result, Err(Error::Timeout { .. })),
+            "expected timeout error, got: {result:?}"
+        );
+
+        let pid = pid_file.read_pid().await;
+        assert!(
+            wait_until_gone(pid).await,
+            "codex ({pid}) survived the timeout"
+        );
+    }
+
+    /// The caller dropping the future is the case an operator kill or a
+    /// graceful shutdown produces, with no wrapper timeout involved.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancellation_kills_the_spawned_process() {
+        use crate::test_support::{PidFile, blocking_codex, wait_until_gone};
+
+        let pid_file = PidFile::new("exec-cancel");
+        let codex = blocking_codex(&pid_file).build().expect("bash must exist");
+
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(500),
+            run_codex(&codex, vec!["exec".into(), "probe".into()]),
+        )
+        .await;
+        assert!(
+            cancelled.is_err(),
+            "fake codex should still have been running, got: {cancelled:?}"
+        );
+
+        let pid = pid_file.read_pid().await;
+        assert!(
+            wait_until_gone(pid).await,
+            "codex ({pid}) survived the dropped future"
+        );
     }
 }

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -143,6 +143,21 @@
 //! # }
 //! ```
 //!
+//! # Cancellation
+//!
+//! Dropping the future returned by a command kills the spawned `codex`
+//! process. That covers a timeout, an aborted task, and a caller that stops
+//! awaiting during a graceful shutdown: cancelling the future cancels the
+//! work, rather than leaving codex running and billing with no handle left to
+//! stop it.
+//!
+//! Two limits are worth knowing:
+//!
+//! - The kill reaps the `codex` process itself. Subprocesses codex spawned for
+//!   tool use are not signalled and can outlive it.
+//! - Reaping needs the tokio runtime to still be running. A future dropped as
+//!   part of runtime shutdown may not get far enough to kill the child.
+//!
 //! # Features
 //!
 //! - `json` *(enabled by default)* - JSONL output parsing via `serde_json`
@@ -155,6 +170,8 @@ pub mod retry;
 pub mod session;
 #[cfg(feature = "json")]
 pub mod streaming;
+#[cfg(all(test, unix))]
+mod test_support;
 pub mod types;
 pub mod version;
 

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -85,6 +85,11 @@ where
     child_cmd.stdout(std::process::Stdio::piped());
     child_cmd.stderr(std::process::Stdio::piped());
 
+    // Kill the child if this future is dropped: on timeout, on caller
+    // cancellation, or on task abort. Without this, tokio detaches the child
+    // and codex keeps running with no handle left to stop it.
+    child_cmd.kill_on_drop(true);
+
     if let Some(dir) = &codex.working_dir {
         child_cmd.current_dir(dir);
     }
@@ -259,6 +264,58 @@ mod tests {
         assert!(
             matches!(result, Err(Error::Timeout { .. })),
             "expected timeout error, got: {result:?}"
+        );
+    }
+
+    /// The streaming path drops both `stream_future` and the child it borrows.
+    /// Without `kill_on_drop`, the timeout above would leave codex running.
+    #[tokio::test]
+    async fn stream_exec_timeout_kills_the_spawned_process() {
+        use crate::test_support::{PidFile, blocking_codex, wait_until_gone};
+
+        let pid_file = PidFile::new("stream-timeout");
+        let codex = blocking_codex(&pid_file)
+            .timeout(std::time::Duration::from_millis(500))
+            .build()
+            .expect("bash must exist");
+
+        let cmd = crate::command::exec::ExecCommand::new("probe").json();
+        let result = stream_exec(&codex, &cmd, |_| {}).await;
+        assert!(
+            matches!(result, Err(Error::Timeout { .. })),
+            "expected timeout error, got: {result:?}"
+        );
+
+        let pid = pid_file.read_pid().await;
+        assert!(
+            wait_until_gone(pid).await,
+            "codex ({pid}) survived the timeout"
+        );
+    }
+
+    /// The caller dropping the stream future, with no wrapper timeout.
+    #[tokio::test]
+    async fn stream_exec_cancellation_kills_the_spawned_process() {
+        use crate::test_support::{PidFile, blocking_codex, wait_until_gone};
+
+        let pid_file = PidFile::new("stream-cancel");
+        let codex = blocking_codex(&pid_file).build().expect("bash must exist");
+
+        let cmd = crate::command::exec::ExecCommand::new("probe").json();
+        let cancelled = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            stream_exec(&codex, &cmd, |_| {}),
+        )
+        .await;
+        assert!(
+            cancelled.is_err(),
+            "fake codex should still have been running, got: {cancelled:?}"
+        );
+
+        let pid = pid_file.read_pid().await;
+        assert!(
+            wait_until_gone(pid).await,
+            "codex ({pid}) survived the dropped future"
         );
     }
 

--- a/crates/codex-wrapper/src/test_support.rs
+++ b/crates/codex-wrapper/src/test_support.rs
@@ -1,0 +1,98 @@
+//! Helpers for the unix-only process-lifetime tests in [`crate::exec`] and
+//! [`crate::streaming`].
+//!
+//! Those tests assert that a spawned `codex` dies when the future driving it
+//! is dropped, which means observing the process from outside the wrapper: the
+//! fake codex records its PID to a file, and the test reads that PID back and
+//! watches it disappear.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::{Codex, CodexBuilder};
+
+/// A file that the fake codex writes its PID to, cleaned up on drop.
+pub(crate) struct PidFile {
+    path: PathBuf,
+}
+
+impl PidFile {
+    /// Reserve a PID file path. `label` distinguishes concurrent tests, which
+    /// share a process ID because cargo runs them as threads.
+    pub(crate) fn new(label: &str) -> Self {
+        let path =
+            std::env::temp_dir().join(format!("codex-wrapper-{}-{label}.pid", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        Self { path }
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Read back the PID the fake codex recorded, waiting up to a second for
+    /// it to appear. Panics rather than returning an error: no PID means the
+    /// fake never ran, which makes the calling test meaningless.
+    pub(crate) async fn read_pid(&self) -> u32 {
+        for _ in 0..100 {
+            if let Ok(contents) = std::fs::read_to_string(&self.path)
+                && let Ok(pid) = contents.trim().parse()
+            {
+                return pid;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("fake codex never recorded a pid at {}", self.path.display());
+    }
+}
+
+impl Drop for PidFile {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// A [`Codex`] client whose binary is a fake codex that blocks until killed,
+/// recording its PID to `pid_file` first.
+///
+/// Returned as a builder so callers can decide whether the run carries a
+/// wrapper timeout or is cancelled from outside.
+pub(crate) fn blocking_codex(pid_file: &PidFile) -> CodexBuilder {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fake-codex-blocks.sh");
+    Codex::builder()
+        .binary("/bin/bash")
+        .arg(script.to_str().expect("fixture path is utf-8"))
+        .env(
+            "CODEX_WRAPPER_TEST_PIDFILE",
+            pid_file.path().to_str().expect("pid file path is utf-8"),
+        )
+}
+
+/// Wait for `pid` to stop running, up to five seconds.
+///
+/// Checks the process state rather than `kill -0`: a killed child lingers as a
+/// zombie until tokio's orphan reaper collects it, and a zombie still answers
+/// `kill -0`, which would read as "still running".
+pub(crate) async fn wait_until_gone(pid: u32) -> bool {
+    for _ in 0..250 {
+        if !is_running(pid) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    false
+}
+
+/// `true` while `pid` is a live process. Empty `ps` output means the PID is
+/// gone; a leading `Z` means it exited and is awaiting reaping.
+fn is_running(pid: u32) -> bool {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "state=", "-p", &pid.to_string()])
+        .output()
+        .expect("ps must be available");
+    let state = String::from_utf8_lossy(&output.stdout);
+    let state = state.trim();
+    !state.is_empty() && !state.starts_with('Z')
+}

--- a/crates/codex-wrapper/tests/fake-codex-blocks.sh
+++ b/crates/codex-wrapper/tests/fake-codex-blocks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Fake codex that records its own PID and then blocks until it is killed.
+#
+# Used by the process-lifetime tests to check that dropping the future kills
+# the spawned process. `exec` replaces this shell with `sleep`, so the PID
+# written here stays the PID tokio spawned, which is the one kill_on_drop
+# reaps. Without `exec` the test would be watching the wrong process.
+echo "$$" >"$CODEX_WRAPPER_TEST_PIDFILE"
+exec sleep 60


### PR DESCRIPTION
Closes #76.

## Problem

Neither spawn site sets `kill_on_drop`, and tokio's default `Child` drop detaches the process rather than killing it:

- `crates/codex-wrapper/src/exec.rs:138` in `run_internal`
- `crates/codex-wrapper/src/streaming.rs:82` in `run_streaming`

This is already reachable from inside the wrapper. Both execution paths wrap themselves in `tokio::time::timeout`:

- `exec.rs:187` drops the `output()` future
- `streaming.rs:174` drops `stream_future`, after which `child` falls out of scope

So `Error::Timeout` currently means "we stopped waiting", not "we stopped codex". The same applies to caller-side cancellation: a dropped future, an aborted task, or a graceful shutdown leaves `codex` running with no handle left to stop it, still consuming tokens and still billing.

## Plan

1. Add `.kill_on_drop(true)` to both `Command` builders.
2. Add a unix-only integration test that spawns a fake codex which records its PID and blocks, drops the future, and asserts the recorded PID is gone. One case for the buffered path, one for the streaming path.
3. Document the caveat on `Codex`: `kill_on_drop` relies on the tokio runtime still being alive to reap the child, so a process dropped during runtime shutdown can still survive.

## Not in scope

Process-group handling. `kill_on_drop` reaps the direct child only, and `codex` spawns its own subprocesses for tool use. Covering those needs `process_group(0)` plus signalling the group, and a SIGTERM-then-SIGKILL grace period cannot run in `Drop`, so it needs an explicit cancellation API rather than a drop-time fix. Filed separately.