### PR TITLE
feat(budget): cumulative token budget tracking across turns

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,37 @@ Global args precede the subcommand, the same order the spawn uses, because the p
 spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
 pasted, but no shell is involved at spawn time: args go to the process directly.
 
+## Token Budgets
+
+Cap what a session may consume. The ceiling is in tokens, not dollars, because the CLI reports
+token counts and no monetary cost:
+
+```rust
+use std::sync::Arc;
+use codex_wrapper::{Codex, Session, TokenBudget};
+
+let budget = TokenBudget::builder()
+    .max_tokens(200_000)
+    .warn_at_tokens(150_000)
+    .on_warning(|total| eprintln!("at {total} tokens"))
+    .build();
+
+let mut session = Session::new(Arc::new(codex)).with_budget(budget.clone());
+```
+
+Each turn's reported usage is added to the budget, and a turn is refused with
+`Error::TokenBudgetExceeded` once the ceiling is reached. The check runs before a turn starts, so
+the ceiling can be overshot by at most the turn that crosses it: usage is only known once spent.
+`TokenBudget` is `Clone` over shared state, so one budget can span several sessions.
+
+Two things a budget cannot see, both worth knowing before relying on one:
+
+- A `turn.completed` with no `usage` object contributes nothing. `turns_missing_usage()` counts
+  those separately, so an unmeasured turn is distinguishable from a genuinely cheap one.
+- A review reports usage as all zeros, so a session of reviews never advances the budget.
+
+Treat the total as a floor on consumption rather than an exact measure.
+
 ## Tracing
 
 Every invocation is wrapped in a `tracing` span. Nothing is emitted unless the host installs a

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -536,6 +536,37 @@ Global args precede the subcommand, the same order the spawn uses, because the p
 spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
 pasted, but no shell is involved at spawn time: args go to the process directly.
 
+## Token Budgets
+
+Cap what a session may consume. The ceiling is in tokens, not dollars, because the CLI reports
+token counts and no monetary cost:
+
+```rust
+use std::sync::Arc;
+use codex_wrapper::{Codex, Session, TokenBudget};
+
+let budget = TokenBudget::builder()
+    .max_tokens(200_000)
+    .warn_at_tokens(150_000)
+    .on_warning(|total| eprintln!("at {total} tokens"))
+    .build();
+
+let mut session = Session::new(Arc::new(codex)).with_budget(budget.clone());
+```
+
+Each turn's reported usage is added to the budget, and a turn is refused with
+`Error::TokenBudgetExceeded` once the ceiling is reached. The check runs before a turn starts, so
+the ceiling can be overshot by at most the turn that crosses it: usage is only known once spent.
+`TokenBudget` is `Clone` over shared state, so one budget can span several sessions.
+
+Two things a budget cannot see, both worth knowing before relying on one:
+
+- A `turn.completed` with no `usage` object contributes nothing. `turns_missing_usage()` counts
+  those separately, so an unmeasured turn is distinguishable from a genuinely cheap one.
+- A review reports usage as all zeros, so a session of reviews never advances the budget.
+
+Treat the total as a floor on consumption rather than an exact measure.
+
 ## Tracing
 
 Every invocation is wrapped in a `tracing` span. Nothing is emitted unless the host installs a

