### PR TITLE
fix: deliver the prompt for ExecCommand::from_stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,26 @@ let output = ExecCommand::new("fix the failing tests")
 | `enable()` / `disable()` | `--enable` / `--disable` | Feature flags |
 | `oss()` | `--oss` | Use local OSS provider |
 | `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
+| `prompt_via_stdin()` | *(prompt becomes `-`)* | Send the prompt on stdin |
 | `retry()` | *(client-side)* | Per-command retry policy |
+
+### Prompts on stdin
+
+For prompts too large or awkward for argv, `ExecCommand::from_stdin` sends the prompt on the
+child's stdin and emits `codex exec -`:
+
+```rust
+use codex_wrapper::{CodexCommand, ExecCommand};
+
+let patch = std::fs::read_to_string("huge.patch")?;
+let output = ExecCommand::from_stdin(format!("Review this patch:\n{patch}"))
+    .execute(&codex)
+    .await?;
+```
+
+Retry does not apply to a stdin prompt. Any policy set on the command or the client is ignored
+for it: a second attempt would need to write the prompt into a pipe the first has already
+consumed, and retrying with an empty stdin would be worse than not retrying.
 
 ## Typed Result
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -157,7 +157,26 @@ let output = ExecCommand::new("fix the failing tests")
 | `enable()` / `disable()` | `--enable` / `--disable` | Feature flags |
 | `oss()` | `--oss` | Use local OSS provider |
 | `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
+| `prompt_via_stdin()` | *(prompt becomes `-`)* | Send the prompt on stdin |
 | `retry()` | *(client-side)* | Per-command retry policy |
