### PR TITLE
feat: add ReviewCommand::execute_json, and correct the item schema against real output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Unit tests
         run: cargo test --lib --all-features
 
+      # Building without default features is not enough: the test target has
+      # its own feature-gating, and a test referring to a json-only type
+      # compiles fine under --all-features while breaking this build.
+      - name: Unit tests without default features
+        run: cargo test --lib --no-default-features
+
       - name: Doc tests
         run: cargo test --doc --all-features
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,18 @@ let output = ReviewCommand::new()
     .json()
     .execute(&codex)
     .await?;
+
+// Typed result, same shape ExecCommand returns
+let result = ReviewCommand::new()
+    .uncommitted()
+    .execute_json(&codex)
+    .await?;
+println!("{}", result.result);
 ```
+
+Review emits the same event vocabulary as `codex exec`, so `execute_json()` assembles the
+review comments into `QueryResult::result`. One difference: a review's `turn.completed`
+reports a usage object of all zeros, so `result.usage` carries no counts.
 
 ## MCP Server Management
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -343,7 +343,18 @@ let output = ReviewCommand::new()
     .json()
     .execute(&codex)
     .await?;
+
+// Typed result, same shape ExecCommand returns
+let result = ReviewCommand::new()
+    .uncommitted()
+    .execute_json(&codex)
+    .await?;
+println!("{}", result.result);
 ```
+
+Review emits the same event vocabulary as `codex exec`, so `execute_json()` assembles the
+review comments into `QueryResult::result`. One difference: a review's `turn.completed`
+reports a usage object of all zeros, so `result.usage` carries no counts.
 
 ## MCP Server Management
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -429,8 +429,8 @@ impl ExecCommand {
 
     /// Execute the command and return a typed [`QueryResult`].
     ///
-    /// Assembles the final result text, ids, and cost from the JSONL event
-    /// stream. Use [`execute_json_lines`](ExecCommand::execute_json_lines) for
+    /// Assembles the final result text, ids, and token usage from the JSONL
+    /// event stream. Use [`execute_json_lines`](ExecCommand::execute_json_lines) for
     /// the raw event stream. Requires the `json` feature.
     #[cfg(feature = "json")]
     pub async fn execute_json(&self, codex: &Codex) -> Result<QueryResult> {
@@ -806,8 +806,8 @@ impl ExecResumeCommand {
 
     /// Execute the resume command and return a typed [`QueryResult`].
     ///
-    /// Assembles the final result text, ids, and cost from the JSONL event
-    /// stream. Requires the `json` feature.
+    /// Assembles the final result text, ids, and token usage from the JSONL
+    /// event stream. Requires the `json` feature.
     #[cfg(feature = "json")]
     pub async fn execute_json(&self, codex: &Codex) -> Result<QueryResult> {
         let events = self.execute_json_lines(codex).await?;

--- a/crates/codex-wrapper/src/command/review.rs
+++ b/crates/codex-wrapper/src/command/review.rs
@@ -295,6 +295,25 @@ impl ReviewCommand {
             })
             .collect()
     }
+
+    /// Execute the review and return a typed
+    /// [`QueryResult`](crate::types::QueryResult).
+    ///
+    /// Review emits the same event vocabulary as `codex exec`, so the review
+    /// comments arrive as the `agent_message` item that
+    /// [`result`](crate::types::QueryResult::result) is assembled from. Use
+    /// [`execute_json_lines`](Self::execute_json_lines) for the raw stream.
+    /// Requires the `json` feature.
+    ///
+    /// One difference from exec, observed on `codex-cli` 0.145.0: the
+    /// `turn.completed` event of a review reports a usage object of all
+    /// zeros, so [`usage`](crate::types::QueryResult::usage) is present but
+    /// carries no counts.
+    #[cfg(feature = "json")]
+    pub async fn execute_json(&self, codex: &Codex) -> Result<crate::types::QueryResult> {
+        let events = self.execute_json_lines(codex).await?;
+        Ok(crate::types::QueryResult::from_events(events))
+    }
 }
 
 impl Default for ReviewCommand {
@@ -501,5 +520,39 @@ mod tests {
                 "/tmp/schema.json"
             ]
         );
+    }
+
+    /// #70 asked whether `QueryResult::from_events` holds up on review output.
+    /// It does: the fixture is a transcript of a real review run, and the
+    /// review comments land in `result` the same way an exec answer does.
+    #[cfg(all(unix, feature = "json"))]
+    #[tokio::test]
+    async fn review_execute_json_assembles_a_query_result() {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-review.sh");
+        let codex = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .build()
+            .expect("bash must exist");
+
+        let result = ReviewCommand::new()
+            .uncommitted()
+            .execute_json(&codex)
+            .await
+            .unwrap();
+
+        assert_eq!(result.result, "- [P1] Keep add performing addition");
+        assert_eq!(
+            result.thread_id.as_deref(),
+            Some("019fd952-7ce9-7662-8a20-9c33c1718dca")
+        );
+        // The command_execution items the reviewer ran are in the stream but
+        // must not leak into the result text.
+        assert!(!result.result.contains("git diff"));
+        assert_eq!(result.events.len(), 6);
+        // Review reports usage, but a real run reports it as all zeros.
+        assert_eq!(result.usage.and_then(|u| u.total()), Some(0));
     }
 }

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -10,27 +10,32 @@
 //! rediscovering the bug.
 //!
 //! **Verified** against `codex-cli` 0.145.0, from the compiled serde tag list
