### PR TITLE
feat: typed accessors for stream items, and record the absent deltas

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ println!("tokens: {:?}", result.usage.and_then(|u| u.total()));
 `QueryResult` fields: `result`, `session_id`, `thread_id`, `usage`, and the
 full `events` stream as an escape hatch.
 
+### Typed accessors on events
+
+`JsonLineEvent` keeps every field in `extra`, with accessors for the ones worth naming:
+`session_id()`, `thread_id()`, `is_turn_completed()`, `is_turn_failed()`, `usage()`,
+`agent_message_text()`, `role()`, `content_text()`, `item_type()`, and `command_execution()`.
+
+**There are no incremental text deltas to consume.** Three captured runs, a one-word exec, a
+four-sentence exec, and a review, each delivered the whole assistant message in a single
+`item.completed`. The CLI emits no `item.updated` and no partial fields, and no flag changes
+that. So this crate has no equivalent of `claude-wrapper`'s `PartialMessageEvent`: streaming here
+delivers whole events as they arrive, not partial sentences.
+
 The CLI reports **token counts, not money**. There is no cost field to read.
 Converting tokens to dollars needs a per-model price table the CLI does not
 provide, so this crate does not guess at one.

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -200,6 +200,18 @@ println!("tokens: {:?}", result.usage.and_then(|u| u.total()));
 `QueryResult` fields: `result`, `session_id`, `thread_id`, `usage`, and the
 full `events` stream as an escape hatch.
 
+### Typed accessors on events
+
+`JsonLineEvent` keeps every field in `extra`, with accessors for the ones worth naming:
+`session_id()`, `thread_id()`, `is_turn_completed()`, `is_turn_failed()`, `usage()`,
+`agent_message_text()`, `role()`, `content_text()`, `item_type()`, and `command_execution()`.
+
+**There are no incremental text deltas to consume.** Three captured runs, a one-word exec, a
+four-sentence exec, and a review, each delivered the whole assistant message in a single
+`item.completed`. The CLI emits no `item.updated` and no partial fields, and no flag changes
+that. So this crate has no equivalent of `claude-wrapper`'s `PartialMessageEvent`: streaming here
+delivers whole events as they arrive, not partial sentences.
+
 The CLI reports **token counts, not money**. There is no cost field to read.
 Converting tokens to dollars needs a per-model price table the CLI does not
 provide, so this crate does not guess at one.

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -27,6 +27,14 @@
 //!   diff-reading steps arrive as `command_execution` items on the same event.
 //! - A review's `turn.completed` reports a usage object of all zeros.
 //!
+//! - The stream carries **no incremental text**. Three captured runs, a
+//!   one-word exec, a four-sentence exec, and a review, each delivered the
+//!   whole assistant message in a single `item.completed`. No `item.updated`,
+//!   no partial or delta fields, and `codex exec --help` has no flag that
+//!   changes output granularity. There is nothing to assemble, which is why
+//!   this module has no equivalent of `claude-wrapper`'s `PartialMessageEvent`
+//!   (#84).
+//!
 //! **Assumed**, still: nothing load-bearing.
 //! [`JsonLineEvent::agent_message_text`] also accepts an `item_type`
 //! discriminator and a `content` block array, neither of which has been seen
@@ -340,6 +348,43 @@ impl JsonLineEvent {
             .join("");
         if text.is_empty() { None } else { Some(text) }
     }
+
+    /// The `item` discriminator on an `item.*` event.
+    ///
+    /// `agent_message` and `command_execution` are the observed values. This
+    /// is the field to match on when narrowing an item event, and it is
+    /// present on `item.started` as well as `item.completed`.
+    ///
+    /// Accepts `item_type` as well as `type` for the same reason
+    /// [`agent_message_text`](Self::agent_message_text) does.
+    #[must_use]
+    pub fn item_type(&self) -> Option<&str> {
+        let item = self.extra.get("item")?;
+        item.get("type").or_else(|| item.get("item_type"))?.as_str()
+    }
+
+    /// A shell command the model ran, from a `command_execution` item.
+    ///
+    /// `None` for any other item. `exit_code` and `status` are only populated
+    /// on `item.completed`; an `item.started` for the same command carries the
+    /// command alone.
+    #[must_use]
+    pub fn command_execution(&self) -> Option<CommandExecution> {
+        if self.item_type()? != "command_execution" {
+            return None;
+        }
+        let item = self.extra.get("item")?;
+        let string = |key: &str| item.get(key).and_then(|v| v.as_str()).map(str::to_string);
+        Some(CommandExecution {
+            command: string("command"),
+            status: string("status"),
+            exit_code: item
+                .get("exit_code")
+                .and_then(serde_json::Value::as_i64)
+                .and_then(|code| i32::try_from(code).ok()),
+            aggregated_output: string("aggregated_output"),
+        })
+    }
 }
 
 /// A typed summary of a completed `codex exec` run, assembled from the JSONL
