### PR TITLE
feat: classify command failures into typed error variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,33 @@ available for a plain minimum-version gate.
 
 ## Error Handling
 
+Failed commands are classified at the error boundary, so a caller branches on the class instead
+of substring-matching stderr:
+
+```rust
+use codex_wrapper::{ExecCommand, CodexCommand, Error, FailureKind};
+
+match ExecCommand::new("test").execute(&codex).await {
+    Ok(output) => println!("{}", output.stdout),
+    Err(e) => match e.failure_kind() {
+        Some(FailureKind::Auth) => eprintln!("re-authenticate and retry"),
+        Some(FailureKind::NotTrustedDirectory) => eprintln!("run in a git repo, or skip the check"),
+        Some(FailureKind::Config) => eprintln!("fix the config: {e}"),
+        Some(FailureKind::SessionNotFound) => eprintln!("start a new session"),
+        _ => eprintln!("{e}"),
+    },
+}
+```
+
+Classification reads stderr, because it has to: every failure observed on `codex-cli` 0.145.0
+exits 1, so the exit code carries no information. Each signature comes from a captured failing
+run. A failure matching none of them stays `Error::CommandFailed` with its output intact, so
+classification never loses anything.
+
+The classified failures are deterministic, so they are never retried even when their exit code is
+on a retry policy's list. Re-running gets the same rejection, and the CLI has already retried the
+auth case internally before it surfaces.
+
 All commands return `Result<T>`, with errors typed via `thiserror`:
 
 ```rust

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -502,6 +502,33 @@ available for a plain minimum-version gate.
 
 ## Error Handling
 
+Failed commands are classified at the error boundary, so a caller branches on the class instead
+of substring-matching stderr:
+
+```rust
+use codex_wrapper::{ExecCommand, CodexCommand, Error, FailureKind};
+
+match ExecCommand::new("test").execute(&codex).await {
+    Ok(output) => println!("{}", output.stdout),
+    Err(e) => match e.failure_kind() {
+        Some(FailureKind::Auth) => eprintln!("re-authenticate and retry"),
+        Some(FailureKind::NotTrustedDirectory) => eprintln!("run in a git repo, or skip the check"),
+        Some(FailureKind::Config) => eprintln!("fix the config: {e}"),
+        Some(FailureKind::SessionNotFound) => eprintln!("start a new session"),
+        _ => eprintln!("{e}"),
+    },
+}
+```
+
+Classification reads stderr, because it has to: every failure observed on `codex-cli` 0.145.0
+exits 1, so the exit code carries no information. Each signature comes from a captured failing
+run. A failure matching none of them stays `Error::CommandFailed` with its output intact, so
+classification never loses anything.
+
+The classified failures are deterministic, so they are never retried even when their exit code is
+on a retry policy's list. Re-running gets the same rejection, and the CLI has already retried the
+auth case internally before it surfaces.
+
 All commands return `Result<T>`, with errors typed via `thiserror`:
 
 ```rust

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -14,6 +14,55 @@ pub enum Error {
     #[error("codex binary not found in PATH")]
     NotFound,
 
+    /// The CLI could not authenticate.
+    ///
+    /// Classified from stderr by [`Error::from_command_failure`]; see
+    /// [`FailureKind`] for what that costs. Not retried: the CLI has already
+    /// retried internally by the time this surfaces, and the credentials will
+    /// not have changed.
+    #[error("codex authentication failed: {}", first_line(message))]
+    Auth {
+        /// The CLI's stderr, trimmed. Retained whole rather than reduced to
+        /// the matched line, so nothing is lost to classification.
+        message: String,
+        command: String,
+        exit_code: i32,
+        working_dir: Option<PathBuf>,
+    },
+
+    /// The CLI rejected the configuration before running.
+    ///
+    /// An unknown key under `--strict-config`, or a malformed override.
+    #[error("codex rejected the configuration: {}", first_line(message))]
+    Config {
+        /// The CLI's stderr, trimmed.
+        message: String,
+        command: String,
+        exit_code: i32,
+        working_dir: Option<PathBuf>,
+    },
+
+    /// The working directory is not a trusted directory or git repo, and
+    /// `--skip-git-repo-check` was not set.
+    #[error("codex refused an untrusted directory: {}", first_line(message))]
+    NotTrustedDirectory {
+        /// The CLI's stderr, trimmed.
+        message: String,
+        command: String,
+        exit_code: i32,
+        working_dir: Option<PathBuf>,
+    },
+
+    /// The session or thread being resumed does not exist.
+    #[error("codex session not found: {}", first_line(message))]
+    SessionNotFound {
+        /// The CLI's stderr, trimmed.
+        message: String,
+        command: String,
+        exit_code: i32,
+        working_dir: Option<PathBuf>,
+    },
+
     /// A codex command failed with a non-zero exit code.
     #[error("codex command failed: {command} (exit code {exit_code}){}{}{}", working_dir.as_ref().map(|d| format!(" (in {})", d.display())).unwrap_or_default(), if stdout.is_empty() { String::new() } else { format!("\nstdout: {stdout}") }, if stderr.is_empty() { String::new() } else { format!("\nstderr: {stderr}") })]
     CommandFailed {
@@ -92,6 +141,165 @@ impl From<std::io::Error> for Error {
 
 /// Result type alias for codex-wrapper operations.
 pub type Result<T> = std::result::Result<T, Error>;
+
+/// The first non-empty line of a message, for a one-line `Display`.
+fn first_line(message: &str) -> &str {
+    message
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or(message)
+}
+
+/// The class of a failed command, for matching without destructuring.
+///
+/// Returned by [`Error::failure_kind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FailureKind {
+    /// The CLI could not authenticate.
+    Auth,
+    /// The CLI rejected the configuration before running.
+    Config,
+    /// The working directory was not trusted.
+    NotTrustedDirectory,
+    /// The session or thread being resumed does not exist.
+    SessionNotFound,
+    /// A non-zero exit that matched no known signature.
+    Unclassified,
+}
+
+/// Signatures observed on `codex-cli` 0.145.0, each from a captured failing
+/// run. Matched against stderr, since every one of them exits 1: the exit code
+/// carries no information here.
+///
+/// Deliberately matched on the stable part of each message. The auth line, for
+/// instance, also carries a request id and a `cf-ray` header that differ every
+/// time.
+const SIGNATURES: &[(&str, FailureKind)] = &[
+    ("401 Unauthorized", FailureKind::Auth),
+    ("Missing bearer or basic authentication", FailureKind::Auth),
+    (
+        "Not inside a trusted directory",
+        FailureKind::NotTrustedDirectory,
+    ),
+    ("Error loading config.toml", FailureKind::Config),
+    ("unknown configuration field", FailureKind::Config),
+    (
+        "no rollout found for thread id",
+        FailureKind::SessionNotFound,
+    ),
+];
+
+impl Error {
+    /// Build an error from a failed command, classifying it by stderr.
+    ///
+    /// Every non-zero exit in this crate goes through here, so a caller can
+    /// branch on the class rather than substring-matching stderr themselves.
+    /// An unrecognized failure stays [`Error::CommandFailed`] with its output
+    /// intact, so classification never loses information.
+    ///
+    /// Classification is by message, because it has to be: every failure
+    /// observed on 0.145.0 exits 1. That makes it sensitive to the CLI
+    /// rewording a message, which is the cost of doing it here instead of in
+    /// every caller. `tests/contract.rs` is where a reworded message should be
+    /// caught.
+    #[must_use]
+    pub fn from_command_failure(
+        command: String,
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+        working_dir: Option<PathBuf>,
+    ) -> Self {
+        let message = stderr.trim().to_string();
+
+        let kind = SIGNATURES
+            .iter()
+            .find(|(needle, _)| message.contains(needle))
+            .map(|(_, kind)| *kind);
+
+        match kind {
+            Some(FailureKind::Auth) => Error::Auth {
+                message,
+                command,
+                exit_code,
+                working_dir,
+            },
+            Some(FailureKind::Config) => Error::Config {
+                message,
+                command,
+                exit_code,
+                working_dir,
+            },
+            Some(FailureKind::NotTrustedDirectory) => Error::NotTrustedDirectory {
+                message,
+                command,
+                exit_code,
+                working_dir,
+            },
+            Some(FailureKind::SessionNotFound) => Error::SessionNotFound {
+                message,
+                command,
+                exit_code,
+                working_dir,
+            },
+            _ => Error::CommandFailed {
+                command,
+                exit_code,
+                stdout,
+                stderr,
+                working_dir,
+            },
+        }
+    }
+
+    /// The class of this failure, or `None` if it is not a command failure.
+    #[must_use]
+    pub fn failure_kind(&self) -> Option<FailureKind> {
+        match self {
+            Error::Auth { .. } => Some(FailureKind::Auth),
+            Error::Config { .. } => Some(FailureKind::Config),
+            Error::NotTrustedDirectory { .. } => Some(FailureKind::NotTrustedDirectory),
+            Error::SessionNotFound { .. } => Some(FailureKind::SessionNotFound),
+            Error::CommandFailed { .. } => Some(FailureKind::Unclassified),
+            _ => None,
+        }
+    }
+
+    /// The process exit code, for any variant that came from one.
+    ///
+    /// Classification moved some failures off [`Error::CommandFailed`], so
+    /// anything reading an exit code should read it here rather than matching
+    /// that one variant.
+    #[must_use]
+    pub fn exit_code(&self) -> Option<i32> {
+        match self {
+            Error::CommandFailed { exit_code, .. }
+            | Error::Auth { exit_code, .. }
+            | Error::Config { exit_code, .. }
+            | Error::NotTrustedDirectory { exit_code, .. }
+            | Error::SessionNotFound { exit_code, .. } => Some(*exit_code),
+            _ => None,
+        }
+    }
+
+    /// Whether re-running the identical command could plausibly succeed.
+    ///
+    /// False for the classified failures: each is a deterministic rejection,
+    /// and the CLI has already retried the auth case internally before it
+    /// surfaces here.
+    #[must_use]
+    pub fn is_deterministic_failure(&self) -> bool {
+        matches!(
+            self,
+            Error::Auth { .. }
+                | Error::Config { .. }
+                | Error::NotTrustedDirectory { .. }
+                | Error::SessionNotFound { .. }
+        )
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -182,5 +390,111 @@ mod tests {
             err.to_string(),
             "CLI version 0.100.0 does not meet minimum requirement 0.145.0"
         );
+    }
+
+    // ---------------------------------------------------------------
+    // Classification (#85)
+    // ---------------------------------------------------------------
+
+    fn classify(stderr: &str) -> Error {
+        Error::from_command_failure(
+            "codex exec hi".into(),
+            1,
+            String::new(),
+            stderr.into(),
+            None,
+        )
+    }
+
+    /// Each string is transcribed from a captured codex-cli 0.145.0 failure,
+    /// varying parts and all.
+    #[test]
+    fn classifies_every_captured_signature() {
+        let cases: &[(&str, FailureKind)] = &[
+            (
+                "ERROR: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: a272310168bcba62-SJC, request id: req_ef11",
+                FailureKind::Auth,
+            ),
+            (
+                "Not inside a trusted directory and --skip-git-repo-check was not specified.",
+                FailureKind::NotTrustedDirectory,
+            ),
+            (
+                "Error loading config.toml: unknown configuration field `bogus` in -c/--config override",
+                FailureKind::Config,
+            ),
+            (
+                "Error: thread/resume: thread/resume failed: no rollout found for thread id 00000000-0000-0000-0000-000000000000 (code -32600)",
+                FailureKind::SessionNotFound,
+            ),
+        ];
+
+        for (stderr, expected) in cases {
+            let err = classify(stderr);
+            assert_eq!(
+                err.failure_kind(),
+                Some(*expected),
+                "misclassified: {stderr}"
+            );
+            assert_eq!(err.exit_code(), Some(1));
+            assert!(err.is_deterministic_failure(), "{stderr}");
+        }
+    }
+
+    /// An unrecognized failure must keep its output rather than being forced
+    /// into a class. Classification is allowed to not know.
+    #[test]
+    fn an_unknown_failure_stays_command_failed_with_its_output() {
+        let err = Error::from_command_failure(
+            "codex exec hi".into(),
+            2,
+            "partial stdout".into(),
+            "something new the CLI started saying".into(),
+            None,
+        );
+
+        assert_eq!(err.failure_kind(), Some(FailureKind::Unclassified));
+        assert!(!err.is_deterministic_failure());
+        match err {
+            Error::CommandFailed {
+                stdout,
+                stderr,
+                exit_code,
+                ..
+            } => {
+                assert_eq!(stdout, "partial stdout");
+                assert_eq!(stderr, "something new the CLI started saying");
+                assert_eq!(exit_code, 2);
+            }
+            other => panic!("expected CommandFailed, got {other:?}"),
+        }
+    }
+
+    /// The whole of stderr is kept, not just the matched line, so nothing is
+    /// lost to classification.
+    #[test]
+    fn a_classified_failure_keeps_the_full_message() {
+        let err = classify(
+            "ERROR: Reconnecting... 5/5\nERROR: unexpected status 401 Unauthorized: Missing bearer",
+        );
+        match &err {
+            Error::Auth { message, .. } => {
+                assert!(message.contains("Reconnecting... 5/5"), "{message}");
+                assert!(message.contains("401 Unauthorized"), "{message}");
+            }
+            other => panic!("expected Auth, got {other:?}"),
+        }
+        // Display stays one line, leading with the first thing stderr said.
+        assert_eq!(
+            err.to_string(),
+            "codex authentication failed: ERROR: Reconnecting... 5/5"
+        );
+    }
+
+    #[test]
+    fn non_command_errors_have_no_failure_kind() {
+        assert_eq!(Error::NotFound.failure_kind(), None);
+        assert_eq!(Error::Timeout { timeout_seconds: 5 }.failure_kind(), None);
+        assert_eq!(Error::NotFound.exit_code(), None);
     }
 }

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -71,9 +71,13 @@ impl SpanOutcome {
     fn settle_from(&mut self, result: &Result<CommandOutput>) {
         match result {
             Ok(output) => self.settle("ok", Some(output.exit_code)),
-            Err(Error::CommandFailed { exit_code, .. }) => self.settle("failed", Some(*exit_code)),
             Err(Error::Timeout { .. }) => self.settle("timeout", None),
-            Err(_) => self.settle("error", None),
+            // Covers the classified failures too, which are no longer
+            // CommandFailed but did still come from a process exit.
+            Err(e) => match e.exit_code() {
+                Some(code) => self.settle("failed", Some(code)),
+                None => self.settle("error", None),
+            },
         }
     }
 }
@@ -242,17 +246,29 @@ pub async fn run_codex_allow_exit_codes(
     let output = run_codex(codex, args).await;
 
     match output {
-        Err(Error::CommandFailed {
-            exit_code,
-            stdout,
-            stderr,
-            ..
-        }) if allowed_codes.contains(&exit_code) => Ok(CommandOutput {
-            stdout,
-            stderr,
-            exit_code,
-            success: false,
-        }),
+        // Matched on the exit code rather than the variant: classification
+        // moves some failures off CommandFailed, and an allowed code is
+        // allowed whatever the wrapper made of the message.
+        Err(e)
+            if e.exit_code()
+                .is_some_and(|code| allowed_codes.contains(&code)) =>
+        {
+            let exit_code = e.exit_code().unwrap_or(-1);
+            let (stdout, stderr) = match &e {
+                Error::CommandFailed { stdout, stderr, .. } => (stdout.clone(), stderr.clone()),
+                Error::Auth { message, .. }
+                | Error::Config { message, .. }
+                | Error::NotTrustedDirectory { message, .. }
+                | Error::SessionNotFound { message, .. } => (String::new(), message.clone()),
+                _ => (String::new(), String::new()),
+            };
+            Ok(CommandOutput {
+                stdout,
+                stderr,
+                exit_code,
+                success: false,
+            })
+        }
         other => other,
     }
 }
@@ -401,13 +417,13 @@ async fn run_internal_inner(
     let exit_code = output.status.code().unwrap_or(-1);
 
     if !output.status.success() {
-        return Err(Error::CommandFailed {
-            command: format!("{} {}", binary.display(), args.join(" ")),
+        return Err(Error::from_command_failure(
+            format!("{} {}", binary.display(), args.join(" ")),
             exit_code,
             stdout,
             stderr,
-            working_dir: working_dir.map(|p| p.to_path_buf()),
-        });
+            working_dir.map(|p| p.to_path_buf()),
+        ));
     }
 
     Ok(CommandOutput {
@@ -541,29 +557,58 @@ mod tests {
     }
 
     /// Minimal recording subscriber, written by hand because #63 rules out a
-    /// new dependency and `tracing-subscriber` would be one. It collects every
-    /// field recorded on any span, which is all these tests need.
+    /// new dependency and `tracing-subscriber` would be one.
+    ///
+    /// Installed once as the **global** default, fanning out to a per-thread
+    /// sink. A thread-local `set_default` is not enough: tracing caches
+    /// callsite interest globally, so a test running concurrently against no
+    /// subscriber caches this crate's span callsites as `never` and the
+    /// recording test then sees nothing. That produced a real flake, about one
+    /// run in three. A single always-enabled global subscriber keeps interest
+    /// stable, and the per-thread sink keeps tests isolated.
     #[cfg(unix)]
     mod recorder {
-        use std::sync::{Arc, Mutex};
+        use std::cell::RefCell;
+        use std::sync::{Arc, Mutex, Once};
 
         use tracing::field::{Field, Visit};
         use tracing::span::{Attributes, Id, Record};
         use tracing::{Event, Metadata, Subscriber};
 
-        #[derive(Clone, Default)]
-        pub(super) struct Recorder(Arc<Mutex<Vec<(String, String)>>>);
+        type Sink = Arc<Mutex<Vec<(String, String)>>>;
 
-        impl Recorder {
-            pub(super) fn value(&self, field: &str) -> Option<String> {
-                self.0
-                    .lock()
-                    .unwrap()
-                    .iter()
-                    .rev()
-                    .find(|(name, _)| name == field)
-                    .map(|(_, value)| value.clone())
+        thread_local! {
+            static SINK: RefCell<Option<Sink>> = const { RefCell::new(None) };
+        }
+
+        struct Global;
+
+        impl Global {
+            fn collect(f: impl FnOnce(&mut Vec<(String, String)>)) {
+                SINK.with(|sink| {
+                    if let Some(sink) = sink.borrow().as_ref() {
+                        f(&mut sink.lock().unwrap());
+                    }
+                });
             }
+        }
+
+        impl Subscriber for Global {
+            /// Always true, so callsite interest is never cached as `never`.
+            fn enabled(&self, _: &Metadata<'_>) -> bool {
+                true
+            }
+            fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+                Self::collect(|fields| attrs.record(&mut Collect(fields)));
+                Id::from_u64(1)
+            }
+            fn record(&self, _: &Id, values: &Record<'_>) {
+                Self::collect(|fields| values.record(&mut Collect(fields)));
+            }
+            fn record_follows_from(&self, _: &Id, _: &Id) {}
+            fn event(&self, _: &Event<'_>) {}
+            fn enter(&self, _: &Id) {}
+            fn exit(&self, _: &Id) {}
         }
 
         struct Collect<'a>(&'a mut Vec<(String, String)>);
@@ -583,29 +628,46 @@ mod tests {
             }
         }
 
-        impl Subscriber for Recorder {
-            fn enabled(&self, _: &Metadata<'_>) -> bool {
-                true
+        pub(super) struct Recorder(Sink);
+
+        impl Recorder {
+            /// Start recording spans raised on this thread.
+            pub(super) fn install() -> Self {
+                static INIT: Once = Once::new();
+                INIT.call_once(|| {
+                    let _ = tracing::subscriber::set_global_default(Global);
+                });
+                let sink: Sink = Arc::new(Mutex::new(Vec::new()));
+                SINK.with(|slot| *slot.borrow_mut() = Some(Arc::clone(&sink)));
+                Self(sink)
             }
-            fn new_span(&self, attrs: &Attributes<'_>) -> Id {
-                attrs.record(&mut Collect(&mut self.0.lock().unwrap()));
-                Id::from_u64(1)
+
+            pub(super) fn dump(&self) -> String {
+                format!("{:?}", self.0.lock().unwrap())
             }
-            fn record(&self, _: &Id, values: &Record<'_>) {
-                values.record(&mut Collect(&mut self.0.lock().unwrap()));
+
+            pub(super) fn value(&self, field: &str) -> Option<String> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .rev()
+                    .find(|(name, _)| name == field)
+                    .map(|(_, value)| value.clone())
             }
-            fn record_follows_from(&self, _: &Id, _: &Id) {}
-            fn event(&self, _: &Event<'_>) {}
-            fn enter(&self, _: &Id) {}
-            fn exit(&self, _: &Id) {}
+        }
+
+        impl Drop for Recorder {
+            fn drop(&mut self) {
+                SINK.with(|slot| *slot.borrow_mut() = None);
+            }
         }
     }
 
     #[cfg(unix)]
     #[tokio::test]
     async fn span_records_the_subcommand_and_a_clean_outcome() {
-        let recorder = recorder::Recorder::default();
-        let _guard = tracing::subscriber::set_default(recorder.clone());
+        let recorder = recorder::Recorder::install();
 
         let codex = Codex::builder()
             .binary("/bin/echo")
@@ -624,8 +686,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn span_does_not_carry_the_prompt() {
-        let recorder = recorder::Recorder::default();
-        let _guard = tracing::subscriber::set_default(recorder.clone());
+        let recorder = recorder::Recorder::install();
 
         let codex = Codex::builder()
             .binary("/bin/echo")
@@ -651,8 +712,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn a_cancelled_run_is_recorded_as_cancelled() {
-        let recorder = recorder::Recorder::default();
-        let _guard = tracing::subscriber::set_default(recorder.clone());
+        let recorder = recorder::Recorder::install();
 
         let pid_file = crate::test_support::PidFile::new("span-cancel");
         let codex = crate::test_support::blocking_codex(&pid_file)
@@ -666,7 +726,12 @@ mod tests {
         .await;
         assert!(cancelled.is_err(), "the run should still have been going");
 
-        assert_eq!(recorder.value("outcome").as_deref(), Some("cancelled"));
+        assert_eq!(
+            recorder.value("outcome").as_deref(),
+            Some("cancelled"),
+            "recorded: {}",
+            recorder.dump()
+        );
     }
 
     /// A wrapper timeout is its own outcome, distinct from a caller
@@ -674,8 +739,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn a_timed_out_run_is_recorded_as_timeout() {
-        let recorder = recorder::Recorder::default();
-        let _guard = tracing::subscriber::set_default(recorder.clone());
+        let recorder = recorder::Recorder::install();
 
         let pid_file = crate::test_support::PidFile::new("span-timeout");
         let codex = crate::test_support::blocking_codex(&pid_file)
@@ -687,5 +751,105 @@ mod tests {
         assert!(matches!(result, Err(Error::Timeout { .. })), "{result:?}");
 
         assert_eq!(recorder.value("outcome").as_deref(), Some("timeout"));
+    }
+
+    // -----------------------------------------------------------------
+    // Classification end to end (#85)
+    // -----------------------------------------------------------------
+
+    #[cfg(unix)]
+    fn failing_codex(case: &str) -> Codex {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-failure.sh");
+        Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .env("CODEX_WRAPPER_TEST_FAILURE", case)
+            .build()
+            .expect("bash must exist")
+    }
+
+    /// Classification has to happen on the spawn path, not only in the
+    /// constructor, or a caller still gets a bare CommandFailed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_real_spawn_returns_a_classified_error() {
+        use crate::error::FailureKind;
+
+        for (case, expected) in [
+            ("auth", FailureKind::Auth),
+            ("not-trusted", FailureKind::NotTrustedDirectory),
+            ("config", FailureKind::Config),
+            ("session", FailureKind::SessionNotFound),
+            ("mystery", FailureKind::Unclassified),
+        ] {
+            let codex = failing_codex(case);
+            let err = run_codex(&codex, vec!["exec".into()]).await.unwrap_err();
+            assert_eq!(err.failure_kind(), Some(expected), "case {case}: {err}");
+        }
+    }
+
+    /// A deterministic failure must not be retried even when its exit code is
+    /// on the retry list. Re-running gets the same rejection, and the auth
+    /// case has already been retried inside the CLI before it reaches here.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_classified_failure_is_not_retried() {
+        let policy = crate::retry::RetryPolicy::new()
+            .max_attempts(3)
+            .initial_backoff(Duration::from_millis(1))
+            .retry_on_exit_codes([1]);
+
+        let started = Instant::now();
+        let codex = failing_codex("auth");
+        let err = run_codex_with_retry(&codex, vec!["exec".into()], Some(&policy))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::Auth { .. }), "{err}");
+        // Three attempts with backoff would be visibly slower; this asserts
+        // the shape rather than the timing, but the timing corroborates it.
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "looks like it retried: {:?}",
+            started.elapsed()
+        );
+    }
+
+    /// An unclassified failure keeps the old retry behaviour.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn an_unclassified_failure_still_retries() {
+        let policy = crate::retry::RetryPolicy::new()
+            .max_attempts(2)
+            .initial_backoff(Duration::from_millis(1))
+            .retry_on_exit_codes([1]);
+
+        let codex = failing_codex("mystery");
+        let err = run_codex_with_retry(&codex, vec!["exec".into()], Some(&policy))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::CommandFailed { .. }), "{err}");
+    }
+
+    /// The allow-list works on the exit code, so it still applies to a
+    /// failure that classification moved off CommandFailed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn allowed_exit_codes_still_apply_to_a_classified_failure() {
+        let codex = failing_codex("auth");
+        let output = run_codex_allow_exit_codes(&codex, vec!["exec".into()], &[1])
+            .await
+            .expect("exit code 1 was allowed");
+
+        assert_eq!(output.exit_code, 1);
+        assert!(!output.success);
+        assert!(
+            output.stderr.contains("401 Unauthorized"),
+            "{}",
+            output.stderr
+        );
     }
 }

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -207,7 +207,7 @@ pub use command::sandbox::SandboxCommand;
 pub use command::session_mgmt::{ArchiveCommand, DeleteCommand, UnarchiveCommand};
 pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;
-pub use error::{Error, Result};
+pub use error::{Error, FailureKind, Result};
 pub use exec::CommandOutput;
 pub use retry::{BackoffStrategy, RetryPolicy};
 #[cfg(feature = "json")]

--- a/crates/codex-wrapper/src/retry.rs
+++ b/crates/codex-wrapper/src/retry.rs
@@ -126,6 +126,11 @@ impl RetryPolicy {
     pub(crate) fn should_retry(&self, error: &Error) -> bool {
         match error {
             Error::Timeout { .. } => self.retry_on_timeout,
+            // A classified failure is a deterministic rejection: bad
+            // credentials, a rejected config, an untrusted directory, a
+            // session that does not exist. Re-running gets the same answer,
+            // so these are never retried even when the exit code is listed.
+            _ if error.is_deterministic_failure() => false,
             Error::CommandFailed { exit_code, .. } => self.retry_exit_codes.contains(exit_code),
             _ => false,
         }

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -209,13 +209,13 @@ where
         let exit_code = status.code().unwrap_or(-1);
         if !status.success() {
             outcome.settle("failed", Some(exit_code));
-            return Err(Error::CommandFailed {
-                command: format!("{} {}", codex.binary.display(), command_args.join(" ")),
+            return Err(Error::from_command_failure(
+                format!("{} {}", codex.binary.display(), command_args.join(" ")),
                 exit_code,
-                stdout: String::new(),
-                stderr: stderr_output,
-                working_dir: codex.working_dir.clone(),
-            });
+                String::new(),
+                stderr_output,
+                codex.working_dir.clone(),
+            ));
         }
 
         outcome.settle("ok", Some(exit_code));

--- a/crates/codex-wrapper/tests/fake-codex-failure.sh
+++ b/crates/codex-wrapper/tests/fake-codex-failure.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fake codex that reproduces a real failure signature on stderr and exits 1.
+#
+# Each message is transcribed from a captured `codex-cli` 0.145.0 run, with
+# the varying parts (request ids, cf-ray headers, paths) kept so the matching
+# is exercised against the shape the CLI really emits, not a tidied version.
+#
+# Selected by CODEX_WRAPPER_TEST_FAILURE. Every one of these exits 1: the exit
+# code carries no information, which is why classification reads stderr.
+case "$CODEX_WRAPPER_TEST_FAILURE" in
+  auth)
+    echo "ERROR: Reconnecting... 5/5" >&2
+    echo "ERROR: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: a272310168bcba62-SJC, request id: req_ef11f9069ab546a5ab970d005756b2bc" >&2
+    ;;
+  not-trusted)
+    echo "Not inside a trusted directory and --skip-git-repo-check was not specified." >&2
+    ;;
+  config)
+    echo "Error loading config.toml: unknown configuration field \`bogus\` in -c/--config override" >&2
+    ;;
+  session)
+    echo "Error: thread/resume: thread/resume failed: no rollout found for thread id 00000000-0000-0000-0000-000000000000 (code -32600)" >&2
+    ;;
+  *)
+    echo "some failure nobody has classified" >&2
+    ;;
+esac
+exit 1