--- a/crates/codex-wrapper/src/budget.rs
+++ b/crates/codex-wrapper/src/budget.rs
@@ -1,0 +1,425 @@
+//! Cumulative token budget tracking across turns.
+//!
+//! # Why tokens and not money
+//!
+//! `claude-wrapper`'s equivalent tracks USD, because that CLI reports a cost
+//! per turn. The codex CLI does not: a completed turn carries token counts and
+//! no monetary field (see the schema block in [`crate::types`]). Converting
+//! tokens to dollars needs a per-model price table the CLI does not provide,
+//! and a hardcoded one would go stale silently, which is the failure mode #73
+//! was filed about. So the ceiling here is denominated in what the CLI
+//! actually reports.
+//!
+//! # What a budget cannot see
+//!
+//! A tracker only counts what it is told, and two codex behaviours mean that
+//! is less than everything:
+//!
+//! - A `turn.completed` event without a `usage` object contributes nothing.
+//!   [`TokenBudget::turns_missing_usage`] counts those separately, so an
+//!   unmeasured turn is distinguishable from a genuinely cheap one.
+//! - A review reports usage as all zeros. A session of reviews never advances
+//!   the total at all.
+//!
+//! Treat a budget as a floor on consumption rather than an exact measure.
+//!
+//! # Example
+//!
+//! ```
+//! use codex_wrapper::TokenBudget;
+//!
+//! let budget = TokenBudget::builder()
+//!     .max_tokens(100_000)
+//!     .warn_at_tokens(80_000)
+//!     .on_warning(|total| eprintln!("at {total} tokens"))
+//!     .build();
+//!
+//! budget.record(Some(50_000));
+//! assert_eq!(budget.total_tokens(), 50_000);
+//! assert_eq!(budget.remaining_tokens(), Some(50_000));
+//! assert!(budget.check().is_ok());
+//!
+//! budget.record(Some(60_000));
+//! assert!(budget.check().is_err());
+//! ```
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::{Error, Result};
+
+type Callback = Arc<dyn Fn(u64) + Send + Sync>;
+
+#[derive(Default)]
+struct Config {
+    max_tokens: Option<u64>,
+    warn_at_tokens: Option<u64>,
+    on_warning: Option<Callback>,
+    on_exceeded: Option<Callback>,
+}
+
+#[derive(Default)]
+struct State {
+    total_tokens: u64,
+    turns_missing_usage: usize,
+    warned: bool,
+    exceeded: bool,
+}
+
+struct Inner {
+    config: Config,
+    state: Mutex<State>,
+}
+
+/// Cumulative token budget with threshold callbacks.
+///
+/// Cloning shares one running total, so a single budget can span several
+/// [`Session`](crate::Session)s. See the [module docs](crate::budget) for what
+/// a budget can and cannot see.
+#[derive(Clone)]
+pub struct TokenBudget {
+    inner: Arc<Inner>,
+}
+
+impl TokenBudget {
+    /// Start building a budget.
+    #[must_use]
+    pub fn builder() -> TokenBudgetBuilder {
+        TokenBudgetBuilder::default()
+    }
+
+    /// Add a turn's token usage to the running total.
+    ///
+    /// `None` records a turn the CLI reported no usage for. It does not move
+    /// the total, and is counted by
+    /// [`turns_missing_usage`](Self::turns_missing_usage) so the gap stays
+    /// visible rather than reading as zero consumption.
+    ///
+    /// Fires `on_warning` the first time the total reaches `warn_at_tokens`,
+    /// and `on_exceeded` the first time it reaches `max_tokens`.
+    pub fn record(&self, tokens: Option<u64>) {
+        let Some(tokens) = tokens else {
+            self.inner
+                .state
+                .lock()
+                .expect("budget mutex poisoned")
+                .turns_missing_usage += 1;
+            return;
+        };
+
+        let (warn_fired, exceeded_fired, total) = {
+            let mut state = self.inner.state.lock().expect("budget mutex poisoned");
+            state.total_tokens = state.total_tokens.saturating_add(tokens);
+
+            let warn_fired = match self.inner.config.warn_at_tokens {
+                Some(threshold) if !state.warned && state.total_tokens >= threshold => {
+                    state.warned = true;
+                    true
+                }
+                _ => false,
+            };
+
+            let exceeded_fired = match self.inner.config.max_tokens {
+                Some(threshold) if !state.exceeded && state.total_tokens >= threshold => {
+                    state.exceeded = true;
+                    true
+                }
+                _ => false,
+            };
+
+            (warn_fired, exceeded_fired, state.total_tokens)
+        };
+
+        // Fired outside the lock: a callback that touches this budget would
+        // otherwise deadlock on it.
+        if warn_fired && let Some(cb) = &self.inner.config.on_warning {
+            cb(total);
+        }
+        if exceeded_fired && let Some(cb) = &self.inner.config.on_exceeded {
+            cb(total);
+        }
+    }
+
+    /// `Err(Error::TokenBudgetExceeded)` once the total reaches `max_tokens`.
+    ///
+    /// `Ok(())` when no ceiling is set.
+    pub fn check(&self) -> Result<()> {
+        let Some(max_tokens) = self.inner.config.max_tokens else {
+            return Ok(());
+        };
+        let total_tokens = self.total_tokens();
+        if total_tokens >= max_tokens {
+            Err(Error::TokenBudgetExceeded {
+                total_tokens,
+                max_tokens,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Tokens recorded so far.
+    #[must_use]
+    pub fn total_tokens(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .expect("budget mutex poisoned")
+            .total_tokens
+    }
+
+    /// Turns recorded with no usage reported.
+    ///
+    /// These consumed tokens the total does not include, so a non-zero count
+    /// means the total is a floor rather than a measure.
+    #[must_use]
+    pub fn turns_missing_usage(&self) -> usize {
+        self.inner
+            .state
+            .lock()
+            .expect("budget mutex poisoned")
+            .turns_missing_usage
+    }
+
+    /// Tokens left before the ceiling, or `None` when there is no ceiling.
+    ///
+    /// Saturates at zero rather than going negative: a turn can overshoot,
+    /// since usage is only known once it has been spent.
+    #[must_use]
+    pub fn remaining_tokens(&self) -> Option<u64> {
+        self.inner
+            .config
+            .max_tokens
+            .map(|max| max.saturating_sub(self.total_tokens()))
+    }
+
+    /// The configured ceiling, if any.
+    #[must_use]
+    pub fn max_tokens(&self) -> Option<u64> {
+        self.inner.config.max_tokens
+    }
+
+    /// The configured warning threshold, if any.
+    #[must_use]
+    pub fn warn_at_tokens(&self) -> Option<u64> {
+        self.inner.config.warn_at_tokens
+    }
+
+    /// Clear the running total and re-arm both thresholds.
+    pub fn reset(&self) {
+        *self.inner.state.lock().expect("budget mutex poisoned") = State::default();
+    }
+}
+
+impl std::fmt::Debug for TokenBudget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenBudget")
+            .field("total_tokens", &self.total_tokens())
+            .field("max_tokens", &self.max_tokens())
+            .field("warn_at_tokens", &self.warn_at_tokens())
+            .field("turns_missing_usage", &self.turns_missing_usage())
+            .finish()
+    }
+}
+
+/// Builder for [`TokenBudget`].
+#[derive(Default)]
+pub struct TokenBudgetBuilder {
+    config: Config,
+}
+
+impl TokenBudgetBuilder {
+    /// Stop at this many tokens. Without one, the budget only counts.
+    #[must_use]
+    pub fn max_tokens(mut self, max: u64) -> Self {
+        self.config.max_tokens = Some(max);
+        self
+    }
+
+    /// Fire `on_warning` once the total reaches this many tokens.
+    #[must_use]
+    pub fn warn_at_tokens(mut self, warn: u64) -> Self {
+        self.config.warn_at_tokens = Some(warn);
+        self
+    }
+
+    /// Called once, with the running total, when `warn_at_tokens` is reached.
+    #[must_use]
+    pub fn on_warning<F>(mut self, f: F) -> Self
+    where
+        F: Fn(u64) + Send + Sync + 'static,
+    {
+        self.config.on_warning = Some(Arc::new(f));
+        self
+    }
+
+    /// Called once, with the running total, when `max_tokens` is reached.
+    #[must_use]
+    pub fn on_exceeded<F>(mut self, f: F) -> Self
+    where
+        F: Fn(u64) + Send + Sync + 'static,
+    {
+        self.config.on_exceeded = Some(Arc::new(f));
+        self
+    }
+
+    /// Build the budget.
+    #[must_use]
+    pub fn build(self) -> TokenBudget {
+        TokenBudget {
+            inner: Arc::new(Inner {
+                config: self.config,
+                state: Mutex::new(State::default()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn records_and_reports_a_running_total() {
+        let budget = TokenBudget::builder().max_tokens(1000).build();
+        budget.record(Some(400));
+        budget.record(Some(350));
+
+        assert_eq!(budget.total_tokens(), 750);
+        assert_eq!(budget.remaining_tokens(), Some(250));
+        assert!(budget.check().is_ok());
+    }
+
+    #[test]
+    fn check_fails_once_the_ceiling_is_reached() {
+        let budget = TokenBudget::builder().max_tokens(100).build();
+        budget.record(Some(100));
+
+        let err = budget.check().unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::TokenBudgetExceeded {
+                    total_tokens: 100,
+                    max_tokens: 100
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    /// A turn can only be measured after it has run, so the total can land
+    /// past the ceiling. Remaining must floor at zero rather than wrap.
+    #[test]
+    fn remaining_saturates_instead_of_wrapping() {
+        let budget = TokenBudget::builder().max_tokens(100).build();
+        budget.record(Some(250));
+
+        assert_eq!(budget.remaining_tokens(), Some(0));
+        assert_eq!(budget.total_tokens(), 250);
+    }
+
+    #[test]
+    fn no_ceiling_means_counting_only() {
+        let budget = TokenBudget::builder().build();
+        budget.record(Some(u64::MAX));
+
+        assert!(budget.check().is_ok());
+        assert_eq!(budget.remaining_tokens(), None);
+    }
+
+    /// An unreported turn must not read as zero consumption, which would let
+    /// a session run indefinitely against a ceiling it never approaches.
+    #[test]
+    fn a_turn_without_usage_is_counted_not_ignored() {
+        let budget = TokenBudget::builder().max_tokens(100).build();
+        budget.record(None);
+        budget.record(Some(10));
+        budget.record(None);
+
+        assert_eq!(budget.total_tokens(), 10);
+        assert_eq!(budget.turns_missing_usage(), 2);
+    }
+
+    #[test]
+    fn callbacks_fire_once_each() {
+        let warnings = Arc::new(AtomicU64::new(0));
+        let exceeded = Arc::new(AtomicU64::new(0));
+        let w = Arc::clone(&warnings);
+        let e = Arc::clone(&exceeded);
+
+        let budget = TokenBudget::builder()
+            .warn_at_tokens(50)
+            .max_tokens(100)
+            .on_warning(move |_| {
+                w.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_exceeded(move |_| {
+                e.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        for _ in 0..10 {
+            budget.record(Some(30));
+        }
+
+        assert_eq!(warnings.load(Ordering::SeqCst), 1);
+        assert_eq!(exceeded.load(Ordering::SeqCst), 1);
+    }
+
+    /// A callback that reads the budget must not deadlock, which it would if
+    /// callbacks fired while the state lock was held.
+    #[test]
+    fn a_callback_can_read_the_budget_it_belongs_to() {
+        let seen = Arc::new(Mutex::new(None));
+        let sink = Arc::clone(&seen);
+        let budget = TokenBudget::builder().max_tokens(10).build();
+        let handle = budget.clone();
+
+        let budget = TokenBudget::builder()
+            .max_tokens(10)
+            .on_exceeded(move |_| {
+                *sink.lock().unwrap() = Some(handle.total_tokens());
+            })
+            .build();
+
+        budget.record(Some(20));
+        assert!(seen.lock().unwrap().is_some());
+    }
+
+    #[test]
+    fn clones_share_one_total() {
+        let budget = TokenBudget::builder().max_tokens(100).build();
+        let other = budget.clone();
+
+        budget.record(Some(60));
+        other.record(Some(50));
+
+        assert_eq!(budget.total_tokens(), 110);
+        assert!(other.check().is_err());
+    }
+
+    #[test]
+    fn reset_clears_the_total_and_rearms_the_thresholds() {
+        let fired = Arc::new(AtomicU64::new(0));
+        let f = Arc::clone(&fired);
+        let budget = TokenBudget::builder()
+            .max_tokens(100)
+            .on_exceeded(move |_| {
+                f.fetch_add(1, Ordering::SeqCst);
+            })
+            .build();
+
+        budget.record(Some(150));
+        budget.record(None);
+        budget.reset();
+
+        assert_eq!(budget.total_tokens(), 0);
+        assert_eq!(budget.turns_missing_usage(), 0);
+        assert!(budget.check().is_ok());
+
+        budget.record(Some(150));
+        assert_eq!(fired.load(Ordering::SeqCst), 2, "threshold must re-arm");
+    }
+}

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -37,6 +37,19 @@ pub enum Error {
     #[error("codex command timed out after {timeout_seconds}s")]
     Timeout { timeout_seconds: u64 },
 
+    /// A session's token budget was reached.
+    ///
+    /// Denominated in tokens rather than money because the CLI reports token
+    /// counts and no cost; see [`crate::budget`].
+    #[error("token budget exceeded: {total_tokens} of {max_tokens} tokens")]
+    TokenBudgetExceeded {
+        /// Tokens recorded when the ceiling was hit. May exceed `max_tokens`,
+        /// since a turn's usage is only known once it has been spent.
+        total_tokens: u64,
+        /// The configured ceiling.
+        max_tokens: u64,
+    },
+
     /// JSON parsing failed.
     #[cfg(feature = "json")]
     #[error("json parse error: {message}")]

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -162,6 +162,8 @@
 //!
 //! - `json` *(enabled by default)* - JSONL output parsing via `serde_json`
 
+#[cfg(feature = "json")]
+pub mod budget;
 pub mod command;
 pub mod error;
 pub mod exec;
@@ -179,6 +181,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+#[cfg(feature = "json")]
+pub use budget::{TokenBudget, TokenBudgetBuilder};
 pub use command::CodexCommand;
 pub use command::apply::ApplyCommand;
 pub use command::completion::{CompletionCommand, Shell};

--- a/crates/codex-wrapper/src/session.rs
+++ b/crates/codex-wrapper/src/session.rs
@@ -89,6 +89,7 @@ pub struct Session {
     codex: Arc<Codex>,
     thread_id: Option<String>,
     history: Vec<TurnRecord>,
+    budget: Option<crate::budget::TokenBudget>,
 }
 
 impl Session {
@@ -100,6 +101,7 @@ impl Session {
             codex,
             thread_id: None,
             history: Vec::new(),
+            budget: None,
         }
     }
 
@@ -112,7 +114,42 @@ impl Session {
             codex,
             thread_id: Some(thread_id.into()),
             history: Vec::new(),
+            budget: None,
         }
+    }
+
+    /// Attach a [`TokenBudget`](crate::TokenBudget).
+    ///
+    /// Every turn's reported usage is added to it, and each turn is refused
+    /// with [`Error::TokenBudgetExceeded`] once the ceiling is reached. The
+    /// check happens before a turn starts, so the ceiling can be overshot by
+    /// at most the turn that crosses it: usage is only known once spent.
+    ///
+    /// The budget is [`Clone`] over shared state, so one can span several
+    /// sessions.
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use codex_wrapper::{Codex, Session, TokenBudget};
+    ///
+    /// # fn example() -> codex_wrapper::Result<()> {
+    /// let codex = Arc::new(Codex::builder().build()?);
+    /// let budget = TokenBudget::builder().max_tokens(200_000).build();
+    /// let session = Session::new(codex).with_budget(budget.clone());
+    /// # let _ = session;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_budget(mut self, budget: crate::budget::TokenBudget) -> Self {
+        self.budget = Some(budget);
+        self
+    }
+
+    /// The attached budget, if any.
+    #[must_use]
+    pub fn budget(&self) -> Option<&crate::budget::TokenBudget> {
+        self.budget.as_ref()
     }
 
     /// Send a prompt, automatically routing to `exec` or `exec resume`.
@@ -219,6 +256,7 @@ impl Session {
     where
         F: FnMut(JsonLineEvent),
     {
+        self.check_budget()?;
         let codex = Arc::clone(&self.codex);
         let mut collected = Vec::new();
         let outcome = cmd
@@ -241,6 +279,7 @@ impl Session {
     where
         F: FnMut(JsonLineEvent),
     {
+        self.check_budget()?;
         let codex = Arc::clone(&self.codex);
         let mut collected = Vec::new();
         let outcome = cmd
@@ -335,12 +374,29 @@ impl Session {
         self.capture_thread_id(&events);
         let result = QueryResult::from_events(events);
         let events = result.events.clone();
+        if let Some(budget) = &self.budget {
+            // `None` when the turn reported no usage, which the budget counts
+            // separately rather than treating as zero consumption.
+            budget.record(result.usage.and_then(|usage| usage.total()));
+        }
         self.history.push(TurnRecord { result });
         events
     }
 
+    /// Refuse a turn that would run past the budget.
+    ///
+    /// Checked before the turn rather than after, so the ceiling stops the
+    /// next run instead of being noticed once more has already been spent.
+    fn check_budget(&self) -> Result<()> {
+        match &self.budget {
+            Some(budget) => budget.check(),
+            None => Ok(()),
+        }
+    }
+
     /// Run an [`ExecCommand`] and record the turn.
     async fn run_exec(&mut self, cmd: ExecCommand) -> Result<Vec<JsonLineEvent>> {
+        self.check_budget()?;
         match cmd.execute_json_lines(&self.codex).await {
             Ok(events) => Ok(self.record_turn(events)),
             Err(Error::CommandFailed {
@@ -365,6 +421,7 @@ impl Session {
 
     /// Run an [`ExecResumeCommand`] and record the turn.
     async fn run_resume(&mut self, cmd: ExecResumeCommand) -> Result<Vec<JsonLineEvent>> {
+        self.check_budget()?;
         match cmd.execute_json_lines(&self.codex).await {
             Ok(events) => Ok(self.record_turn(events)),
             Err(Error::CommandFailed {
@@ -627,5 +684,93 @@ mod tests {
         assert_eq!(session.total_turns(), 2);
         assert_eq!(session.total_tokens(), 330);
         assert_eq!(session.turns_missing_usage(), 0);
+    }
+
+    // -----------------------------------------------------------------
+    // Budget (#60)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn a_session_without_a_budget_is_unaffected() {
+        let mut session = Session::new(test_codex());
+        session.record_turn(completed(500));
+        assert!(session.budget().is_none());
+        assert_eq!(session.total_tokens(), 500);
+    }
+
+    #[test]
+    fn turns_accumulate_into_the_attached_budget() {
+        let budget = crate::budget::TokenBudget::builder()
+            .max_tokens(1000)
+            .build();
+        let mut session = Session::new(test_codex()).with_budget(budget.clone());
+
+        session.record_turn(completed(300));
+        session.record_turn(completed(250));
+
+        assert_eq!(budget.total_tokens(), 550);
+        assert_eq!(session.total_tokens(), 550);
+    }
+
+    /// The ceiling stops the next turn rather than being noticed after more
+    /// has already been spent.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn a_turn_past_the_ceiling_is_refused_before_it_runs() {
+        let budget = crate::budget::TokenBudget::builder()
+            .max_tokens(100)
+            .build();
+        let mut session = streaming_session().with_budget(budget.clone());
+
+        // First turn runs and puts the budget over its ceiling: the fixture
+        // reports 165 tokens.
+        session.send("first").await.unwrap();
+        assert!(budget.total_tokens() >= 100);
+
+        let refused = session.send("second").await;
+        assert!(
+            matches!(refused, Err(Error::TokenBudgetExceeded { .. })),
+            "expected the second turn to be refused, got: {refused:?}"
+        );
+        // Refused before running, so no turn was recorded for it.
+        assert_eq!(session.total_turns(), 1);
+    }
+
+    /// A review reports usage as all zeros (#79), so a session of reviews
+    /// never advances a budget. Pinned rather than left as a surprise.
+    #[test]
+    fn an_all_zero_usage_turn_does_not_advance_the_budget() {
+        let budget = crate::budget::TokenBudget::builder()
+            .max_tokens(100)
+            .build();
+        let mut session = Session::new(test_codex()).with_budget(budget.clone());
+
+        for _ in 0..10 {
+            session.record_turn(completed(0));
+        }
+
+        assert_eq!(budget.total_tokens(), 0);
+        assert_eq!(
+            budget.turns_missing_usage(),
+            0,
+            "zero is reported, not missing"
+        );
+        assert!(budget.check().is_ok(), "a review-only session never stops");
+    }
+
+    /// A turn with no usage object must not read as zero consumption, which
+    /// would let an unmeasured session run forever against its ceiling.
+    #[test]
+    fn a_turn_with_no_usage_is_counted_as_unmeasured() {
+        let budget = crate::budget::TokenBudget::builder()
+            .max_tokens(100)
+            .build();
+        let mut session = Session::new(test_codex()).with_budget(budget.clone());
+
+        session.record_turn(turn(&[r#"{"type":"turn.completed"}"#]));
+
+        assert_eq!(budget.total_tokens(), 0);
+        assert_eq!(budget.turns_missing_usage(), 1);
+        assert_eq!(session.turns_missing_usage(), 1);
     }
 }


### PR DESCRIPTION
Closes #60, rescoped to tokens.

## Why tokens and not USD

The CLI reports token counts and no monetary cost (#73, #79). A USD ceiling would need a per-model price table the CLI does not provide, and `types.rs` already argues against shipping one: it goes stale silently, the same failure mode as #73.

## What landed

`TokenBudget` mirrors `claude-wrapper`'s `BudgetTracker` shape, so the two crates stay recognisable to each other:

```rust
let budget = TokenBudget::builder()
    .max_tokens(200_000)
    .warn_at_tokens(150_000)
    .on_warning(|total| eprintln!("at {total} tokens"))
    .build();

let mut session = Session::new(codex).with_budget(budget.clone());
```

`Session::with_budget` checks before each turn and records after, on both the buffered and streaming paths. `Error::TokenBudgetExceeded` is the refusal; `Error` is already `#[non_exhaustive]` so adding it breaks nothing.

## Three things worth a look in review

**Callbacks fire outside the state lock.** Holding it across a callback deadlocks the obvious thing to write, a callback that reads the budget it belongs to. There is a test for exactly that.

**The ceiling can be overshot, by design.** A turn's usage is only known once spent, so `check` runs before a turn and the ceiling is crossed by at most one turn. `remaining_tokens` saturates at zero rather than wrapping, with a test.

**Two blind spots are surfaced, not hidden.** A budget that undercounts silently is worse than none:

| Case | Behaviour |
|---|---|
| `turn.completed` with no `usage` | counted by `turns_missing_usage`, not treated as zero |
| review turns, which report all zeros (#79) | never advance the budget at all |

Both have tests, and both are in the README and module docs. The second means a review-only session never stops on its ceiling, which is a real limitation rather than a bug in this code.

## Local checks

fmt, clippy `-D warnings`, 172 lib tests all-features, 116 no-default-features, 21 doc tests, rustdoc `-D warnings`.