### PR TITLE
ci: compile and run the tests/ directory in the test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,13 @@ jobs:
       - name: Unit tests without default features
         run: cargo test --lib --no-default-features
 
+      # Runs nothing today: every test under tests/ is #[ignore]d and needs a
+      # real authenticated codex, which the contract job supplies with
+      # --ignored. This step compiles the directory and gives a non-ignored
+      # test somewhere to run, so one is not added to a suite CI never invokes.
+      - name: Integration test harness
+        run: cargo test --test '*' --all-features
+
       - name: Doc tests
         run: cargo test --doc --all-features
 


### PR DESCRIPTION
Closes #88.

Adds the missing harness step:

```yaml
- name: Integration test harness
  run: cargo test --test '*' --all-features
```

## What it actually does today

Nothing runs. Both test binaries compile and report zero:

```
Running tests/contract.rs      0 passed; 0 failed; 17 ignored
Running tests/integration.rs   0 passed; 0 failed; 29 ignored
```

That is the intended state, and the issue says so: every test in `tests/` is `#[ignore]d` and needs a real authenticated `codex`, which the separate `contract` job supplies with `--ignored`. The value here is compile coverage for the directory, plus somewhere for a future non-ignored test to land. Named "Integration test harness" rather than the issue's "Integration tests (fake-binary)", since there are no fake-binary tests under `tests/` yet; the fake-codex tests live in `src/`.

## Windows gating

Not applied. The issue notes `claude-wrapper` gates its equivalent step to non-Windows because of the bash fixture, and says to do the same here *if any fake-binary test moves into `tests/`*. None has, and nothing this step runs touches a shell script, so gating now would be dead configuration. The comment in the workflow records why, so whoever moves a fake-binary test there has the context.