### PR DESCRIPTION
Closes #85.

## Enumerated the real signatures first

Task one on the issue is enumerating what the CLI actually does. Captured four failing runs of `codex-cli` 0.145.0, all of which fail before any model call:

| Failure | exit | stderr signature |
|---|---|---|
| no credentials | 1 | `unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, ... cf-ray: ..., request id: ...` |
| untrusted directory | 1 | `Not inside a trusted directory and --skip-git-repo-check was not specified.` |
| unknown key, `--strict-config` | 1 | `Error loading config.toml: unknown configuration field \`bogus\` in -c/--config override` |
| resume of an unknown thread | 1 | `Error: thread/resume: ... no rollout found for thread id ... (code -32600)` |

Two things follow from that table.

**Every one exits 1**, and stdout is empty in all four. The exit code carries no information, so classification has to read stderr. That is the cost the issue anticipates: it makes this sensitive to the CLI rewording a message. Matching is on the stable fragment of each, since the auth line carries a request id and a `cf-ray` header that differ every run.

**claude's variants do not map.** `MaxTurnsExceeded` and `MaxBudgetExceeded` have no codex analogue, because the CLI has no turn or budget caps to exceed. Added the four classes codex actually produces instead of importing claude's.

## What landed

`Error::from_command_failure` classifies, and both spawn paths go through it so it cannot be bypassed. Unrecognised failures stay `Error::CommandFailed` with stdout and stderr intact, so classification never loses information. Classified variants keep the whole of stderr rather than just the matched line.

