### PR TITLE
docs: add an examples/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,26 @@ To disable default features:
 codex-wrapper = { version = "0.2", default-features = false }
 ```
 
+## Examples
+
+Runnable programs live in
+[`crates/codex-wrapper/examples`](https://github.com/joshrotenberg/codex-wrapper/tree/main/crates/codex-wrapper/examples).
+Each needs a working `codex` on `PATH`:
+
+```bash
+cargo run --example oneshot        # one prompt, raw output
+cargo run --example json_output    # JSONL events and the typed QueryResult
+cargo run --example stream_exec    # events delivered as they arrive
+cargo run --example session        # multi-turn via exec resume
+cargo run --example review         # code review, text and typed
+cargo run --example mcp_servers    # add / list / inspect / remove MCP servers
+cargo run --example health_check   # installed CLI vs the tested version range
+```
+
+All but `oneshot` and `health_check` need the `json` feature, which is on by default. Each is
+declared with its `required-features` in the manifest, so a reduced-feature build skips it
+rather than failing.
+
 ## Testing
 
 ```bash

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -31,3 +31,31 @@ which = "8"
 [dev-dependencies]
 serde_json = "1"
 tokio = { workspace = true }
+
+# Each example declares the features it needs, so a reduced-feature build
+# skips it rather than failing to compile it.
+[[example]]
+name = "oneshot"
+
+[[example]]
+name = "health_check"
+
+[[example]]
+name = "json_output"
+required-features = ["json"]
+
+[[example]]
+name = "stream_exec"
+required-features = ["json"]
+
+[[example]]
+name = "session"
+required-features = ["json"]
+
+[[example]]
+name = "mcp_servers"
+required-features = ["json"]
+
+[[example]]
+name = "review"
+required-features = ["json"]

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -576,6 +576,26 @@ To disable default features:
 codex-wrapper = { version = "0.2", default-features = false }
 ```
 
+## Examples
+
+Runnable programs live in
+[`crates/codex-wrapper/examples`](https://github.com/joshrotenberg/codex-wrapper/tree/main/crates/codex-wrapper/examples).
+Each needs a working `codex` on `PATH`:
+
+```bash
+cargo run --example oneshot        # one prompt, raw output
+cargo run --example json_output    # JSONL events and the typed QueryResult
+cargo run --example stream_exec    # events delivered as they arrive
+cargo run --example session        # multi-turn via exec resume
+cargo run --example review         # code review, text and typed
+cargo run --example mcp_servers    # add / list / inspect / remove MCP servers
+cargo run --example health_check   # installed CLI vs the tested version range
+```
+
+All but `oneshot` and `health_check` need the `json` feature, which is on by default. Each is
+declared with its `required-features` in the manifest, so a reduced-feature build skips it
+rather than failing.
+
 ## Testing
 
 ```bash

--- a/crates/codex-wrapper/examples/health_check.rs
+++ b/crates/codex-wrapper/examples/health_check.rs
@@ -1,0 +1,40 @@
+//! Check the installed CLI against the version range this wrapper is tested
+//! against, before doing any real work.
+//!
+//! ```sh
+//! cargo run --example health_check
+//! ```
+
+use codex_wrapper::{CliVersionStatus, Codex};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+
+    let (min, max) = codex.tested_cli_version_range();
+    println!("tested against: {min} ..= {max}");
+    println!("installed:      {}", codex.cli_version().await?);
+
+    // The soft check: report drift and decide for yourself.
+    match codex.cli_version_status().await? {
+        CliVersionStatus::Tested => println!("status:         tested"),
+        CliVersionStatus::NewerUntested { found, tested_max } => {
+            println!("status:         {found} is newer than the tested {tested_max}");
+            println!("                should still work, semantics may have drifted");
+        }
+        CliVersionStatus::OlderThanMinimum { found, minimum } => {
+            println!("status:         {found} is older than the tested {minimum}");
+            println!("                some emitted flags are likely rejected");
+        }
+    }
+
+    // The hard check: refuse to proceed outside the range. Use this at startup
+    // in anything long-running, so drift surfaces once rather than as a
+    // confusing failure later.
+    match codex.ensure_tested_cli_version().await {
+        Ok(version) => println!("\nok to proceed on {version}"),
+        Err(e) => println!("\nrefusing to proceed: {e}"),
+    }
+
+    Ok(())
+}

