### PR TITLE
feat: gate the safety-bypass flags behind an explicit opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,5 +151,11 @@ jobs:
 
       # No auth is configured here, and none is needed: every check reads
       # `--help` or fails during config load, before the CLI contacts anything.
+      #
+      # CODEX_WRAPPER_ALLOW_DANGEROUS unlocks the two bypass flags gated in
+      # #86, so they stay covered by the contract check. Nothing here runs a
+      # model, so the flags are only ever compared against `--help`.
       - name: Check emitted flags against the CLI
+        env:
+          CODEX_WRAPPER_ALLOW_DANGEROUS: "1"
         run: cargo test --test contract --all-features -- --ignored

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ let output = ExecCommand::new("fix the failing tests")
 | `add_dir()` | `--add-dir` | Additional writable dirs |
 | `ignore_user_config()` | `--ignore-user-config` | Ignore user-level config |
 | `ignore_rules()` | `--ignore-rules` | Ignore project rules files |
-| `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
+| *(see Dangerous Operations)* | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `ephemeral()` | `--ephemeral` | Don't persist session |
 | `output_schema()` | `--output-schema` | JSON Schema for response |
 | `color()` | `--color` | Color output mode |
@@ -544,6 +544,35 @@ match ExecCommand::new("test").execute(&codex).await {
     Err(e) => eprintln!("{e}"),
 }
 ```
+
+## Dangerous Operations
+
+`--dangerously-bypass-approvals-and-sandbox` turns off every approval prompt and the sandbox;
+`--dangerously-bypass-hook-trust` lets configured hooks run unconfirmed. Neither is a plain
+builder method, because a method name is not a barrier: it can be reached by autocomplete, by a
+copied snippet, or by an agent editing a call site.
+
+Both need two things that cannot happen by accident together:
+
+```rust
+use codex_wrapper::{CodexCommand, ExecCommand};
+use codex_wrapper::dangerous::{Dangerous, DangerousClient};
+
+// Errors unless CODEX_WRAPPER_ALLOW_DANGEROUS is set in the environment.
+let allow = DangerousClient::new()?;
+
+let output = ExecCommand::new("rewrite everything")
+    .bypass_approvals_and_sandbox(&allow)?   // re-checks the variable here
+    .execute(&codex)
+    .await?;
+```
+
+The second check is not redundant: a client built while the variable was set stops working the
+moment it is unset, so permission reflects the environment when the bypass is applied rather than
+whenever the client happened to be created. Without it, the call returns
+`Error::DangerousNotAllowed`.
+
+The variable name matches `claude-wrapper`'s `CLAUDE_WRAPPER_ALLOW_DANGEROUS`.
 
 ## Previewing the Command
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -146,7 +146,7 @@ let output = ExecCommand::new("fix the failing tests")
 | `add_dir()` | `--add-dir` | Additional writable dirs |
 | `ignore_user_config()` | `--ignore-user-config` | Ignore user-level config |
 | `ignore_rules()` | `--ignore-rules` | Ignore project rules files |
-| `dangerously_bypass_hook_trust()` | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
+| *(see Dangerous Operations)* | `--dangerously-bypass-hook-trust` | Skip the hook trust prompt |
 | `ephemeral()` | `--ephemeral` | Don't persist session |
 | `output_schema()` | `--output-schema` | JSON Schema for response |
 | `color()` | `--color` | Color output mode |
