### PR TITLE
feat(config): read-side access to ~/.codex/config.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Build without default features
         run: cargo build --no-default-features
 
+      # `config` is off by default, so --all-features is the only job that
+      # compiles it. This checks it also stands alone, without `json`.
+      - name: Build the config feature alone
+        run: cargo build --no-default-features --features config
+
       - name: Unit tests
         run: cargo test --lib --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,16 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "which",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -40,6 +47,22 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -192,6 +215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +320,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +424,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -563,6 +563,36 @@ Global args precede the subcommand, the same order the spawn uses, because the p
 spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
 pasted, but no shell is involved at spawn time: args go to the process directly.
 
+## Reading config.toml
+
+Behind the optional `config` feature, since it pulls in a TOML parser:
+
+```toml
+codex-wrapper = { version = "0.2", features = ["config"] }
+```
+
+```rust
+if let Some(config) = codex.config()? {
+    println!("model:    {:?}", config.model);
+    println!("profiles: {:?}", config.profiles);
+    println!("anything else: {:?}", config.raw.get("personality"));
+}
+```
+
+This matters more than it used to: `approval_policy` and `web_search` moved from `exec` flags to
+config keys in 0.145.0, so config is where some behavior is now decided.
+
+Only the keys the wrapper has a reason to know about are typed (`model`, `approval_policy`,
+`sandbox_mode`, `web_search`, `[features]`, `[projects]` trust levels). Everything else stays in
+`raw`, because modelling the whole file would mean tracking a schema that changes every release.
+
+**Profiles are files, not a table.** `--profile <name>` layers `$CODEX_HOME/<name>.config.toml`
+over the base config, so `profiles` lists those files. A `[profiles]` table is the legacy
+mechanism the CLI no longer writes; it is reported separately as `legacy_profiles` rather than
+mixed in.
+
+A missing `config.toml` is `Ok(None)`, not an error. A malformed one is `Error::ConfigParse`.
+
 ## Auth Pre-flight
 
 Check which credential the CLI would use, synchronously, without spawning it:
@@ -719,6 +749,7 @@ let output = RawCommand::new("cloud")
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `json` | Yes | JSONL output parsing via `serde_json` -- enables `execute_json_lines()`, `execute_json()`, `stream()`, `Session`, `QueryResult`, `JsonLineEvent` and typed accessors |
+| `config` | No | Read `~/.codex/config.toml` via the `toml` crate -- enables `codex.config()` and the `config` module |
 
 To disable default features:
 

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -19,10 +19,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["json"]
 json = ["serde_json"]
+# Read-side access to ~/.codex/config.toml. Optional so the default
+# dependency list stays short: a caller that never reads config pays nothing.
+config = ["dep:toml"]
 
 [dependencies]
 serde = { workspace = true }
 serde_json = { version = "1", optional = true }
+toml = { version = "1", optional = true, default-features = false, features = ["parse", "serde", "std"] }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["process", "time", "io-util", "macros"] }
 tracing = { workspace = true }

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -563,6 +563,36 @@ Global args precede the subcommand, the same order the spawn uses, because the p
 spawn paths share one assembly function. The output is quoted for a POSIX shell so it can be
 pasted, but no shell is involved at spawn time: args go to the process directly.
 
+## Reading config.toml
+
+Behind the optional `config` feature, since it pulls in a TOML parser:
+
+```toml
+codex-wrapper = { version = "0.2", features = ["config"] }
+```
+
+```rust
+if let Some(config) = codex.config()? {
+    println!("model:    {:?}", config.model);
+    println!("profiles: {:?}", config.profiles);
+    println!("anything else: {:?}", config.raw.get("personality"));
+}
+```
+
+This matters more than it used to: `approval_policy` and `web_search` moved from `exec` flags to
+config keys in 0.145.0, so config is where some behavior is now decided.
+
+Only the keys the wrapper has a reason to know about are typed (`model`, `approval_policy`,
+`sandbox_mode`, `web_search`, `[features]`, `[projects]` trust levels). Everything else stays in
+`raw`, because modelling the whole file would mean tracking a schema that changes every release.
+
+**Profiles are files, not a table.** `--profile <name>` layers `$CODEX_HOME/<name>.config.toml`
+over the base config, so `profiles` lists those files. A `[profiles]` table is the legacy
+mechanism the CLI no longer writes; it is reported separately as `legacy_profiles` rather than
+mixed in.
+
+A missing `config.toml` is `Ok(None)`, not an error. A malformed one is `Error::ConfigParse`.
+
 ## Auth Pre-flight
 
 Check which credential the CLI would use, synchronously, without spawning it:
@@ -719,6 +749,7 @@ let output = RawCommand::new("cloud")
 | Feature | Default | Description |
 |---------|---------|-------------|
 | `json` | Yes | JSONL output parsing via `serde_json` -- enables `execute_json_lines()`, `execute_json()`, `stream()`, `Session`, `QueryResult`, `JsonLineEvent` and typed accessors |
+| `config` | No | Read `~/.codex/config.toml` via the `toml` crate -- enables `codex.config()` and the `config` module |
 
 To disable default features:
 

--- a/crates/codex-wrapper/src/auth.rs
+++ b/crates/codex-wrapper/src/auth.rs
@@ -133,9 +133,7 @@ pub fn detect_in(codex_home: impl AsRef<Path>) -> AuthStatus {
 /// testable without mutating global state, which would make the tests race
 /// each other.
 pub(crate) fn detect_with(env: impl Fn(&str) -> Option<String>) -> AuthStatus {
-    let codex_home = env("CODEX_HOME")
-        .filter(|value| !value.is_empty())
-        .map_or_else(|| default_codex_home(&env), PathBuf::from);
+    let codex_home = crate::codex_home::resolve(&env);
     let auth_file = codex_home.join("auth.json");
 
     let vars: Vec<&'static str> = AUTH_ENV_VARS
@@ -182,17 +180,6 @@ fn read_stored_mode(auth_file: &Path) -> Option<Option<String>> {
         return None;
     }
     Some(mode)
-}
-
-/// `$HOME/.codex`, the CLI's default.
-///
-/// Reads `HOME` through the same injected lookup as everything else, so a
-/// test never depends on the machine it runs on.
-fn default_codex_home(env: &impl Fn(&str) -> Option<String>) -> PathBuf {
-    env("HOME").filter(|home| !home.is_empty()).map_or_else(
-        || PathBuf::from(".codex"),
-        |home| Path::new(&home).join(".codex"),
-    )
 }
 
 #[cfg(test)]

--- a/crates/codex-wrapper/src/codex_home.rs
+++ b/crates/codex-wrapper/src/codex_home.rs
@@ -1,0 +1,64 @@
+//! Resolving `CODEX_HOME`, shared by the read-side modules.
+//!
+//! Both [`crate::auth`] and [`crate::config`] look inside the CLI's home
+//! directory, and they have to agree on where it is. They also each sit behind
+//! a different feature, so this lives on its own rather than in either.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve the CLI's home directory over an injected environment lookup.
+///
+/// `CODEX_HOME` when set and non-empty, otherwise `$HOME/.codex`.
+///
+/// The lookup is injected rather than read from the process so callers and
+/// tests can supply their own environment without mutating global state.
+pub(crate) fn resolve(env: &impl Fn(&str) -> Option<String>) -> PathBuf {
+    if let Some(home) = env("CODEX_HOME").filter(|value| !value.is_empty()) {
+        return PathBuf::from(home);
+    }
+    env("HOME").filter(|home| !home.is_empty()).map_or_else(
+        || PathBuf::from(".codex"),
+        |home| Path::new(&home).join(".codex"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_home_wins_when_set() {
+        let home = resolve(&|key| match key {
+            "CODEX_HOME" => Some("/somewhere/else".into()),
+            "HOME" => Some("/home/someone".into()),
+            _ => None,
+        });
+        assert_eq!(home, PathBuf::from("/somewhere/else"));
+    }
+
+    #[test]
+    fn falls_back_to_the_user_home() {
+        let home = resolve(&|key| match key {
+            "HOME" => Some("/home/someone".into()),
+            _ => None,
+        });
+        assert_eq!(home, PathBuf::from("/home/someone/.codex"));
+    }
+
+    /// An empty value is not a path. Treating it as one would resolve the home
+    /// to the filesystem root.
+    #[test]
+    fn an_empty_codex_home_is_ignored() {
+        let home = resolve(&|key| match key {
+            "CODEX_HOME" => Some(String::new()),
+            "HOME" => Some("/home/someone".into()),
+            _ => None,
+        });
+        assert_eq!(home, PathBuf::from("/home/someone/.codex"));
+    }
+
+    #[test]
+    fn a_relative_default_when_nothing_is_set() {
+        assert_eq!(resolve(&|_| None), PathBuf::from(".codex"));
+    }
+}

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -178,6 +178,9 @@ impl ExecCommand {
 
     /// The prompt to write to the child's stdin, if this command sends it
     /// there. `None` when the prompt travels in argv.
+    ///
+    /// Only the streaming path needs this, and that path is `json`-gated.
+    #[cfg(feature = "json")]
     pub(crate) fn stdin_prompt(&self) -> Option<&str> {
         self.prompt_via_stdin
             .then(|| self.prompt.as_deref().unwrap_or_default())

--- a/crates/codex-wrapper/src/config.rs
+++ b/crates/codex-wrapper/src/config.rs
@@ -1,0 +1,330 @@
+//! Read-side access to `$CODEX_HOME/config.toml`.
+//!
+//! Requires the `config` feature, which is off by default: it pulls in a TOML
+//! parser, and a caller that never reads config should not pay for one.
+//!
+//! This matters more than it used to. Several `exec` options moved from flags
+//! to config keys in 0.145.0 (`approval_policy`, `web_search`), so config is
+//! where some behavior is now decided, and a host reporting or overriding
+//! effective settings would otherwise parse the file itself.
+//!
+//! # What is typed and what is not
+//!
+//! Only the keys this wrapper has a reason to know about are typed. Everything
+//! else stays in [`CodexConfig::raw`] as parsed TOML. Modelling the whole file
+//! would mean tracking a schema that changes every release, and a key this
+//! crate cannot name is not a key it should hide.
+//!
+//! # Profiles are files, not a table
+//!
+//! Verified against `codex-cli` 0.145.0: `--profile <name>` layers
+//! `$CODEX_HOME/<name>.config.toml` over the base config, so the available
+//! profiles are the `*.config.toml` files in the home directory.
+//!
+//! A `[profiles]` table in `config.toml` is the legacy mechanism. The CLI now
+//! refuses to write one, reporting that it "contains legacy config profile
+//! tables and can no longer be written". Any such table is reported separately
+//! as [`CodexConfig::legacy_profiles`] rather than mixed in with the real ones.
+//!
+//! # Example
+//!
+//! ```no_run
+//! # fn example() -> codex_wrapper::Result<()> {
+//! if let Some(config) = codex_wrapper::config::load()? {
+//!     println!("model:    {:?}", config.model);
+//!     println!("profiles: {:?}", config.profiles);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+/// The parsed contents of `config.toml`, plus the profiles beside it.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct CodexConfig {
+    /// The file this was read from.
+    pub path: PathBuf,
+
+    /// Default model (`model`).
+    pub model: Option<String>,
+    /// When the model asks for approval (`approval_policy`).
+    pub approval_policy: Option<String>,
+    /// Sandbox policy (`sandbox_mode`).
+    pub sandbox_mode: Option<String>,
+    /// Web search mode (`web_search`).
+    pub web_search: Option<String>,
+
+    /// Feature flags under `[features]`, for the ones with boolean values.
+    pub features: BTreeMap<String, bool>,
+
+    /// Per-directory trust, from `[projects."<path>"]` tables.
+    ///
+    /// This is what decides the `Not inside a trusted directory` refusal that
+    /// [`crate::Error::NotTrustedDirectory`] classifies.
+    pub project_trust: BTreeMap<String, String>,
+
+    /// Profile names, from the `<name>.config.toml` files beside this one.
+    pub profiles: Vec<String>,
+
+    /// Names from a legacy `[profiles]` table, if the file still has one.
+    ///
+    /// The CLI no longer writes these. Present so an old config is visible
+    /// rather than silently ignored.
+    pub legacy_profiles: Vec<String>,
+
+    /// Everything in the file, including the keys typed above.
+    pub raw: toml::Table,
+}
+
+/// Read the config for the current environment.
+///
+/// `Ok(None)` when there is no `config.toml`, which is a normal state rather
+/// than an error. `Err` only when a file exists and cannot be read or parsed.
+pub fn load() -> Result<Option<CodexConfig>> {
+    let home = crate::codex_home::resolve(&|key| std::env::var(key).ok());
+    load_from_home(home)
+}
+
+/// [`load`], but against an explicit `CODEX_HOME`.
+pub fn load_from_home(codex_home: impl AsRef<Path>) -> Result<Option<CodexConfig>> {
+    let home = codex_home.as_ref();
+    let path = home.join("config.toml");
+
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(Error::Io {
+                message: format!("failed to read {}: {e}", path.display()),
+                source: e,
+                working_dir: Some(home.to_path_buf()),
+            });
+        }
+    };
+
+    let raw: toml::Table = contents
+        .parse::<toml::Table>()
+        .map_err(|e| Error::ConfigParse {
+            path: path.clone(),
+            message: e.to_string(),
+        })?;
+
+    Ok(Some(CodexConfig {
+        model: string_at(&raw, "model"),
+        approval_policy: string_at(&raw, "approval_policy"),
+        sandbox_mode: string_at(&raw, "sandbox_mode"),
+        web_search: string_at(&raw, "web_search"),
+        features: bool_table(&raw, "features"),
+        project_trust: project_trust(&raw),
+        profiles: profile_files(home),
+        legacy_profiles: table_keys(&raw, "profiles"),
+        raw,
+        path,
+    }))
+}
+
+fn string_at(table: &toml::Table, key: &str) -> Option<String> {
+    table.get(key)?.as_str().map(str::to_string)
+}
+
+fn bool_table(table: &toml::Table, key: &str) -> BTreeMap<String, bool> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_table)
+        .map(|features| {
+            features
+                .iter()
+                .filter_map(|(name, value)| Some((name.clone(), value.as_bool()?)))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn table_keys(table: &toml::Table, key: &str) -> Vec<String> {
+    table
+        .get(key)
+        .and_then(toml::Value::as_table)
+        .map(|inner| inner.keys().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// `[projects."<path>"] trust_level = "..."` flattened to path and level.
+fn project_trust(table: &toml::Table) -> BTreeMap<String, String> {
+    table
+        .get("projects")
+        .and_then(toml::Value::as_table)
+        .map(|projects| {
+            projects
+                .iter()
+                .filter_map(|(path, value)| {
+                    let level = value.as_table()?.get("trust_level")?.as_str()?;
+                    Some((path.clone(), level.to_string()))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Profile names, from `<name>.config.toml` beside the base config.
+///
+/// An unreadable directory yields no profiles rather than an error: a missing
+/// profile list should not fail a config read.
+fn profile_files(home: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(home) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .filter_map(std::result::Result::ok)
+        .filter_map(|entry| {
+            let name = entry.file_name().into_string().ok()?;
+            // `config.toml` itself is the base, not a profile.
+            let stem = name.strip_suffix(".config.toml")?;
+            (!stem.is_empty()).then(|| stem.to_string())
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_home(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "codex-wrapper-config-{}-{label}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write(home: &Path, name: &str, contents: &str) {
+        std::fs::write(home.join(name), contents).unwrap();
+    }
+
+    #[test]
+    fn a_missing_config_is_not_an_error() {
+        let home = temp_home("missing");
+        assert_eq!(load_from_home(&home).unwrap(), None);
+    }
+
+    /// The key names and layout come from a real `~/.codex/config.toml`.
+    #[test]
+    fn reads_the_typed_keys() {
+        let home = temp_home("typed");
+        write(
+            &home,
+            "config.toml",
+            r#"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+web_search = "live"
+
+[features]
+web-search = true
+disabled-thing = false
+
+[projects."/Users/someone/a-repo"]
+trust_level = "trusted"
+"#,
+        );
+
+        let config = load_from_home(&home).unwrap().unwrap();
+        assert_eq!(config.model.as_deref(), Some("gpt-5.6-sol"));
+        assert_eq!(config.approval_policy.as_deref(), Some("on-request"));
+        assert_eq!(config.sandbox_mode.as_deref(), Some("workspace-write"));
+        assert_eq!(config.web_search.as_deref(), Some("live"));
+        assert_eq!(config.features.get("web-search"), Some(&true));
+        assert_eq!(config.features.get("disabled-thing"), Some(&false));
+        assert_eq!(
+            config
+                .project_trust
+                .get("/Users/someone/a-repo")
+                .map(String::as_str),
+            Some("trusted")
+        );
+    }
+
+    /// A key this crate does not model must stay reachable, or the reader
+    /// hides configuration from the host it is reporting for.
+    #[test]
+    fn untyped_keys_stay_in_raw() {
+        let home = temp_home("raw");
+        write(
+            &home,
+            "config.toml",
+            "model = \"m\"\npersonality = \"terse\"\nservice_tier = \"priority\"\n",
+        );
+
+        let config = load_from_home(&home).unwrap().unwrap();
+        assert_eq!(
+            config.raw.get("personality").and_then(toml::Value::as_str),
+            Some("terse")
+        );
+        // Typed keys are in raw too, so `raw` is the whole file.
+        assert!(config.raw.contains_key("model"));
+    }
+
+    /// Profiles are `<name>.config.toml` files, not a table. Verified against
+    /// 0.145.0, whose `--profile` help says it layers that file.
+    #[test]
+    fn profiles_come_from_the_files_beside_the_config() {
+        let home = temp_home("profiles");
+        write(&home, "config.toml", "model = \"base\"\n");
+        write(&home, "work.config.toml", "model = \"work-model\"\n");
+        write(
+            &home,
+            "personal.config.toml",
+            "model = \"personal-model\"\n",
+        );
+        // Not a profile: no `.config.toml` suffix.
+        write(&home, "notes.toml", "x = 1\n");
+
+        let config = load_from_home(&home).unwrap().unwrap();
+        assert_eq!(config.profiles, vec!["personal", "work"]);
+        assert!(config.legacy_profiles.is_empty());
+    }
+
+    /// The CLI refuses to write these now, so an old config still carrying
+    /// them should be visible rather than silently dropped.
+    #[test]
+    fn a_legacy_profiles_table_is_reported_separately() {
+        let home = temp_home("legacy");
+        write(
+            &home,
+            "config.toml",
+            "[profiles.old]\nmodel = \"legacy-model\"\n",
+        );
+
+        let config = load_from_home(&home).unwrap().unwrap();
+        assert_eq!(config.legacy_profiles, vec!["old"]);
+        assert!(
+            config.profiles.is_empty(),
+            "a legacy table is not a usable profile"
+        );
+    }
+
+    #[test]
+    fn a_malformed_config_is_an_error_not_a_silent_default() {
+        let home = temp_home("malformed");
+        write(&home, "config.toml", "this is not = = toml");
+
+        let err = load_from_home(&home).unwrap_err();
+        assert!(
+            matches!(err, Error::ConfigParse { .. }),
+            "expected a parse error, got: {err:?}"
+        );
+        // It never ran a command, so it must not look like a command failure.
+        assert_eq!(err.failure_kind(), None);
+        assert_eq!(err.exit_code(), None);
+    }
+}

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -99,6 +99,20 @@ pub enum Error {
         max_tokens: u64,
     },
 
+    /// A file on disk could not be parsed.
+    ///
+    /// Distinct from [`Error::Config`], which is the CLI rejecting a
+    /// configuration it was given. This one never ran a command, so it
+    /// carries no exit code and is not a [`FailureKind`].
+    #[cfg(feature = "config")]
+    #[error("failed to parse {}: {message}", path.display())]
+    ConfigParse {
+        /// The file that could not be parsed.
+        path: PathBuf,
+        /// The parser's message.
+        message: String,
+    },
+
     /// JSON parsing failed.
     #[cfg(feature = "json")]
     #[error("json parse error: {message}")]

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -166,7 +166,12 @@
 pub mod auth;
 #[cfg(feature = "json")]
 pub mod budget;
+// Only the read-side modules need it, and each sits behind its own feature.
+#[cfg(any(feature = "json", feature = "config"))]
+mod codex_home;
 pub mod command;
+#[cfg(feature = "config")]
+pub mod config;
 pub mod error;
 pub mod exec;
 pub mod retry;
@@ -211,6 +216,8 @@ pub use command::sandbox::SandboxCommand;
 pub use command::session_mgmt::{ArchiveCommand, DeleteCommand, UnarchiveCommand};
 pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;
+#[cfg(feature = "config")]
+pub use config::CodexConfig;
 pub use error::{Error, FailureKind, Result};
 pub use exec::CommandOutput;
 pub use retry::{BackoffStrategy, RetryPolicy};
@@ -277,6 +284,21 @@ impl Codex {
     }
 
     /// Query the installed Codex CLI version.
+    /// Read `config.toml` for this client's `CODEX_HOME`.
+    ///
+    /// `Ok(None)` when there is no config file. Requires the `config` feature.
+    /// See [`crate::config`] for what is typed and what stays raw.
+    #[cfg(feature = "config")]
+    pub fn config(&self) -> Result<Option<crate::config::CodexConfig>> {
+        let home = crate::codex_home::resolve(&|key| {
+            self.env
+                .get(key)
+                .cloned()
+                .or_else(|| std::env::var(key).ok())
+        });
+        crate::config::load_from_home(home)
+    }
+
     /// Which credential this client's CLI would use, without spawning it.
     ///
     /// Honors a `CODEX_HOME` set on this client via


### PR DESCRIPTION
Closes #58.

## The open question

The issue said to decide the TOML dependency before implementing. Decision was an optional dependency behind a `config` feature, off by default, matching the existing `json`/`serde_json` pattern. The default dependency list is unchanged and a caller that never reads config pays nothing.

```toml
codex-wrapper = { version = "0.2", features = ["config"] }
```

## Profiles are files, not a table

Verified against 0.145.0. `--profile <name>` layers `$CODEX_HOME/<name>.config.toml` over the base config, so the profile list comes from those files.

A `[profiles]` table is the legacy mechanism, and the CLI now refuses to write one: the binary carries the message "`profiles` contains legacy config profile tables and can no longer be written". So a legacy table is reported as `legacy_profiles`, separately, rather than mixed in with names that would actually work.

## What is typed

`model`, `approval_policy`, `sandbox_mode`, `web_search`, `[features]` booleans, and `[projects."<path>"] trust_level`. That last one is what decides the `Not inside a trusted directory` refusal classified in #85, so the two fit together.

Everything else stays in `raw`. Modelling the whole file means tracking a schema that changes every release, and a key this crate cannot name is not a key it should hide.

## Error::ConfigParse rather than reusing Error::Config

`Error::Config` is the CLI rejecting a configuration it was given, so it carries a command and an exit code. A file that failed to parse ran no command. Reusing it would have made `failure_kind()` report a command failure that never happened and `exit_code()` return `Some(0)`. The new variant carries the path and the parser's message, and a test asserts it is not a `FailureKind`.

## The new CI step earned itself

`config` is off by default, so `--all-features` was the only job compiling it. Added a step building the feature alone, which immediately caught dead code under that combination: `ExecCommand::stdin_prompt` is only used by the `json`-gated streaming path. Fixed by gating it.

`CODEX_HOME` resolution moved to a shared module, since `auth` and `config` sit behind different features and have to agree on where the home is.

## Local checks

Every CI command, in order: fmt, clippy `-D warnings`, build all-features, build no-default, build config-alone, 201 lib tests all-features, 124 no-default, both test binaries, 24 doc tests, rustdoc `-D warnings`.

## Noticed, not fixed

`tests/integration.rs` has no feature gates, so `cargo clippy --all-targets --no-default-features` fails to compile it. No CI job runs that combination, and it predates this change, so it is left alone. Worth its own issue if the no-default-features story should be airtight.