--- a/crates/codex-wrapper/examples/json_output.rs
+++ b/crates/codex-wrapper/examples/json_output.rs
@@ -1,0 +1,40 @@
+//! Structured JSONL output: the raw event stream, and the typed result
+//! assembled from it.
+//!
+//! ```sh
+//! cargo run --example json_output
+//! ```
+
+use codex_wrapper::{Codex, ExecCommand, SandboxMode};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+
+    let cmd = ExecCommand::new("Reply with exactly: ok")
+        .sandbox(SandboxMode::ReadOnly)
+        .skip_git_repo_check()
+        .ephemeral();
+
+    // The raw stream, one parsed event per JSONL line.
+    let events = cmd.execute_json_lines(&codex).await?;
+    println!("{} events", events.len());
+    for event in &events {
+        println!("  {}", event.event_type);
+    }
+
+    // The same run, assembled into a typed result.
+    let result = cmd.execute_json(&codex).await?;
+    println!("\nresult: {}", result.result);
+    println!("thread: {:?}", result.thread_id);
+
+    // The CLI reports token counts and no monetary cost. `total()` falls back
+    // to input plus output, because a real turn.completed carries no
+    // total_tokens field.
+    match result.usage.and_then(|usage| usage.total()) {
+        Some(tokens) => println!("tokens: {tokens}"),
+        None => println!("tokens: not reported"),
+    }
+
+    Ok(())
+}

--- a/crates/codex-wrapper/examples/mcp_servers.rs
+++ b/crates/codex-wrapper/examples/mcp_servers.rs
@@ -1,0 +1,39 @@
+//! Manage MCP servers through the CLI: add, list, inspect, remove.
+//!
+//! ```sh
+//! cargo run --example mcp_servers
+//! ```
+//!
+//! This registers a server named `example-echo` and removes it again, so it
+//! leaves your codex config as it found it.
+
+use codex_wrapper::{
+    Codex, CodexCommand, McpAddCommand, McpGetCommand, McpListCommand, McpRemoveCommand,
+};
+
+const NAME: &str = "example-echo";
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+
+    // Typed listing, rather than parsing the human-readable table.
+    let servers = McpListCommand::new().execute_json(&codex).await?;
+    println!("before: {servers}");
+
+    McpAddCommand::stdio(NAME, "bash")
+        .arg("-c")
+        .arg("cat")
+        .env("EXAMPLE", "1")
+        .execute(&codex)
+        .await?;
+    println!("\nadded {NAME}");
+
+    let detail = McpGetCommand::new(NAME).execute(&codex).await?;
+    println!("\n{}", detail.stdout);
+
+    McpRemoveCommand::new(NAME).execute(&codex).await?;
+    println!("removed {NAME}");
+
+    Ok(())
+}

--- a/crates/codex-wrapper/examples/oneshot.rs
+++ b/crates/codex-wrapper/examples/oneshot.rs
@@ -1,0 +1,22 @@
+//! One prompt, one answer, raw output.
+//!
+//! ```sh
+//! cargo run --example oneshot
+//! ```
+
+use codex_wrapper::{Codex, CodexCommand, ExecCommand, SandboxMode};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+
+    let output = ExecCommand::new("Name the three primary colors. One sentence.")
+        .sandbox(SandboxMode::ReadOnly)
+        .skip_git_repo_check()
+        .ephemeral()
+        .execute(&codex)
+        .await?;
+
+    println!("{}", output.stdout);
+    Ok(())
+}

--- a/crates/codex-wrapper/examples/review.rs
+++ b/crates/codex-wrapper/examples/review.rs
@@ -1,0 +1,41 @@
+//! Review the uncommitted changes in the current repo, as text and as a
+//! typed result.
+//!
+//! ```sh
+//! cargo run --example review
+//! ```
+//!
+//! Needs a git repo with uncommitted changes. With a clean tree the CLI has
+//! nothing to review and exits non-zero.
+
+use codex_wrapper::{Codex, CodexCommand, ReviewCommand};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+
+    let output = ReviewCommand::new()
+        .uncommitted()
+        .ephemeral()
+        .execute(&codex)
+        .await?;
+    println!("{}", output.stdout);
+
+    // The same review as a typed result. Review emits the same event
+    // vocabulary as exec, so the comments land in `result`.
+    let result = ReviewCommand::new()
+        .uncommitted()
+        .ephemeral()
+        .execute_json(&codex)
+        .await?;
+
+    println!("--- typed ---");
+    println!("thread:   {:?}", result.thread_id);
+    println!("comments: {}", result.result);
+
+    // Usage is reported for a review, but as zeros: unlike an exec turn, a
+    // review's turn.completed carries no real counts.
+    println!("tokens:   {:?}", result.usage.and_then(|u| u.total()));
+
+    Ok(())
+}

