### PR TITLE
feat: to_command_string() for previewing the argv a builder will spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,24 @@ match ExecCommand::new("test").execute(&codex).await {
 }
 ```
 
+## Previewing the Command
+
+Every builder can render the exact command line it will spawn, without spawning it:
+
+```rust
+use codex_wrapper::{Codex, CodexCommand, ExecCommand};
+
+let codex = Codex::builder().config("model=\"gpt-5\"").build()?;
+let cmd = ExecCommand::new("fix the failing tests").ephemeral();
+
+println!("{}", cmd.to_command_string(&codex));
+// codex -c 'model="gpt-5"' exec --ephemeral 'fix the failing tests'
+```
+
+Global args precede the subcommand, the same order the spawn uses, because the preview and both
+spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
+pasted, but no shell is involved at spawn time: args go to the process directly.
+
 ## Cancellation
 
 Dropping the future returned by a command kills the spawned `codex` process. That covers a

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -499,6 +499,24 @@ match ExecCommand::new("test").execute(&codex).await {
 }
 ```
 
+## Previewing the Command
+
+Every builder can render the exact command line it will spawn, without spawning it:
+
+```rust
+use codex_wrapper::{Codex, CodexCommand, ExecCommand};
+
+let codex = Codex::builder().config("model=\"gpt-5\"").build()?;
+let cmd = ExecCommand::new("fix the failing tests").ephemeral();
+
+println!("{}", cmd.to_command_string(&codex));
+// codex -c 'model="gpt-5"' exec --ephemeral 'fix the failing tests'
+```
+
+Global args precede the subcommand, the same order the spawn uses, because the preview and both
+spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
+pasted, but no shell is involved at spawn time: args go to the process directly.
+
 ## Cancellation
 
 Dropping the future returned by a command kills the spawned `codex` process. That covers a