Three accessors: `failure_kind()` for matching without destructuring, `exit_code()`, and `is_deterministic_failure()`.

## Two behaviour changes worth review

**Classified failures are never retried**, even when their exit code is on a policy's list. Each is a deterministic rejection, and the CLI has already retried the auth case internally (the captured stderr shows `Reconnecting... 5/5` before it gives up). A policy listing exit code 1 previously retried these; now it does not. Tested both ways.

**Anything reading an exit code must use `exit_code()`**, not match `CommandFailed`. `run_codex_allow_exit_codes` would otherwise have silently stopped honouring its allow-list for classified failures. Fixed, with a test.

## Fixes a flaky test from #63

While testing this I hit a failure in `a_cancelled_run_is_recorded_as_cancelled`, about one run in three. Not caused by this change: it is a defect in the test harness I added in #63, now on `main`.

The recorder installed itself with a thread-local `set_default`, but tracing caches callsite interest **globally**. A test running concurrently against no subscriber caches this crate's span callsites as `never`, and the recording test then sees nothing at all, which is what `recorded: []` in the failure output showed. The recorder is now a single always-enabled global subscriber fanning out to a per-thread sink, so interest stays stable and tests stay isolated. Six consecutive clean runs where it previously failed one in three.

## Local checks

fmt, clippy `-D warnings`, 180 lib tests all-features, 124 no-default-features, 21 doc tests, rustdoc `-D warnings`, both test binaries compile.