--- a/crates/codex-wrapper/examples/session.rs
+++ b/crates/codex-wrapper/examples/session.rs
@@ -1,0 +1,48 @@
+//! Multi-turn conversation. The first turn runs `codex exec`, later turns
+//! route through `codex exec resume` with the captured thread id.
+//!
+//! ```sh
+//! cargo run --example session
+//! ```
+
+use std::sync::Arc;
+
+use codex_wrapper::{Codex, ExecCommand, SandboxMode, Session};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Arc::new(Codex::builder().build()?);
+    let mut session = Session::new(Arc::clone(&codex));
+
+    // First turn configured explicitly, so it runs outside a git repo.
+    // `send` is the shorthand when the defaults are fine.
+    session
+        .execute(
+            ExecCommand::new("Remember the number 41. Reply with just: stored")
+                .sandbox(SandboxMode::ReadOnly)
+                .skip_git_repo_check(),
+        )
+        .await?;
+
+    // Second turn resumes automatically: the session captured the thread id.
+    session
+        .send("Add one to the number you stored. Reply with digits only.")
+        .await?;
+
+    println!("thread:      {:?}", session.id());
+    println!("turns:       {}", session.total_turns());
+    println!(
+        "last answer: {:?}",
+        session.last_result().map(|r| &r.result)
+    );
+
+    // Usage accumulates across turns. Any turn whose `turn.completed` carried
+    // no usage object is counted rather than silently treated as zero.
+    println!("tokens:      {}", session.total_tokens());
+    let missing = session.turns_missing_usage();
+    if missing > 0 {
+        println!("             ({missing} turn(s) reported no usage)");
+    }
+
+    Ok(())
+}

--- a/crates/codex-wrapper/examples/stream_exec.rs
+++ b/crates/codex-wrapper/examples/stream_exec.rs
@@ -1,0 +1,31 @@
+//! Stream events as they arrive instead of buffering the whole run.
+//!
+//! ```sh
+//! cargo run --example stream_exec
+//! ```
+
+use codex_wrapper::{Codex, ExecCommand, JsonLineEvent, SandboxMode};
+
+#[tokio::main]
+async fn main() -> codex_wrapper::Result<()> {
+    let codex = Codex::builder().build()?;
+
+    let cmd = ExecCommand::new("Count from one to five, one number per line.")
+        .sandbox(SandboxMode::ReadOnly)
+        .skip_git_repo_check()
+        .ephemeral();
+
+    let mut turns = 0;
+    cmd.stream(&codex, |event: JsonLineEvent| {
+        if let Some(text) = event.agent_message_text() {
+            println!("{text}");
+        }
+        if event.is_turn_completed() {
+            turns += 1;
+        }
+    })
+    .await?;
+
+    println!("\n{turns} turn(s) completed");
+    Ok(())
+}


### PR DESCRIPTION
Closes #83.

Seven examples, each declared with `required-features` in the manifest:

| Example | Covers | Needs `json` |
|---|---|---|
| `oneshot` | `ExecCommand` returning `CommandOutput` | no |
| `health_check` | `cli_version_status` and `ensure_tested_cli_version` | no |
| `json_output` | `execute_json_lines` and `execute_json` | yes |
| `stream_exec` | `stream` with a callback | yes |
| `session` | multi-turn via `Session` and `exec resume` | yes |
| `mcp_servers` | `mcp add` / `list` / `get` / `remove` | yes |
| `review` | `ReviewCommand` text and typed output | yes |

Verified the gating does what it is for:

```
$ cargo build --examples --all-features     # all seven
$ cargo build --examples --no-default-features
$ ls target/debug/examples                  # health_check, oneshot
```

## Two deviations from the issue

**`mcp_servers`, not `mcp_config`.** The issue's name suggests config-file generation, which is #87's `McpConfigBuilder` and does not exist yet. This example manages servers through the CLI, so it is named for what it does and leaves the better name free for #87.

**The README link is an absolute URL.** `README.md` and `crates/codex-wrapper/README.md` are byte-identical copies at different depths, so no single relative path resolves from both. An absolute URL does.

## Notes

`mcp_servers` adds a server and removes it again, so it leaves the config as it found it. `review` needs uncommitted changes to review, and `session` configures its first turn explicitly so it runs outside a git repo. Each says so in its doc comment.

CI compiles these: `cargo clippy --all-targets` covers examples.