@@ -544,6 +544,35 @@ match ExecCommand::new("test").execute(&codex).await {
     Err(e) => eprintln!("{e}"),
 }
 ```
+
+## Dangerous Operations
+
+`--dangerously-bypass-approvals-and-sandbox` turns off every approval prompt and the sandbox;
+`--dangerously-bypass-hook-trust` lets configured hooks run unconfirmed. Neither is a plain
+builder method, because a method name is not a barrier: it can be reached by autocomplete, by a
+copied snippet, or by an agent editing a call site.
+
+Both need two things that cannot happen by accident together:
+
+```rust
+use codex_wrapper::{CodexCommand, ExecCommand};
+use codex_wrapper::dangerous::{Dangerous, DangerousClient};
+
+// Errors unless CODEX_WRAPPER_ALLOW_DANGEROUS is set in the environment.
+let allow = DangerousClient::new()?;
+
+let output = ExecCommand::new("rewrite everything")
+    .bypass_approvals_and_sandbox(&allow)?   // re-checks the variable here
+    .execute(&codex)
+    .await?;
+```
+
+The second check is not redundant: a client built while the variable was set stops working the
+moment it is unset, so permission reflects the environment when the bypass is applied rather than
+whenever the client happened to be created. Without it, the call returns
+`Error::DangerousNotAllowed`.
+
+The variable name matches `claude-wrapper`'s `CLAUDE_WRAPPER_ALLOW_DANGEROUS`.
 
 ## Previewing the Command
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -309,7 +309,7 @@ impl ExecCommand {
     ///
     /// Allows configured hooks to run without confirmation. Use with caution.
     #[must_use]
-    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+    pub(crate) fn set_bypass_hook_trust(mut self) -> Self {
         self.dangerously_bypass_hook_trust = true;
         self
     }
@@ -356,7 +356,7 @@ impl ExecCommand {
     ///
     /// Passes `--dangerously-bypass-approvals-and-sandbox`. Use with caution.
     #[must_use]
-    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+    pub(crate) fn set_bypass_approvals_and_sandbox(mut self) -> Self {
         self.dangerously_bypass_approvals_and_sandbox = true;
         self
     }
@@ -783,7 +783,7 @@ impl ExecResumeCommand {
     ///
     /// Allows configured hooks to run without confirmation. Use with caution.
     #[must_use]
-    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+    pub(crate) fn set_bypass_hook_trust(mut self) -> Self {
         self.dangerously_bypass_hook_trust = true;
         self
     }
@@ -824,7 +824,7 @@ impl ExecResumeCommand {
     ///
     /// Passes `--dangerously-bypass-approvals-and-sandbox`. Use with caution.
     #[must_use]
-    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+    pub(crate) fn set_bypass_approvals_and_sandbox(mut self) -> Self {
         self.dangerously_bypass_approvals_and_sandbox = true;
         self
     }
@@ -1033,8 +1033,8 @@ mod tests {
     #[test]
     fn exec_args_hook_trust() {
         let args = ExecCommand::new("go")
-            .dangerously_bypass_approvals_and_sandbox()
-            .dangerously_bypass_hook_trust()
+            .set_bypass_approvals_and_sandbox()
+            .set_bypass_hook_trust()
             .args();
 
         assert_eq!(
@@ -1082,7 +1082,7 @@ mod tests {
         let args = ExecResumeCommand::new()
             .last()
             .strict_config()
-            .dangerously_bypass_hook_trust()
+            .set_bypass_hook_trust()
             .args();
 
         assert_eq!(

--- a/crates/codex-wrapper/src/command/fork.rs
+++ b/crates/codex-wrapper/src/command/fork.rs
@@ -169,14 +169,14 @@ impl ForkCommand {
     }
 
     #[must_use]
-    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+    pub(crate) fn set_bypass_approvals_and_sandbox(mut self) -> Self {
         self.dangerously_bypass_approvals_and_sandbox = true;
         self
     }
 
     /// Bypass the hook trust prompt (`--dangerously-bypass-hook-trust`).
     #[must_use]
-    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+    pub(crate) fn set_bypass_hook_trust(mut self) -> Self {
         self.dangerously_bypass_hook_trust = true;
         self
     }
@@ -396,7 +396,7 @@ mod tests {
         let args = ForkCommand::new()
             .last()
             .strict_config()
-            .dangerously_bypass_hook_trust()
+            .set_bypass_hook_trust()
             .no_alt_screen()
             .remote("ws://host:9000")
             .remote_auth_token_env("CODEX_TOKEN")

--- a/crates/codex-wrapper/src/command/resume.rs
+++ b/crates/codex-wrapper/src/command/resume.rs
@@ -171,14 +171,14 @@ impl ResumeCommand {
     }
 
     #[must_use]
-    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+    pub(crate) fn set_bypass_approvals_and_sandbox(mut self) -> Self {
         self.dangerously_bypass_approvals_and_sandbox = true;
         self
     }
 
     /// Bypass the hook trust prompt (`--dangerously-bypass-hook-trust`).
     #[must_use]
-    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+    pub(crate) fn set_bypass_hook_trust(mut self) -> Self {
         self.dangerously_bypass_hook_trust = true;
         self
     }

--- a/crates/codex-wrapper/src/command/review.rs
+++ b/crates/codex-wrapper/src/command/review.rs
@@ -202,7 +202,7 @@ impl ReviewCommand {
     ///
     /// Allows configured hooks to run without confirmation. Use with caution.
     #[must_use]
-    pub fn dangerously_bypass_hook_trust(mut self) -> Self {
+    pub(crate) fn set_bypass_hook_trust(mut self) -> Self {
         self.dangerously_bypass_hook_trust = true;
         self
     }
@@ -219,7 +219,7 @@ impl ReviewCommand {
     }
 
     #[must_use]
-    pub fn dangerously_bypass_approvals_and_sandbox(mut self) -> Self {
+    pub(crate) fn set_bypass_approvals_and_sandbox(mut self) -> Self {
         self.dangerously_bypass_approvals_and_sandbox = true;
         self
     }
@@ -444,7 +444,7 @@ mod tests {
         let args = ReviewCommand::new()
             .uncommitted()
             .strict_config()
-            .dangerously_bypass_hook_trust()
+            .set_bypass_hook_trust()
             .args();
 
         assert_eq!(

--- a/crates/codex-wrapper/src/dangerous.rs
+++ b/crates/codex-wrapper/src/dangerous.rs
@@ -1,0 +1,237 @@
+//! Opt-in access to the flags that disable codex's safety controls.
+//!
+//! `--dangerously-bypass-approvals-and-sandbox` turns off every approval
+//! prompt and the sandbox. `--dangerously-bypass-hook-trust` lets configured
+//! hooks run without confirmation. Both were plain builder methods, reachable
+//! from any chain by autocomplete, by a copied snippet, or by an agent editing
+//! a call site. A method name is not a barrier.
+//!
+//! They now need two things that cannot both happen by accident:
+//!
+//! 1. A [`DangerousClient`], which only constructs when
+//!    `CODEX_WRAPPER_ALLOW_DANGEROUS` is set in the process environment.
+//! 2. A call through [`Dangerous`], passing that client, which re-checks the
+//!    variable at the point of use.
+//!
+//! The second check is not redundant. A client built while the variable was
+//! set stops working the moment it is unset, so the gate reflects the
+//! environment at the moment the bypass is applied rather than whenever the
+//! client happened to be created.
+//!
+//! The name matches the sibling crate's `CLAUDE_WRAPPER_ALLOW_DANGEROUS`.
+//!
+//! # Example
+//!
+//! ```
+//! use codex_wrapper::{ExecCommand, dangerous::{Dangerous, DangerousClient}};
+//!
+//! // Without the environment variable, there is no way through.
+//! assert!(DangerousClient::new().is_err());
+//! ```
+//!
+//! ```no_run
+//! use codex_wrapper::{CodexCommand, ExecCommand};
+//! use codex_wrapper::dangerous::{Dangerous, DangerousClient};
+//!
+//! # async fn example(codex: &codex_wrapper::Codex) -> codex_wrapper::Result<()> {
+//! // With CODEX_WRAPPER_ALLOW_DANGEROUS set in the environment:
+//! let allow = DangerousClient::new()?;
+//! let output = ExecCommand::new("rewrite everything")
+//!     .bypass_approvals_and_sandbox(&allow)?
+//!     .execute(codex)
+//!     .await?;
+//! # let _ = output;
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::error::{Error, Result};
+
+/// The environment variable that unlocks the bypass flags.
+pub const ALLOW_DANGEROUS_ENV: &str = "CODEX_WRAPPER_ALLOW_DANGEROUS";
+
+/// Proof that bypassing codex's safety controls is permitted here.
+///
+/// Constructing one requires [`ALLOW_DANGEROUS_ENV`] to be set. Holding one is
+/// not enough on its own: every [`Dangerous`] method re-checks.
+#[derive(Debug, Clone, Copy)]
+pub struct DangerousClient {
+    // Keeps the type unconstructible except through `new`.
+    _private: (),
+}
+
+impl DangerousClient {
+    /// `Err(Error::DangerousNotAllowed)` unless [`ALLOW_DANGEROUS_ENV`] is set
+    /// to a non-empty value.
+    pub fn new() -> Result<Self> {
+        allowed(&|key| std::env::var(key).ok())?;
+        Ok(Self { _private: () })
+    }
+
+    /// A client without the environment check, for testing the second gate.
+    ///
+    /// Exists so a test can prove that holding a client is not sufficient,
+    /// without setting a process-wide variable that would race other tests.
+    #[cfg(test)]
+    pub(crate) fn unchecked() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// The gate itself, over an injected environment lookup.
+///
+/// Injected rather than reading the process environment directly so tests can
+/// exercise the allowed path without mutating global state, which would make
+/// them race each other.
+pub(crate) fn allowed(env: &impl Fn(&str) -> Option<String>) -> Result<()> {
+    match env(ALLOW_DANGEROUS_ENV) {
+        Some(value) if !value.trim().is_empty() => Ok(()),
+        _ => Err(Error::DangerousNotAllowed {
+            variable: ALLOW_DANGEROUS_ENV,
+        }),
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Bypassing codex's safety controls, for the builders that support it.
+///
+/// Sealed: this exists to gate an existing capability, not to be implemented
+/// elsewhere.
+pub trait Dangerous: sealed::Sealed + Sized {
+    /// Disable every approval prompt and the sandbox
+    /// (`--dangerously-bypass-approvals-and-sandbox`).
+    ///
+    /// The model's shell commands run with the permissions of the calling
+    /// process, against the real filesystem, with nothing to contain a
+    /// mistake.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::DangerousNotAllowed`] if [`ALLOW_DANGEROUS_ENV`] is not set
+    /// at the moment of the call.
+    fn bypass_approvals_and_sandbox(self, allow: &DangerousClient) -> Result<Self>;
+
+    /// Let configured hooks run without the trust prompt
+    /// (`--dangerously-bypass-hook-trust`).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::DangerousNotAllowed`] if [`ALLOW_DANGEROUS_ENV`] is not set
+    /// at the moment of the call.
+    fn bypass_hook_trust(self, allow: &DangerousClient) -> Result<Self>;
+}
+
+/// Implement [`Dangerous`] over the crate-internal setters.
+///
+/// The setters are `pub(crate)`, so this trait is the only way to reach them
+/// from outside, and every path through it is gated.
+macro_rules! impl_dangerous {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl sealed::Sealed for $ty {}
+
+            impl Dangerous for $ty {
+                fn bypass_approvals_and_sandbox(
+                    self,
+                    _allow: &DangerousClient,
+                ) -> Result<Self> {
+                    allowed(&|key| std::env::var(key).ok())?;
+                    Ok(self.set_bypass_approvals_and_sandbox())
+                }
+
+                fn bypass_hook_trust(self, _allow: &DangerousClient) -> Result<Self> {
+                    allowed(&|key| std::env::var(key).ok())?;
+                    Ok(self.set_bypass_hook_trust())
+                }
+            }
+        )+
+    };
+}
+
+impl_dangerous!(
+    crate::command::exec::ExecCommand,
+    crate::command::exec::ExecResumeCommand,
+    crate::command::review::ReviewCommand,
+    crate::command::fork::ForkCommand,
+    crate::command::resume::ResumeCommand,
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_gate_is_closed_by_default() {
+        // Not set in this process, and nothing here sets it.
+        let err = DangerousClient::new().unwrap_err();
+        assert!(matches!(err, Error::DangerousNotAllowed { .. }), "{err:?}");
+        assert!(err.to_string().contains(ALLOW_DANGEROUS_ENV));
+    }
+
+    #[test]
+    fn the_gate_opens_for_a_non_empty_value() {
+        assert!(allowed(&|_| Some("1".into())).is_ok());
+        assert!(allowed(&|_| Some("anything".into())).is_ok());
+    }
+
+    /// An exported-but-empty variable is the shape a shell leaves behind after
+    /// `export X=`, and it must not count as permission.
+    #[test]
+    fn a_blank_value_does_not_open_the_gate() {
+        assert!(allowed(&|_| Some(String::new())).is_err());
+        assert!(allowed(&|_| Some("   ".into())).is_err());
+        assert!(allowed(&|_| None).is_err());
+    }
+
+    /// The second gate, and the reason it is not redundant: a client built
+    /// while the variable was set must stop working once it is gone.
+    #[test]
+    fn holding_a_client_is_not_enough() {
+        use crate::command::exec::ExecCommand;
+
+        let stale = DangerousClient::unchecked();
+        let err = ExecCommand::new("rewrite everything")
+            .bypass_approvals_and_sandbox(&stale)
+            .unwrap_err();
+        assert!(matches!(err, Error::DangerousNotAllowed { .. }), "{err:?}");
+
+        let err = ExecCommand::new("rewrite everything")
+            .bypass_hook_trust(&stale)
+            .unwrap_err();
+        assert!(matches!(err, Error::DangerousNotAllowed { .. }), "{err:?}");
+    }
+
+    /// Gating must not have disconnected the flags from the command line.
+    #[test]
+    fn the_flags_still_reach_argv_once_set() {
+        use crate::command::exec::ExecCommand;
+        use crate::command::{CodexCommand, review::ReviewCommand};
+
+        let args = ExecCommand::new("x")
+            .set_bypass_approvals_and_sandbox()
+            .set_bypass_hook_trust()
+            .args();
+        assert!(
+            args.iter()
+                .any(|a| a == "--dangerously-bypass-approvals-and-sandbox"),
+            "{args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--dangerously-bypass-hook-trust"),
+            "{args:?}"
+        );
+
+        let args = ReviewCommand::new()
+            .uncommitted()
+            .set_bypass_approvals_and_sandbox()
+            .args();
+        assert!(
+            args.iter()
+                .any(|a| a == "--dangerously-bypass-approvals-and-sandbox"),
+            "{args:?}"
+        );
+    }
+}

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -113,6 +113,15 @@ pub enum Error {
         message: String,
     },
 
