### PR TITLE
feat: tracing spans around command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,34 @@ Global args precede the subcommand, the same order the spawn uses, because the p
 spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
 pasted, but no shell is involved at spawn time: args go to the process directly.
 
+## Tracing
+
+Every invocation is wrapped in a `tracing` span. Nothing is emitted unless the host installs a
+subscriber, and there is no separate metrics abstraction: `tracing` is the seam, and hosts that
+want metrics bridge it themselves.
+
+| Span | Raised by |
+|---|---|
+| `codex.exec` | any buffered run, one per attempt |
+| `codex.stream` | a streaming run, closing when the stream ends |
+| `codex.retry` | a retried run, parent to each attempt's span |
+
+Fields on open: `subcommand`, `binary`, `working_dir`. On close: `outcome`, `duration_ms`, and
+`exit_code` where the process produced one.
+
+`outcome` distinguishes four endings, including the two that are easy to miss:
+
+| `outcome` | Meaning |
+|---|---|
+| `ok` | exited zero |
+| `failed` | exited non-zero |
+| `timeout` | hit the client's timeout |
+| `cancelled` | the future was dropped, so the run was abandoned and the process killed |
+
+**The prompt is never recorded.** It travels in argv, so recording the arguments would put it in
+the host's logs; the same goes for the environment. Note that the existing `debug!` line does log
+the full argv, prompt included, as a debugging aid at that level.
+
 ## Cancellation
 
 Dropping the future returned by a command kills the spawned `codex` process. That covers a

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -536,6 +536,34 @@ Global args precede the subcommand, the same order the spawn uses, because the p
 spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
 pasted, but no shell is involved at spawn time: args go to the process directly.
 
+## Tracing
+
+Every invocation is wrapped in a `tracing` span. Nothing is emitted unless the host installs a
+subscriber, and there is no separate metrics abstraction: `tracing` is the seam, and hosts that
+want metrics bridge it themselves.
+
+| Span | Raised by |
+|---|---|
+| `codex.exec` | any buffered run, one per attempt |
+| `codex.stream` | a streaming run, closing when the stream ends |
+| `codex.retry` | a retried run, parent to each attempt's span |
+
+Fields on open: `subcommand`, `binary`, `working_dir`. On close: `outcome`, `duration_ms`, and
+`exit_code` where the process produced one.
+
+`outcome` distinguishes four endings, including the two that are easy to miss:
+
+| `outcome` | Meaning |
+|---|---|
+| `ok` | exited zero |
+| `failed` | exited non-zero |
+| `timeout` | hit the client's timeout |
+| `cancelled` | the future was dropped, so the run was abandoned and the process killed |
+
+**The prompt is never recorded.** It travels in argv, so recording the arguments would put it in
+the host's logs; the same goes for the environment. Note that the existing `debug!` line does log
+the full argv, prompt included, as a debugging aid at that level.
+
 ## Cancellation
 
 Dropping the future returned by a command kills the spawned `codex` process. That covers a

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -2,13 +2,89 @@
 //! binary, including timeout and retry support.
 
 use std::fmt;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::process::Command;
-use tracing::debug;
+use tracing::{Instrument, Span, debug, field, info_span};
 
 use crate::Codex;
 use crate::error::{Error, Result};