+
+### Prompts on stdin
+
+For prompts too large or awkward for argv, `ExecCommand::from_stdin` sends the prompt on the
+child's stdin and emits `codex exec -`:
+
+```rust
+use codex_wrapper::{CodexCommand, ExecCommand};
+
+let patch = std::fs::read_to_string("huge.patch")?;
+let output = ExecCommand::from_stdin(format!("Review this patch:\n{patch}"))
+    .execute(&codex)
+    .await?;
+```
+
+Retry does not apply to a stdin prompt. Any policy set on the command or the client is ignored
+for it: a second attempt would need to write the prompt into a pipe the first has already
+consumed, and retrying with an empty stdin would be worse than not retrying.
 
 ## Typed Result
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -67,6 +67,7 @@ pub(crate) fn effective_sandbox(
 #[derive(Debug, Clone)]
 pub struct ExecCommand {
     prompt: Option<String>,
+    prompt_via_stdin: bool,
     approval_policy: Option<ApprovalPolicyConfig>,
     web_search: Option<WebSearchMode>,
     config_overrides: Vec<String>,
@@ -101,6 +102,7 @@ impl ExecCommand {
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
             prompt: Some(prompt.into()),
+            prompt_via_stdin: false,
             approval_policy: None,
             web_search: None,
             config_overrides: Vec::new(),
@@ -130,10 +132,55 @@ impl ExecCommand {
         }
     }
 
-    /// Read the prompt from stdin (`-`).
+    /// Send the prompt on stdin instead of as an argument (`codex exec -`).
+    ///
+    /// Shorthand for [`new`](Self::new) followed by
+    /// [`prompt_via_stdin`](Self::prompt_via_stdin). Use it for prompts that
+    /// are large or awkward to pass through argv.
+    ///
+    /// ```no_run
+    /// use codex_wrapper::{Codex, CodexCommand, ExecCommand};
+    ///
+    /// # async fn example() -> codex_wrapper::Result<()> {
+    /// let codex = Codex::builder().build()?;
+    /// let diff = std::fs::read_to_string("huge.patch")?;
+    /// let output = ExecCommand::from_stdin(format!("Review this patch:\n{diff}"))
+    ///     .execute(&codex)
+    ///     .await?;
+    /// # let _ = output;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Before 0.3 this took no argument and set the prompt to the literal
+    /// `-`, which could not work: nothing wrote to the child's stdin, so the
+    /// CLI saw an immediate EOF and an empty prompt (#81).
     #[must_use]
-    pub fn from_stdin() -> Self {
-        Self::new("-")
+    pub fn from_stdin(prompt: impl Into<String>) -> Self {
+        Self::new(prompt).prompt_via_stdin()
+    }
+
+    /// Deliver this command's prompt on stdin rather than in argv.
+    ///
+    /// The prompt is replaced by `-` in the argument list and written to the
+    /// child's stdin instead.
+    ///
+    /// Retry does not apply to a stdin prompt, and any policy set on the
+    /// command or the client is ignored for it. A second attempt would need to
+    /// write the prompt again, into a pipe the first attempt has already
+    /// consumed, and retrying with an empty stdin would be worse than not
+    /// retrying.
+    #[must_use]
+    pub fn prompt_via_stdin(mut self) -> Self {
+        self.prompt_via_stdin = true;
+        self
+    }
+
+    /// The prompt to write to the child's stdin, if this command sends it
+    /// there. `None` when the prompt travels in argv.
+    pub(crate) fn stdin_prompt(&self) -> Option<&str> {
+        self.prompt_via_stdin
+            .then(|| self.prompt.as_deref().unwrap_or_default())
     }
 
     /// Override a config key (`-c key=value`).
@@ -423,7 +470,12 @@ impl ExecCommand {
             args.push("--json".into());
         }
 
-        let output = exec::run_codex_with_retry(codex, args, self.retry_policy.as_ref()).await?;
+        let output = if self.prompt_via_stdin {
+            let prompt = self.prompt.as_deref().unwrap_or_default();
+            exec::run_codex_with_stdin_prompt(codex, args, prompt).await?
+        } else {
+            exec::run_codex_with_retry(codex, args, self.retry_policy.as_ref()).await?
+        };
         parse_json_lines(&output.stdout)
     }
 
@@ -511,7 +563,11 @@ impl CodexCommand for ExecCommand {
             args.push("--output-last-message".into());
             args.push(path.clone());
         }
-        if let Some(prompt) = &self.prompt {
+        if self.prompt_via_stdin {
+            // The prompt travels on stdin; `-` is how the CLI is told to read
+            // it from there.
+            args.push("-".into());
+        } else if let Some(prompt) = &self.prompt {
             args.push(prompt.clone());
         }
 
@@ -519,6 +575,10 @@ impl CodexCommand for ExecCommand {
     }
 
     async fn execute(&self, codex: &Codex) -> Result<CommandOutput> {
+        if self.prompt_via_stdin {
+            let prompt = self.prompt.as_deref().unwrap_or_default();
+            return exec::run_codex_with_stdin_prompt(codex, self.args(), prompt).await;
+        }
         exec::run_codex_with_retry(codex, self.args(), self.retry_policy.as_ref()).await
     }
 }
@@ -1183,5 +1243,88 @@ mod tests {
                 "/tmp/schema.json"
             ]
         );
+    }
+
+    /// #81: the builder emitted `codex exec -` while every spawn path closed
+    /// the child's stdin, so the prompt was never delivered. This drives a
+    /// fake codex that echoes back what it read, which is the only way to see
+    /// the difference: the argv is identical either way.
+    #[cfg(all(unix, feature = "json"))]
+    #[tokio::test]
+    async fn stdin_prompt_reaches_the_child() {
+        let codex = echoing_stdin_codex();
+        let prompt = "a prompt too awkward for argv\nwith a second line";
+
+        let result = ExecCommand::from_stdin(prompt)
+            .execute_json(&codex)
+            .await
+            .unwrap();
+
+        assert_eq!(result.result, prompt);
+    }
+
+    /// The same delivery, on the streaming path, which pipes stdin separately.
+    #[cfg(all(unix, feature = "json"))]
+    #[tokio::test]
+    async fn stdin_prompt_reaches_the_child_when_streaming() {
+        let codex = echoing_stdin_codex();
+        let prompt = "streamed stdin prompt";
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = std::sync::Arc::clone(&seen);
+
+        ExecCommand::from_stdin(prompt)
+            .stream(&codex, move |event| {
+                if let Some(text) = event.agent_message_text() {
+                    sink.lock().unwrap().push(text);
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(seen.lock().unwrap().as_slice(), &[prompt.to_string()]);
+    }
+
+    /// A prompt larger than a pipe buffer must not deadlock: the write and the
+    /// output drain have to run concurrently.
+    #[cfg(all(unix, feature = "json"))]
+    #[tokio::test]
+    async fn a_prompt_larger_than_the_pipe_buffer_still_completes() {
+        let codex = echoing_stdin_codex();
+        // Well past the usual 64 KiB pipe capacity.
+        let prompt = "x".repeat(512 * 1024);
+
+        let result = ExecCommand::from_stdin(&prompt)
+            .execute_json(&codex)
+            .await
+            .unwrap();
+
+        assert_eq!(result.result.len(), prompt.len());
+    }
+
+    #[cfg(all(unix, feature = "json"))]
+    fn echoing_stdin_codex() -> Codex {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-echo-stdin.sh");
+        Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .build()
+            .expect("bash must exist")
+    }
+
+    #[test]
+    fn from_stdin_emits_the_dash_positional_not_the_prompt() {
+        let args = ExecCommand::from_stdin("secret prompt").ephemeral().args();
+        assert_eq!(args, vec!["exec", "--ephemeral", "-"]);
+        // The prompt must not leak into argv, which is the whole point of
+        // sending it on stdin.
+        assert!(!args.iter().any(|a| a.contains("secret")));
+    }
+
+    #[test]
+    fn prompt_via_stdin_converts_an_existing_prompt() {
+        let args = ExecCommand::new("hello").prompt_via_stdin().args();
+        assert_eq!(args, vec!["exec", "-"]);
     }
 }

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -162,17 +162,75 @@ pub async fn run_codex_allow_exit_codes(
     }
 }
 
+/// Run a codex command, writing `prompt` to the child's stdin.
+///
+/// For `codex exec -`, where the prompt is delivered on stdin rather than as
+/// an argument. The prompt is written and the handle dropped, so the CLI sees
+/// EOF and stops waiting for more.
+///
+/// Retry does not apply. The policy is deliberately ignored rather than
+/// honored: a retry would have to write the prompt again, and the first
+/// attempt has already moved the caller's data into a pipe that cannot be
+/// rewound. Silently retrying with an empty stdin would be worse than not
+/// retrying at all.
+pub async fn run_codex_with_stdin_prompt(
+    codex: &Codex,
+    args: Vec<String>,
+    prompt: &str,
+) -> Result<CommandOutput> {
+    let command_args = assemble_args(codex, args);
+
+    debug!(
+        binary = %codex.binary.display(),
+        args = ?command_args,
+        prompt_bytes = prompt.len(),
+        "executing codex command with a stdin prompt"
+    );
+
+    let run = run_internal_inner(
+        &codex.binary,
+        &command_args,
+        &codex.env,
+        codex.working_dir.as_deref(),
+        Some(prompt),
+    );
+
+    match codex.timeout {
+        Some(timeout) => tokio::time::timeout(timeout, run)
+            .await
+            .map_err(|_| Error::Timeout {
+                timeout_seconds: timeout.as_secs(),
+            })?,
+        None => run.await,
+    }
+}
+
 async fn run_internal(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
 ) -> Result<CommandOutput> {
+    run_internal_inner(binary, args, env, working_dir, None).await
+}
+
+async fn run_internal_inner(
+    binary: &std::path::Path,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+    working_dir: Option<&std::path::Path>,
+    stdin_prompt: Option<&str>,
+) -> Result<CommandOutput> {
     let mut cmd = Command::new(binary);
     cmd.args(args);
 
-    // Prevent child from inheriting/blocking on parent's stdin.
-    cmd.stdin(std::process::Stdio::null());
+    // Pipe stdin only when there is a prompt to write. Otherwise close it, so
+    // the child neither inherits nor blocks on the parent's.
+    if stdin_prompt.is_some() {
+        cmd.stdin(std::process::Stdio::piped());
+    } else {
+        cmd.stdin(std::process::Stdio::null());
+    }
 
     // Kill the child if this future is dropped: on timeout, on caller
     // cancellation, or on task abort. Without this, tokio detaches the child
@@ -187,11 +245,51 @@ async fn run_internal(
         cmd.env(key, value);
     }
 
-    let output = cmd.output().await.map_err(|e| Error::Io {
-        message: format!("failed to spawn codex: {e}"),
-        source: e,
-        working_dir: working_dir.map(|p| p.to_path_buf()),
-    })?;
+    let output = match stdin_prompt {
+        // `Command::output` forces stdin to null, so the piped case cannot use
+        // it and spawns directly.
+        None => cmd.output().await.map_err(|e| Error::Io {
+            message: format!("failed to spawn codex: {e}"),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        })?,
+        Some(prompt) => {
+            cmd.stdout(std::process::Stdio::piped());
+            cmd.stderr(std::process::Stdio::piped());
+
+            let mut child = cmd.spawn().map_err(|e| Error::Io {
+                message: format!("failed to spawn codex: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
+
+            let mut stdin = child.stdin.take().expect("stdin was configured as piped");
+            let write = async move {
+                use tokio::io::AsyncWriteExt;
+                stdin.write_all(prompt.as_bytes()).await?;
+                // Closing the write half is what tells the CLI the prompt is
+                // complete. Without it the child waits for more input.
+                stdin.shutdown().await
+            };
+
+            // Concurrently, not sequentially: a prompt larger than the pipe
+            // buffer blocks until the child reads it, and a child that writes
+            // to stdout meanwhile blocks until we read that. Waiting for the
+            // write to finish before draining stdout would deadlock both.
+            let (write_result, output_result) = tokio::join!(write, child.wait_with_output());
+
+            write_result.map_err(|e| Error::Io {
+                message: format!("failed to write the prompt to codex stdin: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
+            output_result.map_err(|e| Error::Io {
+                message: format!("failed to wait on codex: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?
+        }
+    };
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -48,7 +48,7 @@ where
     if !args.contains(&"--json".to_string()) {
         args.push("--json".into());
     }
-    run_streaming(codex, args, handler).await
+    run_streaming(codex, args, cmd.stdin_prompt(), handler).await
 }
 
 /// Stream JSONL events from `codex exec resume`, invoking `handler` for each
@@ -65,11 +65,19 @@ where
     if !args.contains(&"--json".to_string()) {
         args.push("--json".into());
     }
-    run_streaming(codex, args, handler).await
+    run_streaming(codex, args, None, handler).await
 }
 
 /// Core streaming implementation shared by both exec variants.
-async fn run_streaming<F>(codex: &Codex, args: Vec<String>, mut handler: F) -> Result<()>
+///
+/// `stdin_prompt` carries the prompt for a `codex exec -` run, where it is
+/// delivered on stdin rather than in argv.
+async fn run_streaming<F>(
+    codex: &Codex,
+    args: Vec<String>,
+    stdin_prompt: Option<&str>,
+    mut handler: F,
+) -> Result<()>
 where
     F: FnMut(JsonLineEvent),
 {
@@ -79,7 +87,11 @@ where
 
     let mut child_cmd = Command::new(&codex.binary);
     child_cmd.args(&command_args);
-    child_cmd.stdin(std::process::Stdio::null());
+    if stdin_prompt.is_some() {
+        child_cmd.stdin(std::process::Stdio::piped());
+    } else {
+        child_cmd.stdin(std::process::Stdio::null());
+    }
     child_cmd.stdout(std::process::Stdio::piped());
     child_cmd.stderr(std::process::Stdio::piped());
 
@@ -103,6 +115,32 @@ where
 
     let stdout = child.stdout.take().expect("stdout was configured as piped");
     let stderr = child.stderr.take().expect("stderr was configured as piped");
+    // Taken up front so the write does not borrow `child`, which the wait
+    // below needs.
+    let child_stdin = child.stdin.take();
+
+    // Write the prompt and close the handle, so the CLI stops waiting for
+    // more. This runs as part of the streamed future rather than before it,
+    // so a prompt larger than the pipe buffer cannot block the readers.
+    let stdin_task = async {
+        let (Some(prompt), Some(mut stdin)) = (stdin_prompt, child_stdin) else {
+            return Ok(());
+        };
+        use tokio::io::AsyncWriteExt;
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| Error::Io {
+                message: format!("failed to write the prompt to codex stdin: {e}"),
+                source: e,
+                working_dir: codex.working_dir.clone(),
+            })?;
+        stdin.shutdown().await.map_err(|e| Error::Io {
+            message: format!("failed to close codex stdin: {e}"),
+            source: e,
+            working_dir: codex.working_dir.clone(),
+        })
+    };
 
     let stdout_task = async {
         let reader = BufReader::new(stdout);
@@ -146,7 +184,9 @@ where
     };
 
     let stream_future = async {
-        let (events_result, stderr_result) = tokio::join!(stdout_task, stderr_task);
+        let (stdin_result, events_result, stderr_result) =
+            tokio::join!(stdin_task, stdout_task, stderr_task);
+        stdin_result?;
         let events = events_result?;
         let stderr_output = stderr_result?;
 

--- a/crates/codex-wrapper/tests/fake-codex-echo-stdin.sh
+++ b/crates/codex-wrapper/tests/fake-codex-echo-stdin.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fake codex that reports what it received on stdin.
+#
+# Used to check that a `codex exec -` prompt is actually delivered. The
+# previous implementation spawned with stdin closed, so this script would have
+# read nothing and the bug was invisible from argv alone.
+#
+# Emits the real event vocabulary so the JSONL paths can consume it, with the
+# stdin content as the agent message.
+prompt=$(cat)
+escaped=${prompt//\\/\\\\}
+escaped=${escaped//\"/\\\"}
+escaped=${escaped//$'\n'/\\n}
+echo '{"type":"thread.started","thread_id":"thread_stdin"}'
+echo '{"type":"turn.started"}'
+echo "{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"$escaped\"}}"
+echo '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":1,"reasoning_output_tokens":0}}'


### PR DESCRIPTION
Closes #81.

## Verified the premise first

Before building the delivery path, checked that the CLI does what `from_stdin` assumes:

```
$ printf 'Reply with exactly: stdinworks' | codex exec - --json --ephemeral --skip-git-repo-check
...
{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"stdinworks"}}
```

So the argv was already right and only the delivery was missing.

## The fix

- `exec::run_codex_with_stdin_prompt` pipes stdin, writes the prompt, and closes the handle so the CLI stops waiting.
- The streaming path pipes stdin too, rather than erroring on the combination.
- A `prompt_via_stdin` flag on `ExecCommand` drives the dispatch from `execute`, `execute_json_lines`, and `stream`.

The write runs **concurrently** with draining stdout and stderr. Sequentially it deadlocks: a prompt larger than the pipe buffer blocks until the child reads it, and a child writing into a full stdout pipe blocks until we read that. There is a 512 KiB test for exactly this.

Retry is skipped for stdin runs, as the issue notes. The policy is ignored rather than honored because a second attempt cannot rewind the pipe the first consumed.

## API shape

Mirrors `claude-wrapper`'s `prompt_via_stdin: bool` rather than inventing a codex-only shape:

```rust
ExecCommand::from_stdin(prompt)           // shorthand
ExecCommand::new(prompt).prompt_via_stdin() // equivalent
```

**Breaking:** `from_stdin()` now takes the prompt. The old no-argument form set the prompt to the literal `-` and could not deliver anything, so no working caller can break. Flagged as `BREAKING CHANGE:` in the commit for release-plz.

## Tests

Five, driven by a fake codex that echoes back what it read on stdin. That indirection is necessary: the argv is byte-identical whether or not the prompt is delivered, so an args-only test cannot see this bug, which is how it survived.

Confirmed the main test fails without the dispatch, with the original symptom:

```
assertion `left == right` failed
  left: ""
 right: "a prompt too awkward for argv\nwith a second line"
```

## Local checks

fmt, clippy `-D warnings`, 154 lib tests all-features, 112 no-default-features, 19 doc tests, rustdoc `-D warnings`, examples build.