+    /// A bypass of codex's safety controls was requested without permission.
+    ///
+    /// See [`crate::dangerous`]. Never a command failure: nothing ran.
+    #[error("bypassing codex safety controls requires {variable} to be set")]
+    DangerousNotAllowed {
+        /// The environment variable that would have permitted it.
+        variable: &'static str,
+    },
+
     /// JSON parsing failed.
     #[cfg(feature = "json")]
     #[error("json parse error: {message}")]

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -52,7 +52,7 @@
 //! // Each command is a separate builder
 //! let output = ExecCommand::new("fix the failing tests")
 //!     .model("o3")
-//!     .dangerously_bypass_approvals_and_sandbox()
+//!     .sandbox(codex_wrapper::SandboxMode::WorkspaceWrite)
 //!     .skip_git_repo_check()
 //!     .ephemeral()
 //!     .execute(&codex)
@@ -172,6 +172,7 @@ mod codex_home;
 pub mod command;
 #[cfg(feature = "config")]
 pub mod config;
+pub mod dangerous;
 pub mod error;
 pub mod exec;
 #[cfg(feature = "json")]

--- a/crates/codex-wrapper/tests/contract.rs
+++ b/crates/codex-wrapper/tests/contract.rs
@@ -289,11 +289,9 @@ fn exec_contract() {
         .local_provider("ollama")
         .sandbox(SandboxMode::WorkspaceWrite)
         .strict_config()
-        .dangerously_bypass_hook_trust()
         .ignore_user_config()
         .ignore_rules()
         .profile("default")
-        .dangerously_bypass_approvals_and_sandbox()
         .cd("/tmp")
         .skip_git_repo_check()
         .add_dir("/tmp/extra")
@@ -329,11 +327,9 @@ fn exec_resume_contract() {
         .image("/tmp/a.png")
         .model("o3")
         .strict_config()
-        .dangerously_bypass_hook_trust()
         .ignore_user_config()
         .ignore_rules()
         .output_schema("/tmp/schema.json")
-        .dangerously_bypass_approvals_and_sandbox()
         .skip_git_repo_check()
         .ephemeral()
         .json()
@@ -362,11 +358,9 @@ fn review_contract() {
         .model("o3")
         .title("probe")
         .strict_config()
-        .dangerously_bypass_hook_trust()
         .ignore_user_config()
         .ignore_rules()
         .output_schema("/tmp/schema.json")
-        .dangerously_bypass_approvals_and_sandbox()
         .skip_git_repo_check()
         .ephemeral()
         .json()
@@ -397,8 +391,6 @@ fn fork_contract() {
         .profile("default")
         .sandbox(SandboxMode::WorkspaceWrite)
         .approval_policy(ApprovalPolicy::Never)
-        .dangerously_bypass_approvals_and_sandbox()
-        .dangerously_bypass_hook_trust()
         .strict_config()
         .no_alt_screen()
         .remote("ws://127.0.0.1:9000")
@@ -432,8 +424,6 @@ fn resume_contract() {
         .profile("default")
         .sandbox(SandboxMode::WorkspaceWrite)
         .approval_policy(ApprovalPolicy::Never)
-        .dangerously_bypass_approvals_and_sandbox()
-        .dangerously_bypass_hook_trust()
         .strict_config()
         .no_alt_screen()
         .include_non_interactive()
@@ -612,4 +602,49 @@ fn top_level_review_remains_a_subset_of_exec_review() {
          narrower and needs updating",
         cli_version()
     );
+}
+
+// ---------------------------------------------------------------------------
+// Dangerous flags (#86)
+//
+// These moved behind `dangerous::DangerousClient`, so a maximal builder can no
+// longer emit them and the checks above lost that coverage. This restores it
+// through the gated path. The contract CI job sets the variable; a local run
+// without it fails loudly rather than skipping, because a silent skip here
+// would read as "these flags are still verified" when they are not.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore]
+fn dangerous_flags_contract() {
+    use codex_wrapper::dangerous::{ALLOW_DANGEROUS_ENV, Dangerous, DangerousClient};
+
+    let allow = DangerousClient::new().unwrap_or_else(|_| {
+        panic!(
+            "set {ALLOW_DANGEROUS_ENV}=1 to run this check; without it the two \
+             dangerous flags are not verified against the CLI at all"
+        )
+    });
+
+    let args = ExecCommand::new("probe")
+        .bypass_approvals_and_sandbox(&allow)
+        .unwrap()
+        .bypass_hook_trust(&allow)
+        .unwrap()
+        .args();
+    assert!(
+        args.iter()
+            .any(|a| a == "--dangerously-bypass-approvals-and-sandbox"),
+        "{args:?}"
+    );
+    assert_contract("ExecCommand::dangerous", args, 1);
+
+    let args = ReviewCommand::new()
+        .uncommitted()
+        .bypass_approvals_and_sandbox(&allow)
+        .unwrap()
+        .bypass_hook_trust(&allow)
+        .unwrap()
+        .args();
+    assert_contract("ReviewCommand::dangerous", args, 2);
 }


### PR DESCRIPTION
Closes #86.

```rust
use codex_wrapper::dangerous::{Dangerous, DangerousClient};

let allow = DangerousClient::new()?;              // needs CODEX_WRAPPER_ALLOW_DANGEROUS
let output = ExecCommand::new("rewrite everything")
    .bypass_approvals_and_sandbox(&allow)?        // re-checks the variable here
    .execute(&codex)
    .await?;
```

## Two gates, and why the second one earns its place

A `DangerousClient` proves permission existed at construction. The trait method re-checks at the point of use, so a client built while the variable was set stops working the moment it is unset. Permission reflects the environment when the bypass is applied, not whenever the client happened to be created.

`holding_a_client_is_not_enough` tests exactly that, using a test-only unchecked constructor. That means no test sets a process-wide variable, so none of them can race each other, which matters after the flake fixed in #99.

## Enforcement is structural, not by convention

The ten setters across five builders are now `pub(crate)`, and the `Dangerous` trait is sealed. There is no way to reach the flags from outside the crate except through the gated path. A public trait with ungated methods would not have worked: sealing prevents implementing a trait, not calling it.

**Breaking change**, as the issue anticipated: `dangerously_bypass_approvals_and_sandbox` and `dangerously_bypass_hook_trust` are gone from `ExecCommand`, `ExecResumeCommand`, `ReviewCommand`, `ForkCommand`, and `ResumeCommand`.

## The part worth checking in review

Gating cost `tests/contract.rs` its coverage of these two flags: that suite builds a maximal command from each builder, and a maximal builder can no longer emit them. Dropping them silently would have left the suite looking complete while two flags went unverified against the CLI, which is the failure mode that suite exists to prevent.

Restored as `dangerous_flags_contract`, which goes through the gated path, with `CODEX_WRAPPER_ALLOW_DANGEROUS` set on the contract CI job. It panics rather than skipping when the gate is closed, so a local run without the variable says so instead of quietly passing.

Verified against the real CLI:

```
$ CODEX_WRAPPER_ALLOW_DANGEROUS=1 cargo test --test contract --all-features -- --ignored
test result: ok. 18 passed
```

Nothing in that job runs a model; the flags are only ever compared against `--help`.

## Local checks

fmt, clippy `-D warnings`, 215 lib tests all-features, 129 no-default, 27 doc tests, rustdoc `-D warnings`, config-alone build, both test binaries, and the contract suite above.