+
+/// Build the span covering one invocation.
+///
+/// The fields carry what identifies a run, never what it contains: no prompt
+/// and no environment. Both routinely hold content a host would not want in
+/// its logs, and a span is recorded whenever any subscriber is installed.
+pub(crate) fn command_span(name: &'static str, codex: &Codex, args: &[String]) -> Span {
+    let working_dir = codex
+        .working_dir
+        .as_ref()
+        .map_or_else(|| "(inherited)".to_string(), |p| p.display().to_string());
+
+    info_span!(
+        parent: Span::current(),
+        "codex",
+        otel.name = name,
+        subcommand = args.first().map_or("(none)", String::as_str),
+        binary = %codex.binary.display(),
+        working_dir = %working_dir,
+        outcome = field::Empty,
+        exit_code = field::Empty,
+        duration_ms = field::Empty,
+    )
+}
+
+/// Records how a run ended on its span, including when it does not end at all.
+///
+/// The dropped-future case is the one worth the machinery. Cancellation kills
+/// the process and runs nothing else, so without this the span would close
+/// with no outcome and an abandoned run would be indistinguishable from one
+/// still in progress. The span is passed in and held rather than read from
+/// [`Span::current`]: current-span tracking is the subscriber's job, and a
+/// subscriber that does not implement it would silently drop every record,
+/// including the drop-time one this exists for.
+pub(crate) struct SpanOutcome {
+    span: Span,
+    started: Instant,
+    settled: bool,
+}
+
+impl SpanOutcome {
+    pub(crate) fn start(span: Span) -> Self {
+        Self {
+            span,
+            started: Instant::now(),
+            settled: false,
+        }
+    }
+
+    pub(crate) fn settle(&mut self, outcome: &'static str, exit_code: Option<i32>) {
+        self.settled = true;
+        self.span.record("outcome", outcome);
+        self.span
+            .record("duration_ms", self.started.elapsed().as_millis() as u64);
+        if let Some(code) = exit_code {
+            self.span.record("exit_code", code);
+        }
+    }
+
+    fn settle_from(&mut self, result: &Result<CommandOutput>) {
+        match result {
+            Ok(output) => self.settle("ok", Some(output.exit_code)),
+            Err(Error::CommandFailed { exit_code, .. }) => self.settle("failed", Some(*exit_code)),
+            Err(Error::Timeout { .. }) => self.settle("timeout", None),
+            Err(_) => self.settle("error", None),
+        }
+    }
+}
+
+impl Drop for SpanOutcome {
+    fn drop(&mut self) {
+        if !self.settled {
+            self.settle("cancelled", None);
+        }
+    }
+}
 
 /// Raw output from a Codex CLI invocation.
 ///