@@ -415,6 +460,24 @@ impl QueryResult {
             events,
         }
     }
+}
+
+/// A shell command the model ran, from a `command_execution` item.
+///
+/// Every field is optional: an `item.started` carries the command with no
+/// outcome yet, and the CLI has added fields to this item before.
+#[cfg(feature = "json")]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CommandExecution {
+    /// The command line, as the CLI recorded it.
+    pub command: Option<String>,
+    /// Reported status, `completed` being the observed value.
+    pub status: Option<String>,
+    /// Exit code, once the command has finished.
+    pub exit_code: Option<i32>,
+    /// Combined stdout and stderr, when the CLI included it.
+    pub aggregated_output: Option<String>,
 }
 
 /// Token counts reported on a completed turn.
@@ -853,5 +916,66 @@ mod tests {
         assert_eq!(result.result, "");
         assert_eq!(result.usage, None);
         assert_eq!(result.thread_id.as_deref(), Some("thread_2"));
+    }
+
+    /// Both values transcribed from captured runs.
+    #[cfg(feature = "json")]
+    #[test]
+    fn item_type_reads_the_discriminator() {
+        let message: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"hi"}}"#,
+        )
+        .unwrap();
+        assert_eq!(message.item_type(), Some("agent_message"));
+
+        let command: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"git diff"}}"#,
+        )
+        .unwrap();
+        assert_eq!(command.item_type(), Some("command_execution"));
+
+        let turn: JsonLineEvent = serde_json::from_str(r#"{"type":"turn.completed"}"#).unwrap();
+        assert_eq!(turn.item_type(), None);
+    }
+
+    /// Transcribed from a captured `codex exec review` run, where the reviewer
+    /// reads the diff before commenting.
+    #[cfg(feature = "json")]
+    #[test]
+    fn command_execution_reads_a_finished_command() {
+        let event: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"git diff","aggregated_output":"","exit_code":0,"status":"completed"}}"#,
+        )
+        .unwrap();
+
+        let command = event.command_execution().unwrap();
+        assert_eq!(command.command.as_deref(), Some("git diff"));
+        assert_eq!(command.exit_code, Some(0));
+        assert_eq!(command.status.as_deref(), Some("completed"));
+    }
+
+    /// An `item.started` has no outcome yet, and must not invent one.
+    #[cfg(feature = "json")]
+    #[test]
+    fn command_execution_tolerates_a_command_still_running() {
+        let event: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"git diff"}}"#,
+        )
+        .unwrap();
+
+        let command = event.command_execution().unwrap();
+        assert_eq!(command.command.as_deref(), Some("git diff"));
+        assert_eq!(command.exit_code, None);
+        assert_eq!(command.status, None);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn command_execution_is_none_for_other_items() {
+        let event: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"hi"}}"#,
+        )
+        .unwrap();
+        assert!(event.command_execution().is_none());
     }
 }


### PR DESCRIPTION
Refs #84, delivering the buildable half.

## The delta type is not here, and cannot be

The issue's headline ask is an equivalent of `claude-wrapper`'s `PartialMessageEvent` / `BlockType` / `BlockDelta`. Three captured runs of `codex-cli` 0.145.0 say there is nothing to put in it:

```
thread.started
turn.started
item.completed   item.type=agent_message   <- entire response, at once
turn.completed
```

A four-sentence prompt produced exactly one `item.completed`. No `item.updated`, no partial or delta fields anywhere, and `codex exec --help` has no flag that changes granularity.

So the gap the issue calls "the thing that blocks a shared streaming surface" is not in this wrapper. claude streams fragments because its CLI sends them; codex sends whole messages. A unified stream callback has to be defined at whole-event granularity, with claude's deltas as a claude-only extension. That is now recorded in the schema block in `types.rs` rather than left for someone to rediscover.

## What did land

The issue's accessor list was already covered by `session_id`, `thread_id`, `is_turn_completed`, `is_turn_failed`, `usage`, `agent_message_text`, `role`, and `content_text`. Two additions, both from captured output:

- **`item_type()`** reads the `item` discriminator (`agent_message`, `command_execution`), accepting `item_type` as well as `type` for the same reason `agent_message_text` does.
- **`command_execution()`** types the shell commands a review runs to read the diff, returning a `CommandExecution` whose fields are all optional: an `item.started` carries the command with no outcome yet, and there is a test for that.

`cost_usd()` from the issue's sketch is unavailable for the same reason as #60.

## Disposition

This leaves #84 with its delta half deliberately unbuilt. Closing it rather than leaving it open would misrepresent it as delivered, so it is `Refs` rather than `Closes`; close it as not-buildable if you agree with the reasoning above.

## Local checks

fmt, clippy `-D warnings`, 219 lib tests all-features, 129 no-default, 27 doc tests, rustdoc `-D warnings`.