-//! and a live run:
+//! and live runs of both `codex exec --json` and `codex exec review --json`:
 //!
 //! - The event vocabulary is `thread.started`, `turn.started`, `turn.completed`,
 //!   `turn.failed`, `item.started`, `item.updated`, `item.completed`. There is
-//!   no bare `completed`.
+//!   no bare `completed`. Review emits the same vocabulary as exec.
 //! - `thread.started` carries `thread_id`.
-//! - A completed turn reports token counts, never a monetary cost. The
-//!   `TokenUsage` fields are `input_tokens`, `cached_input_tokens`,
-//!   `cache_write_input_tokens`, `output_tokens`, `reasoning_output_tokens`,
-//!   `total_tokens`.
+//! - A completed turn reports token counts, never a monetary cost. The `usage`
+//!   object carries `input_tokens`, `cached_input_tokens`,
+//!   `cache_write_input_tokens`, `output_tokens`, and
+//!   `reasoning_output_tokens`. It does **not** carry `total_tokens`, so
+//!   [`TokenUsage::total`] reaches a total through its input plus output
+//!   fallback on every real run.
+//! - Assistant text arrives as an `item.completed` event whose `item` has a
+//!   `type` of `agent_message` and its text in a `text` field. A review's
+//!   diff-reading steps arrive as `command_execution` items on the same event.
+//! - A review's `turn.completed` reports a usage object of all zeros.
 //!
-//! **Assumed**, reconstructed from binary string tables rather than a live
-//! successful run:
+//! **Assumed**, still: nothing load-bearing.
+//! [`JsonLineEvent::agent_message_text`] also accepts an `item_type`
+//! discriminator and a `content` block array, neither of which has been seen
+//! in real output. That tolerance stays because the failure mode when this
+//! parser guesses wrong is an empty result rather than an error, which is how
+//! #73 went unnoticed.
 //!
-//! - Assistant text arrives as an `item.completed` event whose `item` has an
-//!   `agent_message` discriminator.
-//! - That the discriminator is `item_type` and the text is a `text` field.
-//!   [`JsonLineEvent::agent_message_text`] accepts `type` and a `content`
-//!   block array as alternatives rather than committing to one.
-//!
-//! To confirm, capture a real run and check `result` is non-empty:
+//! To re-confirm after a CLI upgrade, capture a run and check `result` is
+//! non-empty:
 //!
 //! ```sh
 //! codex exec --json --ephemeral --skip-git-repo-check "reply with: ok" > turn.jsonl