@@ -66,7 +142,16 @@ pub async fn run_codex_with_retry(
 
     match policy {
         Some(policy) => {
-            crate::retry::with_retry(policy, || run_codex_once(codex, args.clone())).await
+            // A parent span so the retry events and each attempt's own span
+            // nest under one run rather than arriving as unrelated lines.
+            let span = info_span!(
+                "codex.retry",
+                subcommand = args.first().map_or("(none)", String::as_str),
+                max_attempts = policy.max_attempts,
+            );
+            crate::retry::with_retry(policy, || run_codex_once(codex, args.clone()))
+                .instrument(span)
+                .await
         }
         None => run_codex_once(codex, args).await,
     }
@@ -112,30 +197,40 @@ pub(crate) fn shell_quote(arg: &str) -> String {
 }
 
 async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutput> {
+    let span = command_span("codex.exec", codex, &args);
+    let outcome_span = span.clone();
     let command_args = assemble_args(codex, args);
 
-    debug!(binary = %codex.binary.display(), args = ?command_args, "executing codex command");
+    async move {
+        debug!(binary = %codex.binary.display(), args = ?command_args, "executing codex command");
 
-    let output = if let Some(timeout) = codex.timeout {
-        run_with_timeout(
-            &codex.binary,
-            &command_args,
-            &codex.env,
-            codex.working_dir.as_deref(),
-            timeout,
-        )
-        .await?
-    } else {
-        run_internal(
-            &codex.binary,
-            &command_args,
-            &codex.env,
-            codex.working_dir.as_deref(),
-        )
-        .await?
-    };
-
-    Ok(output)
+        let mut outcome = SpanOutcome::start(outcome_span);
+        let result = match codex.timeout {
+            Some(timeout) => {
+                run_with_timeout(
+                    &codex.binary,
+                    &command_args,
+                    &codex.env,
+                    codex.working_dir.as_deref(),
+                    timeout,
+                )
+                .await
+            }
+            None => {
+                run_internal(
+                    &codex.binary,
+                    &command_args,
+                    &codex.env,
+                    codex.working_dir.as_deref(),
+                )
+                .await
+            }
+        };
+        outcome.settle_from(&result);
+        result
+    }
+    .instrument(span)
+    .await
 }
 
 /// Run a codex command and allow specific non-zero exit codes.
@@ -178,31 +273,41 @@ pub async fn run_codex_with_stdin_prompt(
     args: Vec<String>,
     prompt: &str,
 ) -> Result<CommandOutput> {
+    let span = command_span("codex.exec", codex, &args);
+    let outcome_span = span.clone();
     let command_args = assemble_args(codex, args);
 
-    debug!(
-        binary = %codex.binary.display(),
-        args = ?command_args,
-        prompt_bytes = prompt.len(),
-        "executing codex command with a stdin prompt"
-    );
+    async move {
+        debug!(
+            binary = %codex.binary.display(),
+            args = ?command_args,
+            prompt_bytes = prompt.len(),
+            "executing codex command with a stdin prompt"
+        );
 
-    let run = run_internal_inner(
-        &codex.binary,
-        &command_args,
-        &codex.env,
-        codex.working_dir.as_deref(),
-        Some(prompt),
-    );
+        let mut outcome = SpanOutcome::start(outcome_span);
+        let run = run_internal_inner(
+            &codex.binary,
+            &command_args,
+            &codex.env,
+            codex.working_dir.as_deref(),
+            Some(prompt),
+        );
 
-    match codex.timeout {
-        Some(timeout) => tokio::time::timeout(timeout, run)
-            .await
-            .map_err(|_| Error::Timeout {
-                timeout_seconds: timeout.as_secs(),
-            })?,
-        None => run.await,
+        let result = match codex.timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, run).await {
+                Ok(result) => result,
+                Err(_) => Err(Error::Timeout {
+                    timeout_seconds: timeout.as_secs(),
+                }),
+            },
+            None => run.await,
+        };
+        outcome.settle_from(&result);
+        result
     }
+    .instrument(span)
+    .await
 }
 
 async fn run_internal(
@@ -433,5 +538,154 @@ mod tests {
             wait_until_gone(pid).await,
             "codex ({pid}) survived the dropped future"
         );
+    }
+
+    /// Minimal recording subscriber, written by hand because #63 rules out a
+    /// new dependency and `tracing-subscriber` would be one. It collects every
+    /// field recorded on any span, which is all these tests need.
+    #[cfg(unix)]
+    mod recorder {
+        use std::sync::{Arc, Mutex};
+
+        use tracing::field::{Field, Visit};
+        use tracing::span::{Attributes, Id, Record};
+        use tracing::{Event, Metadata, Subscriber};
+
+        #[derive(Clone, Default)]
+        pub(super) struct Recorder(Arc<Mutex<Vec<(String, String)>>>);
+
+        impl Recorder {
+            pub(super) fn value(&self, field: &str) -> Option<String> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .rev()
+                    .find(|(name, _)| name == field)
+                    .map(|(_, value)| value.clone())
+            }
+        }
+
+        struct Collect<'a>(&'a mut Vec<(String, String)>);
+
+        impl Visit for Collect<'_> {
+            fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                self.0.push((field.name().into(), format!("{value:?}")));
+            }
+            fn record_str(&mut self, field: &Field, value: &str) {
+                self.0.push((field.name().into(), value.into()));
+            }
+            fn record_i64(&mut self, field: &Field, value: i64) {
+                self.0.push((field.name().into(), value.to_string()));
+            }
+            fn record_u64(&mut self, field: &Field, value: u64) {
+                self.0.push((field.name().into(), value.to_string()));
+            }
+        }
+
+        impl Subscriber for Recorder {
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+                attrs.record(&mut Collect(&mut self.0.lock().unwrap()));
+                Id::from_u64(1)
+            }
+            fn record(&self, _: &Id, values: &Record<'_>) {
+                values.record(&mut Collect(&mut self.0.lock().unwrap()));
+            }
+            fn record_follows_from(&self, _: &Id, _: &Id) {}
+            fn event(&self, _: &Event<'_>) {}
+            fn enter(&self, _: &Id) {}
+            fn exit(&self, _: &Id) {}
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn span_records_the_subcommand_and_a_clean_outcome() {
+        let recorder = recorder::Recorder::default();
+        let _guard = tracing::subscriber::set_default(recorder.clone());
+
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .build()
+            .expect("echo must exist");
+        run_codex(&codex, vec!["exec".into()]).await.unwrap();
+
+        assert_eq!(recorder.value("subcommand").as_deref(), Some("exec"));
+        assert_eq!(recorder.value("outcome").as_deref(), Some("ok"));
+        assert_eq!(recorder.value("exit_code").as_deref(), Some("0"));
+        assert!(recorder.value("duration_ms").is_some());
+    }
+
+    /// The prompt must never reach the span. It is in argv, so recording the
+    /// arguments would leak it into any host's logs.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn span_does_not_carry_the_prompt() {
+        let recorder = recorder::Recorder::default();
+        let _guard = tracing::subscriber::set_default(recorder.clone());
+
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .build()
+            .expect("echo must exist");
+        run_codex(&codex, vec!["exec".into(), "a very secret prompt".into()])
+            .await
+            .unwrap();
+
+        let recorded = format!("{:?}", recorder.value("subcommand"));
+        assert!(!recorded.contains("secret"));
+        for field in ["binary", "working_dir", "outcome", "exit_code"] {
+            let value = recorder.value(field).unwrap_or_default();
+            assert!(
+                !value.contains("secret"),
+                "{field} leaked the prompt: {value}"
+            );
+        }
+    }
+
+    /// A dropped future records an outcome rather than leaving the span open,
+    /// so an abandoned run is distinguishable from one still in progress.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_cancelled_run_is_recorded_as_cancelled() {
+        let recorder = recorder::Recorder::default();
+        let _guard = tracing::subscriber::set_default(recorder.clone());
+
+        let pid_file = crate::test_support::PidFile::new("span-cancel");
+        let codex = crate::test_support::blocking_codex(&pid_file)
+            .build()
+            .expect("bash must exist");
+
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(300),
+            run_codex(&codex, vec!["exec".into()]),
+        )
+        .await;
+        assert!(cancelled.is_err(), "the run should still have been going");
+
+        assert_eq!(recorder.value("outcome").as_deref(), Some("cancelled"));
+    }
+
+    /// A wrapper timeout is its own outcome, distinct from a caller
+    /// cancelling: the run reached its deadline rather than being abandoned.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_timed_out_run_is_recorded_as_timeout() {
+        let recorder = recorder::Recorder::default();
+        let _guard = tracing::subscriber::set_default(recorder.clone());
+
+        let pid_file = crate::test_support::PidFile::new("span-timeout");
+        let codex = crate::test_support::blocking_codex(&pid_file)
+            .timeout(Duration::from_millis(300))
+            .build()
+            .expect("bash must exist");
+
+        let result = run_codex(&codex, vec!["exec".into()]).await;
+        assert!(matches!(result, Err(Error::Timeout { .. })), "{result:?}");
+
+        assert_eq!(recorder.value("outcome").as_deref(), Some("timeout"));
     }
 }

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -24,7 +24,7 @@
 
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
-use tracing::debug;
+use tracing::{Instrument, debug};
 
 use crate::Codex;
 use crate::command::CodexCommand;