--- a/crates/codex-wrapper/src/command/mod.rs
+++ b/crates/codex-wrapper/src/command/mod.rs
@@ -41,4 +41,107 @@ pub trait CodexCommand: Send + Sync {
 
     /// Execute the command against the given [`Codex`] client.
     fn execute(&self, codex: &Codex) -> impl Future<Output = Result<Self::Output>> + Send;
+
+    /// Render the exact command line this builder will spawn, quoted for a
+    /// POSIX shell.
+    ///
+    /// Useful for logging a reproduction or checking an invocation before
+    /// running it. The client's global args precede the command's own, the
+    /// same order the spawn uses, because both go through one assembly
+    /// function: the preview cannot drift from what runs.
+    ///
+    /// ```no_run
+    /// use codex_wrapper::{Codex, CodexCommand, ExecCommand};
+    ///
+    /// # fn example() -> codex_wrapper::Result<()> {
+    /// let codex = Codex::builder().build()?;
+    /// let cmd = ExecCommand::new("fix the failing tests").ephemeral();
+    /// println!("{}", cmd.to_command_string(&codex));
+    /// // codex exec --ephemeral 'fix the failing tests'
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// The rendering is for humans. It is faithful to the argv, but the args
+    /// are passed to the process directly rather than through a shell, so a
+    /// shell is never involved at spawn time.
+    fn to_command_string(&self, codex: &Codex) -> String {
+        crate::exec::command_string(codex, self.args())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use crate::command::exec::{ExecCommand, ExecResumeCommand};
+
+    /// Run a fake codex that echoes its argv, one argument per line.
+    async fn spawned_args(cmd: &impl CodexCommand, codex: &Codex) -> Vec<String> {
+        let output = crate::exec::run_codex(codex, cmd.args()).await.unwrap();
+        output.stdout.lines().map(str::to_string).collect()
+    }
+
+    fn echoing_codex() -> Codex {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-echo-args.sh");
+        Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .config("model=\"gpt-5\"")
+            .build()
+            .expect("bash must exist")
+    }
+
+    /// The preview is only worth anything if it matches the real spawn. This
+    /// compares against the argv a process actually received, rather than
+    /// against the assembly function the preview itself calls: a test written
+    /// that way would still pass if the spawn path stopped using it.
+    ///
+    /// Quoting is shared with the implementation here, and covered on its own
+    /// in `exec::tests`. What this pins is the part a shared function cannot
+    /// prove by itself: that the args reaching the process are the same ones,
+    /// in the same order, that the preview claims.
+    #[tokio::test]
+    async fn preview_matches_the_argv_a_spawn_receives() {
+        let codex = echoing_codex();
+        let cmd = ExecCommand::new("fix the failing tests").ephemeral();
+
+        let spawned = spawned_args(&cmd, &codex).await;
+        let preview = cmd.to_command_string(&codex);
+
+        // The fake is `bash <script>`, so the echoed argv is the preview with
+        // the binary and the script path removed from the front.
+        let rendered: Vec<String> = spawned
+            .iter()
+            .map(|a| crate::exec::shell_quote(a))
+            .collect();
+        assert!(
+            preview.ends_with(&rendered.join(" ")),
+            "preview {preview:?} does not end with the spawned argv {rendered:?}"
+        );
+        // The global -c pair from the client is in there, ahead of the args.
+        assert_eq!(spawned[0], "-c");
+        assert_eq!(spawned[1], "model=\"gpt-5\"");
+        assert_eq!(spawned[2], "exec");
+    }
+
+    #[test]
+    fn preview_puts_global_args_before_the_subcommand() {
+        let codex = echoing_codex();
+        let preview = ExecCommand::new("hi").ephemeral().to_command_string(&codex);
+        assert!(
+            preview.contains(r#"-c 'model="gpt-5"' exec"#),
+            "globals must precede the subcommand: {preview}"
+        );
+        assert!(preview.ends_with("--ephemeral hi"), "{preview}");
+    }
+
+    #[test]
+    fn preview_is_available_on_every_builder() {
+        let codex = echoing_codex();
+        // Provided on the trait, so a resume builder gets it too.
+        let preview = ExecResumeCommand::new().last().to_command_string(&codex);
+        assert!(preview.contains("exec resume --last"), "{preview}");
+    }
 }

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -72,14 +72,47 @@ pub async fn run_codex_with_retry(
     }
 }
 
-async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutput> {
-    let mut command_args = Vec::new();
-
-    // Global args first (before subcommand)
-    command_args.extend(codex.global_args.clone());
-
-    // Then command-specific args
+/// Assemble the full argument list for an invocation: the client's global
+/// args first, since they precede the subcommand, then the command's own.
+///
+/// Both spawn paths and [`CodexCommand::to_command_string`] go through here,
+/// so a previewed command cannot drift from the one that actually runs.
+///
+/// [`CodexCommand::to_command_string`]: crate::command::CodexCommand::to_command_string
+pub(crate) fn assemble_args(codex: &Codex, args: Vec<String>) -> Vec<String> {
+    let mut command_args = Vec::with_capacity(codex.global_args.len() + args.len());
+    command_args.extend(codex.global_args.iter().cloned());
     command_args.extend(args);
+    command_args
+}
+
+/// Render an invocation as a copy-pasteable shell command.
+pub(crate) fn command_string(codex: &Codex, args: Vec<String>) -> String {
+    let mut out = shell_quote(&codex.binary.display().to_string());
+    for arg in assemble_args(codex, args) {
+        out.push(' ');
+        out.push_str(&shell_quote(&arg));
+    }
+    out
+}
+
+/// Quote a single argument for a POSIX shell, if it needs it.
+///
+/// The empty string is quoted: unquoted it would vanish from the rendered
+/// command, turning a preview into something that runs differently from what
+/// it describes.
+pub(crate) fn shell_quote(arg: &str) -> String {
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+    if arg.contains(|c: char| c.is_whitespace() || "\"'$\\`|;<>&()[]{}*?!~#".contains(c)) {
+        return format!("'{}'", arg.replace('\'', r"'\''"));
+    }
+    arg.to_string()
+}
+
+async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutput> {
+    let command_args = assemble_args(codex, args);
 
     debug!(binary = %codex.binary.display(), args = ?command_args, "executing codex command");
 
@@ -207,6 +240,29 @@ mod tests {
             exit_code: 0,
             success: true,
         }
+    }
+
+    #[test]
+    fn shell_quote_leaves_plain_words_alone() {
+        assert_eq!(shell_quote("exec"), "exec");
+        assert_eq!(shell_quote("--ephemeral"), "--ephemeral");
+        assert_eq!(shell_quote("model=gpt-5"), "model=gpt-5");
+    }
+
+    #[test]
+    fn shell_quote_wraps_anything_a_shell_would_read() {
+        assert_eq!(shell_quote("fix the tests"), "'fix the tests'");
+        assert_eq!(shell_quote("$HOME"), "'$HOME'");
+        assert_eq!(shell_quote("a;b"), "'a;b'");
+        assert_eq!(shell_quote("*.rs"), "'*.rs'");
+        assert_eq!(shell_quote("it's"), r"'it'\''s'");
+    }
+
+    /// An unquoted empty string would disappear from the rendered command,
+    /// making the preview describe a different invocation than it previews.
+    #[test]
+    fn shell_quote_keeps_the_empty_argument_visible() {
+        assert_eq!(shell_quote(""), "''");
     }
 
     #[test]

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -73,9 +73,7 @@ async fn run_streaming<F>(codex: &Codex, args: Vec<String>, mut handler: F) -> R
 where
     F: FnMut(JsonLineEvent),
 {
-    let mut command_args = Vec::new();
-    command_args.extend(codex.global_args.clone());
-    command_args.extend(args);
+    let command_args = crate::exec::assemble_args(codex, args);
 
     debug!(binary = %codex.binary.display(), args = ?command_args, "streaming codex command");
 

--- a/crates/codex-wrapper/tests/fake-codex-echo-args.sh
+++ b/crates/codex-wrapper/tests/fake-codex-echo-args.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Fake codex that prints the arguments it was given, one per line.
+#
+# Used to check that the argv preview matches what a spawn actually receives.
+# Comparing against this rather than against the assembly function is the
+# point: a test that calls the same function the preview calls would pass even
+# if the spawn path stopped using it.
+for arg in "$@"; do
+  echo "$arg"
+done


### PR DESCRIPTION
Closes #90.

```rust
let codex = Codex::builder().config("model=\"gpt-5\"").build()?;
let cmd = ExecCommand::new("fix the failing tests").ephemeral();
cmd.to_command_string(&codex);
// codex -c 'model="gpt-5"' exec --ephemeral 'fix the failing tests'
```

## Shared assembly

Per the issue's design note, the concatenation that `run_codex_once` and `run_streaming` each carried is now `exec::assemble_args`, and all three callers go through it. That sharing is the whole point: a preview built on its own copy of the logic would drift.

## Beyond the issue's minimum

The issue asks for the method on `ExecCommand` and `ExecResumeCommand` "at minimum". It is a provided method on the `CodexCommand` trait instead, so all 30-odd builders get it with no per-builder code.

## One deliberate difference from claude-wrapper

`claude-wrapper`'s `shell_quote` returns the empty string unquoted, so an empty argument disappears from the rendered command and the preview describes an invocation one argument shorter than the real one. This quotes it as `''`. Worth a matching issue on that side; not filed here.

The metacharacter set is also slightly wider, adding `*?!~#`, so a glob or a comment character renders as something that pastes back correctly.

## Test approach

`preview_matches_the_argv_a_spawn_receives` runs a fake codex that echoes its argv and compares the preview against what the process actually received. Asserting against `assemble_args` instead would be circular: it would keep passing if the spawn path stopped calling it, which is the exact regression worth catching. Quoting is covered separately in `exec::tests`, including the empty-string case.

## Local checks

Actions is healthy again, so CI will run this. Locally: fmt, clippy `-D warnings`, 149 lib tests all-features, 110 no-default-features, 18 doc tests, rustdoc `-D warnings`, and both test binaries compile.