@@ -279,14 +284,12 @@ impl JsonLineEvent {
     ///
     /// Returns `None` for any other event or item type.
     ///
-    /// The item layout here is **assumed**, not verified against a live run;
-    /// see the ASSUMPTIONS block on [`QueryResult`]. Both `item_type` and
-    /// `type` are accepted as the discriminator, and the text is read from
-    /// either a `text` field or a `content` block array, because which of
-    /// those the CLI emits has not been confirmed. Tolerating both is
-    /// deliberate: the previous parser assumed one exact shape and silently
-    /// yielded empty results when it was wrong, which is the bug this
-    /// replaces.
+    /// Real output uses a `type` discriminator and a `text` field; see the
+    /// schema block at the top of this module. An `item_type` discriminator
+    /// and a `content` block array are also accepted, neither of them
+    /// observed. Tolerating the unobserved shapes is deliberate: the previous
+    /// parser committed to one exact layout and silently yielded empty results
+    /// when it was wrong, which is the bug this replaces.
     #[must_use]
     pub fn agent_message_text(&self) -> Option<String> {
         if self.event_type != "item.completed" {
@@ -421,8 +424,9 @@ impl QueryResult {
 /// so this crate does not attempt it: a hardcoded table would go stale
 /// silently, which is the same class of bug as #73.
 ///
-/// Every field is optional. An observed `turn.completed` carried only three of
-/// the six, so absence is normal rather than exceptional.
+/// Every field is optional, and absence is normal rather than exceptional:
+/// observed runs carry five of the six and never `total_tokens`, which is why
+/// [`TokenUsage::total`] falls back to input plus output.
 #[cfg(feature = "json")]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TokenUsage {
@@ -436,7 +440,7 @@ pub struct TokenUsage {
     pub output_tokens: Option<u64>,
     /// Output tokens spent on reasoning.
     pub reasoning_output_tokens: Option<u64>,
-    /// Total tokens as reported by the CLI.
+    /// Total tokens, if the CLI ever reports one. Observed runs do not.
     pub total_tokens: Option<u64>,
 }
 
@@ -704,25 +708,27 @@ mod tests {
         assert_eq!(TokenUsage::default().total(), None);
     }
 
+    /// The shape a real run emits: `type` on the item, text in `text`.
     #[test]
     fn agent_message_text_from_item_completed() {
         let event: JsonLineEvent = serde_json::from_str(
-            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"hello"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hello"}}"#,
         )
         .unwrap();
         assert_eq!(event.agent_message_text().as_deref(), Some("hello"));
     }
 
-    /// The item layout is assumed rather than verified, so the accessor
-    /// tolerates the plausible variants instead of committing to one and
-    /// silently returning nothing when wrong. See #73.
+    /// `item_type` and content blocks are not shapes the CLI has been seen to
+    /// emit. The accessor still tolerates them, because the cost of being
+    /// wrong here is a silently empty result rather than a loud failure, which
+    /// is how #73 stayed hidden. These cases keep that tolerance covered.
     #[test]
     fn agent_message_text_tolerates_layout_variants() {
-        let type_key: JsonLineEvent = serde_json::from_str(
-            r#"{"type":"item.completed","item":{"type":"agent_message","text":"a"}}"#,
+        let item_type_key: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"item_type":"agent_message","text":"a"}}"#,
         )
         .unwrap();
-        assert_eq!(type_key.agent_message_text().as_deref(), Some("a"));
+        assert_eq!(item_type_key.agent_message_text().as_deref(), Some("a"));
 
         let content_blocks: JsonLineEvent = serde_json::from_str(
             r#"{"type":"item.completed","item":{"item_type":"agent_message","content":[{"text":"b"},{"text":"c"}]}}"#,
@@ -733,14 +739,15 @@ mod tests {
 
     #[test]
     fn agent_message_text_ignores_other_items_and_events() {
+        // The item type a review's diff-reading steps arrive as.
         let other_item: JsonLineEvent = serde_json::from_str(
-            r#"{"type":"item.completed","item":{"item_type":"command_execution","text":"ls"}}"#,
+            r#"{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"git diff","exit_code":0}}"#,
         )
         .unwrap();
         assert_eq!(other_item.agent_message_text(), None);
 
         let other_event: JsonLineEvent = serde_json::from_str(
-            r#"{"type":"item.started","item":{"item_type":"agent_message","text":"x"}}"#,
+            r#"{"type":"item.started","item":{"id":"item_0","type":"agent_message","text":"x"}}"#,
         )
         .unwrap();
         assert_eq!(other_event.agent_message_text(), None);

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -676,6 +676,7 @@ mod tests {
         assert!(!bogus.is_turn_completed());
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn json_line_event_usage() {
         let event: JsonLineEvent = serde_json::from_str(
@@ -691,6 +692,7 @@ mod tests {
         assert_eq!(usage.total(), Some(165));
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn token_usage_total_falls_back_to_input_plus_output() {
         let usage = TokenUsage {
@@ -703,12 +705,14 @@ mod tests {
 
     /// A missing total must not read as zero, which would silently understate
     /// a session's usage.
+    #[cfg(feature = "json")]
     #[test]
     fn token_usage_total_is_none_when_nothing_reported() {
         assert_eq!(TokenUsage::default().total(), None);
     }
 
     /// The shape a real run emits: `type` on the item, text in `text`.
+    #[cfg(feature = "json")]
     #[test]
     fn agent_message_text_from_item_completed() {
         let event: JsonLineEvent = serde_json::from_str(
@@ -722,6 +726,7 @@ mod tests {
     /// emit. The accessor still tolerates them, because the cost of being
     /// wrong here is a silently empty result rather than a loud failure, which
     /// is how #73 stayed hidden. These cases keep that tolerance covered.
+    #[cfg(feature = "json")]
     #[test]
     fn agent_message_text_tolerates_layout_variants() {
         let item_type_key: JsonLineEvent = serde_json::from_str(
@@ -737,6 +742,7 @@ mod tests {
         assert_eq!(content_blocks.agent_message_text().as_deref(), Some("bc"));
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn agent_message_text_ignores_other_items_and_events() {
         // The item type a review's diff-reading steps arrive as.
@@ -753,6 +759,7 @@ mod tests {
         assert_eq!(other_event.agent_message_text(), None);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn json_line_event_role() {
         let event: JsonLineEvent =
@@ -814,6 +821,7 @@ mod tests {
         assert_eq!(result.events.len(), 3);
     }
 
+    #[cfg(feature = "json")]
     #[test]
     fn query_result_concatenates_multiple_agent_messages() {
         let events: Vec<JsonLineEvent> = [
@@ -830,6 +838,7 @@ mod tests {
 
     /// A failed turn has no agent message and no usage. Both must come back
     /// empty rather than fabricated.
+    #[cfg(feature = "json")]
     #[test]
     fn query_result_from_a_failed_turn() {
         let events: Vec<JsonLineEvent> = [

--- a/crates/codex-wrapper/tests/fake-codex-review.sh
+++ b/crates/codex-wrapper/tests/fake-codex-review.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fake `codex exec review --json` output.
+#
+# Transcribed from a real codex-cli 0.145.0 run against a one-line uncommitted
+# diff, with the review text shortened. Review emits the same event vocabulary
+# as exec, preceded by the command_execution items the reviewer runs to read
+# the diff.
+#
+# Two details are real and load-bearing, both verified in that run:
+#   - the item discriminator is `type`, not `item_type`
+#   - a review's `turn.completed` reports a usage object of all zeros
+echo '{"type":"thread.started","thread_id":"019fd952-7ce9-7662-8a20-9c33c1718dca"}'
+echo '{"type":"turn.started"}'
+echo '{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"git diff"}}'
+echo '{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"git diff","aggregated_output":"","exit_code":0,"status":"completed"}}'
+echo '{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"- [P1] Keep add performing addition"}}'
+echo '{"type":"turn.completed","usage":{"input_tokens":0,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0}}'

--- a/crates/codex-wrapper/tests/fake-codex.sh
+++ b/crates/codex-wrapper/tests/fake-codex.sh
@@ -8,11 +8,14 @@
 # never emitted, which made every test that consumed it self-consistent and
 # wrong. See #73.
 #
-# Verified against the CLI: the event names, and that a completed turn reports
-# token counts rather than any monetary cost.
-# Assumed: the exact `item.completed` layout. See the ASSUMPTIONS block in
-# src/types.rs.
+# Verified against a real `codex exec --json --ephemeral` run: the event names,
+# the `type` discriminator on the item, and a completed turn reporting token
+# counts rather than any monetary cost. The usage object carries no
+# `total_tokens`, so `TokenUsage::total` reaches 165 through its input plus
+# output fallback, which is the path every real run takes.
+#
+# The ids and counts are synthetic. The shape is not.
 echo '{"type":"thread.started","thread_id":"thread_test"}'
 echo '{"type":"turn.started"}'
-echo '{"type":"item.completed","item":{"id":"item_0","item_type":"agent_message","text":"hello"}}'
-echo '{"type":"turn.completed","usage":{"input_tokens":120,"cached_input_tokens":0,"output_tokens":45,"reasoning_output_tokens":0,"total_tokens":165}}'
+echo '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hello"}}'
+echo '{"type":"turn.completed","usage":{"input_tokens":120,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":45,"reasoning_output_tokens":0}}'

--- a/crates/codex-wrapper/tests/integration.rs
+++ b/crates/codex-wrapper/tests/integration.rs
@@ -259,6 +259,29 @@ async fn review_uncommitted() {
     assert!(output.is_ok() || output.is_err());
 }
 
+/// Requires uncommitted changes in the working tree to review. With a clean
+/// tree the CLI exits non-zero and this reports that rather than a schema
+/// problem.
+#[tokio::test]
+#[ignore]
+async fn review_query_result() {
+    let codex = codex();
+    let result = ReviewCommand::new()
+        .uncommitted()
+        .ephemeral()
+        .execute_json(&codex)
+        .await
+        .unwrap();
+    assert!(
+        result.thread_id.is_some(),
+        "expected a thread_id from the stream"
+    );
+    assert!(
+        !result.result.is_empty(),
+        "expected review comments in the assembled result, got: {result:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Resume / Fork (interactive - just verify arg building doesn't break)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #70. Closes #80.

## Verified against the CLI first

#70 asked for the event shape to be confirmed before assuming `QueryResult::from_events` works on review output. Captured two real `codex-cli` 0.145.0 runs, `codex exec review --uncommitted --json --ephemeral` and `codex exec --json --ephemeral`. Full findings are on #70; the ones that change code:

1. Review emits the same vocabulary as exec: `thread.started`, `turn.started`, `item.started`, `item.completed`, `turn.completed`, with the review comments in an `agent_message` item and the reviewer's diff-reading steps as `command_execution` items. `from_events` works on it unchanged.
2. The item discriminator is `type`, not `item_type`. #74 marked this assumed and had `agent_message_text` accept both, so nothing parsed wrong, but `tests/fake-codex.sh` asserted the invented shape, which is the fixture problem #73 was filed about.
3. `turn.completed.usage` carries no `total_tokens`. `TokenUsage::total` already falls back to input plus output, so that fallback is the path every real run takes rather than an edge case.
4. A review's `turn.completed` reports usage as all zeros, where the exec run reported 16605 input and 5 output.

## Changes

- `ReviewCommand::execute_json()` returning `QueryResult`, mirroring `ExecCommand` and `ExecResumeCommand`.
- `tests/fake-codex-review.sh`, transcribed from the captured review stream.
- `tests/fake-codex.sh` switched to the `type` discriminator and to a usage object with no `total_tokens`. The counts still total 165, now through the fallback, so the session tests reading that number keep asserting the same thing against a shape the CLI actually emits.
- Unit test asserting the reviewer's `command_execution` items stay out of the assembled result text, plus an ignored integration test against the real CLI.
- Schema block in `types.rs` corrected: the item layout moves from Assumed to Verified, `total_tokens` is recorded as a field the CLI does not emit, and the primary-path tests now use the real shape while the `item_type` tolerance keeps its own labelled test.
- Two `execute_json` doc comments still described a cost field #74 removed.

## Added scope: #80

`cargo test --lib --no-default-features` has not compiled on `main` since #74: nine `types.rs` tests name json-only types without a gate. CI builds that configuration but never tests it, so nothing caught it. Gated the tests and added the missing CI step.

This is here rather than in its own PR because this PR was already rewriting those same test functions; separating them would have meant two changes editing the same lines for no independent benefit.

## CI

GitHub Actions is in a major outage, so no checks have run. Ran the CI job set locally on this branch, all passing:

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo build --all-features`, `cargo build --no-default-features`, `cargo test --lib --all-features` (139), `cargo test --lib --no-default-features` (102), `cargo test --doc --all-features` (17), `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`, and `cargo test --test contract --all-features -- --ignored` (17) against the locally installed codex 0.145.0.