@@ -81,9 +81,15 @@ async fn run_streaming<F>(
 where
     F: FnMut(JsonLineEvent),
 {
+    let span = crate::exec::command_span("codex.stream", codex, &args);
     let command_args = crate::exec::assemble_args(codex, args);
+    let _span_guard = span.clone().entered();
 
     debug!(binary = %codex.binary.display(), args = ?command_args, "streaming codex command");
+
+    // Settles on every exit below, and on drop for the one that has no exit:
+    // a cancelled stream, which is the outcome most easily missed.
+    let mut outcome = crate::exec::SpanOutcome::start(span.clone());
 
     let mut child_cmd = Command::new(&codex.binary);
     child_cmd.args(&command_args);
@@ -202,6 +208,7 @@ where
 
         let exit_code = status.code().unwrap_or(-1);
         if !status.success() {
+            outcome.settle("failed", Some(exit_code));
             return Err(Error::CommandFailed {
                 command: format!("{} {}", codex.binary.display(), command_args.join(" ")),
                 exit_code,
@@ -211,17 +218,27 @@ where
             });
         }
 
+        outcome.settle("ok", Some(exit_code));
         Ok(())
     };
 
+    // Dropped explicitly before awaiting: the guard exists so the span is the
+    // parent of everything above, while the await below must not hold it
+    // across a yield point.
+    drop(_span_guard);
+
     if let Some(timeout) = codex.timeout {
-        tokio::time::timeout(timeout, stream_future)
-            .await
-            .map_err(|_| Error::Timeout {
+        // On elapse the stream future is dropped, taking `outcome` with it,
+        // whose drop records the run as cancelled. That is the same path a
+        // caller dropping this future takes.
+        match tokio::time::timeout(timeout, stream_future.instrument(span.clone())).await {
+            Ok(result) => result,
+            Err(_) => Err(Error::Timeout {
                 timeout_seconds: timeout.as_secs(),
-            })?
+            }),
+        }
     } else {
-        stream_future.await
+        stream_future.instrument(span).await
     }
 }
 


### PR DESCRIPTION
Closes #63.

| Span | Raised by |
|---|---|
| `codex.exec` | any buffered run, one per attempt |
| `codex.stream` | a streaming run, closing when the stream ends |
| `codex.retry` | a retried run, parent to each attempt's span |

Fields on open: `subcommand`, `binary`, `working_dir`. On close: `outcome`, `duration_ms`, `exit_code`.

## The four outcomes

The issue asks for the Elixir module's three-outcome shape, noting the failure case is the one that gets missed. There are four here, and the extra one is that case:

| `outcome` | Meaning |
|---|---|
| `ok` | exited zero |
| `failed` | exited non-zero |
| `timeout` | hit the client's timeout |
| `cancelled` | the future was dropped, so the run was abandoned |

`cancelled` needs a `Drop` impl to record at all. After #77 a dropped future kills the process and runs nothing else, so without it the span closes with no outcome and an abandoned run is indistinguishable from one still in progress.

## One thing the tests caught

The guard first read `Span::current()`. That is wrong in a way nothing else here would have surfaced: current-span tracking is the subscriber's job, via a `current_span()` method with a default impl that returns nothing. Against such a subscriber every record silently disappears, including the drop-time one the guard exists for. The span is now passed in and held, so recording does not depend on subscriber behaviour.

The tests use a hand-written recording subscriber rather than `tracing-subscriber`, since the issue rules out a new dependency. It is about 50 lines and it is what exposed the bug above.

## Constraints honored

No new dependencies, and no output unless the host installs a subscriber. No separate metrics abstraction, per the issue's "deliberately not doing".

**No prompt, no environment on any span.** The prompt is in argv, so recording the arguments would put it in a host's logs. Worth noting separately: the pre-existing `debug!` line does log the full argv, prompt included. That is a deliberate debugging aid rather than something this PR introduces, and the README now says so, but it is worth a decision if prompt privacy matters.

## Local checks

fmt, clippy `-D warnings`, 158 lib tests all-features, 116 no-default-features, 19 doc tests, rustdoc `-D warnings`, examples build.