### PR TITLE
feat: per-run MCP server config via -c overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,38 @@ McpAddCommand::http("sentry", "https://mcp.sentry.dev/mcp")
 McpRemoveCommand::new("old-server").execute(&codex).await?;
 ```
 
+## Per-run MCP Servers
+
+`mcp add` mutates persistent config, which is the wrong tool for a host running isolated
+invocations: a cancelled run leaves residue and concurrent runs race. `McpConfigBuilder` scopes a
+server set to one run instead:
+
+```rust
+use codex_wrapper::{ExecCommand, McpConfigBuilder, McpServerConfig};
+
+let mcp = McpConfigBuilder::new()
+    .server("files", McpServerConfig::stdio("npx").arg("-y").arg("server"))
+    .server("docs", McpServerConfig::http("https://example.com/mcp")
+        .bearer_token_env_var("TOKEN"));
+
+let mut cmd = ExecCommand::new("summarize the docs");
+for override_ in mcp.config_overrides() {
+    cmd = cmd.config(override_);
+}
+```
+
+**These are `-c` overrides, not a config file.** codex has no `--mcp-config` flag; the only
+config-bearing options are `-c`, `--profile`, and `--ignore-user-config`. Overrides suit the
+purpose better anyway: nothing is written, nothing survives a cancelled run, and two runs cannot
+collide. A contract check feeds the builder's real output to the CLI so the generated forms
+cannot drift.
+
+For the cases that do want a file, `to_toml()` and `write_profile()` produce a
+`$CODEX_HOME/<name>.config.toml` that `--profile` layers. That one is persistent.
+
+Only the *name* of the environment variable holding a bearer token is ever recorded, never the
+token.
+
 ## Sandbox Execution
 
 Run commands inside the Codex sandbox:

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -403,6 +403,38 @@ McpAddCommand::http("sentry", "https://mcp.sentry.dev/mcp")
 McpRemoveCommand::new("old-server").execute(&codex).await?;
 ```
 
+## Per-run MCP Servers
+
+`mcp add` mutates persistent config, which is the wrong tool for a host running isolated
+invocations: a cancelled run leaves residue and concurrent runs race. `McpConfigBuilder` scopes a
+server set to one run instead:
+
+```rust
+use codex_wrapper::{ExecCommand, McpConfigBuilder, McpServerConfig};
+
+let mcp = McpConfigBuilder::new()
+    .server("files", McpServerConfig::stdio("npx").arg("-y").arg("server"))
+    .server("docs", McpServerConfig::http("https://example.com/mcp")
+        .bearer_token_env_var("TOKEN"));
+
+let mut cmd = ExecCommand::new("summarize the docs");
+for override_ in mcp.config_overrides() {
+    cmd = cmd.config(override_);
+}
+```
+
+**These are `-c` overrides, not a config file.** codex has no `--mcp-config` flag; the only
+config-bearing options are `-c`, `--profile`, and `--ignore-user-config`. Overrides suit the
+purpose better anyway: nothing is written, nothing survives a cancelled run, and two runs cannot
+collide. A contract check feeds the builder's real output to the CLI so the generated forms
+cannot drift.
+
+For the cases that do want a file, `to_toml()` and `write_profile()` produce a
+`$CODEX_HOME/<name>.config.toml` that `--profile` layers. That one is persistent.
+
+Only the *name* of the environment variable holding a bearer token is ever recorded, never the
+token.
+
 ## Sandbox Execution
 
 Run commands inside the Codex sandbox:

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -177,6 +177,7 @@ pub mod error;
 pub mod exec;
 #[cfg(feature = "json")]
 pub mod history;
+pub mod mcp_config;
 pub mod retry;
 #[cfg(feature = "json")]
 pub mod session;
@@ -225,6 +226,7 @@ pub use error::{Error, FailureKind, Result};
 pub use exec::CommandOutput;
 #[cfg(feature = "json")]
 pub use history::{SessionFile, SessionLog, SessionMeta, SessionQuery};
+pub use mcp_config::{McpConfigBuilder, McpServerConfig};
 pub use retry::{BackoffStrategy, RetryPolicy};
 #[cfg(feature = "json")]
 pub use session::{Session, TurnRecord};

--- a/crates/codex-wrapper/src/mcp_config.rs
+++ b/crates/codex-wrapper/src/mcp_config.rs
@@ -1,0 +1,426 @@
+//! Build MCP server configuration for a single run, without touching the
+//! user's persistent config.
+//!
+//! [`McpAddCommand`](crate::McpAddCommand) and friends mutate
+//! `$CODEX_HOME/config.toml`. That is the wrong tool for a host running many
+//! isolated invocations: a cancelled run leaves residue, and two overlapping
+//! runs race each other.
+//!
+//! # Why overrides rather than a config file
+//!
+//! `claude-wrapper`'s equivalent writes a JSON file and passes it to
+//! `--mcp-config`. Codex has no such flag. Checked against 0.145.0: the only
+//! config-bearing options on `codex exec` are `-c/--config`, `--profile`,
+//! which layers `$CODEX_HOME/<name>.config.toml`, and `--ignore-user-config`.
+//! Nothing consumes a standalone server-config file.
+//!
+//! So the per-run mechanism here is `-c` overrides, which suits the purpose
+//! better than a file would: nothing is written, nothing is left behind when a
+//! run is cancelled, and concurrent runs cannot collide.
+//!
+//! For the cases that do want a file, [`McpConfigBuilder::to_toml`] and
+//! [`McpConfigBuilder::write_profile`] produce a profile that `--profile`
+//! layers.
+//!
+//! # Verified forms
+//!
+//! Each of these was accepted by `codex exec --strict-config`, which rejects
+//! a malformed server outright (a table with no transport fails with
+//! `invalid transport`):
+//!
+//! ```text
+//! mcp_servers.<name>.command="npx"
+//! mcp_servers.<name>.args=["-y","server"]
+//! mcp_servers.<name>.env={API_KEY="x"}
+//! mcp_servers.<name>.url="https://example.com/mcp"
+//! mcp_servers.<name>.bearer_token_env_var="TOKEN"
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use codex_wrapper::{ExecCommand, McpConfigBuilder};
+//!
+//! let mcp = McpConfigBuilder::new()
+//!     .stdio_server("files", "npx")
+//!     .http_server("docs", "https://example.com/mcp");
+//!
+//! let mut cmd = ExecCommand::new("summarize the docs");
+//! for override_ in mcp.config_overrides() {
+//!     cmd = cmd.config(override_);
+//! }
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+/// How a server is reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Transport {
+    Stdio {
+        command: String,
+        args: Vec<String>,
+    },
+    Http {
+        url: String,
+        bearer_token_env_var: Option<String>,
+    },
+}
+
+/// One MCP server's configuration.
+///
+/// Mirrors what [`McpAddCommand`](crate::McpAddCommand) can register, so the
+/// two describe the same thing whether it is persisted or scoped to a run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerConfig {
+    transport: Transport,
+    env: BTreeMap<String, String>,
+}
+
+impl McpServerConfig {
+    /// A server launched as a subprocess.
+    #[must_use]
+    pub fn stdio(command: impl Into<String>) -> Self {
+        Self {
+            transport: Transport::Stdio {
+                command: command.into(),
+                args: Vec::new(),
+            },
+            env: BTreeMap::new(),
+        }
+    }
+
+    /// A server reached over HTTP.
+    #[must_use]
+    pub fn http(url: impl Into<String>) -> Self {
+        Self {
+            transport: Transport::Http {
+                url: url.into(),
+                bearer_token_env_var: None,
+            },
+            env: BTreeMap::new(),
+        }
+    }
+
+    /// Append a launch argument. Ignored for an HTTP server.
+    #[must_use]
+    pub fn arg(mut self, value: impl Into<String>) -> Self {
+        if let Transport::Stdio { args, .. } = &mut self.transport {
+            args.push(value.into());
+        }
+        self
+    }
+
+    /// Set an environment variable for the subprocess.
+    #[must_use]
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// Name the environment variable holding the bearer token.
+    ///
+    /// The token itself is never part of the configuration: only the name of
+    /// the variable to read it from, matching `mcp add --bearer-token-env-var`.
+    /// Ignored for a stdio server.
+    #[must_use]
+    pub fn bearer_token_env_var(mut self, env_var: impl Into<String>) -> Self {
+        if let Transport::Http {
+            bearer_token_env_var,
+            ..
+        } = &mut self.transport
+        {
+            *bearer_token_env_var = Some(env_var.into());
+        }
+        self
+    }
+
+    /// `key = value` pairs for this server, without the `mcp_servers.<name>.`
+    /// prefix.
+    fn fields(&self) -> Vec<(String, String)> {
+        let mut out = Vec::new();
+        match &self.transport {
+            Transport::Stdio { command, args } => {
+                out.push(("command".into(), toml_string(command)));
+                if !args.is_empty() {
+                    let items: Vec<String> = args.iter().map(|a| toml_string(a)).collect();
+                    out.push(("args".into(), format!("[{}]", items.join(","))));
+                }
+            }
+            Transport::Http {
+                url,
+                bearer_token_env_var,
+            } => {
+                out.push(("url".into(), toml_string(url)));
+                if let Some(var) = bearer_token_env_var {
+                    out.push(("bearer_token_env_var".into(), toml_string(var)));
+                }
+            }
+        }
+        if !self.env.is_empty() {
+            let pairs: Vec<String> = self
+                .env
+                .iter()
+                .map(|(k, v)| format!("{}={}", toml_key(k), toml_string(v)))
+                .collect();
+            out.push(("env".into(), format!("{{{}}}", pairs.join(","))));
+        }
+        out
+    }
+}
+
+/// A set of MCP servers for one run.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpConfigBuilder {
+    servers: BTreeMap<String, McpServerConfig>,
+}
+
+impl McpConfigBuilder {
+    /// An empty set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a server.
+    #[must_use]
+    pub fn server(mut self, name: impl Into<String>, config: McpServerConfig) -> Self {
+        self.servers.insert(name.into(), config);
+        self
+    }
+
+    /// Add a subprocess server. Shorthand for [`McpServerConfig::stdio`].
+    #[must_use]
+    pub fn stdio_server(self, name: impl Into<String>, command: impl Into<String>) -> Self {
+        self.server(name, McpServerConfig::stdio(command))
+    }
+
+    /// Add an HTTP server. Shorthand for [`McpServerConfig::http`].
+    #[must_use]
+    pub fn http_server(self, name: impl Into<String>, url: impl Into<String>) -> Self {
+        self.server(name, McpServerConfig::http(url))
+    }
+
+    /// `key=value` strings for
+    /// [`ExecCommand::config`](crate::ExecCommand::config), or for the client
+    /// builder's `config` when the whole client should carry them.
+    ///
+    /// Ordered, so the same set produces the same arguments.
+    #[must_use]
+    pub fn config_overrides(&self) -> Vec<String> {
+        self.servers
+            .iter()
+            .flat_map(|(name, config)| {
+                config.fields().into_iter().map(move |(key, value)| {
+                    format!("mcp_servers.{}.{key}={value}", toml_key(name))
+                })
+            })
+            .collect()
+    }
+
+    /// The same configuration as a TOML document.
+    ///
+    /// Suitable for a `$CODEX_HOME/<name>.config.toml` profile, which
+    /// `--profile` layers over the base config.
+    #[must_use]
+    pub fn to_toml(&self) -> String {
+        let mut out = String::new();
+        for (name, config) in &self.servers {
+            out.push_str(&format!("[mcp_servers.{}]\n", toml_key(name)));
+            for (key, value) in config.fields() {
+                out.push_str(&format!("{key} = {value}\n"));
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Write [`to_toml`](Self::to_toml) to `$CODEX_HOME/<profile>.config.toml`
+    /// and return the path.
+    ///
+    /// Reachable afterwards as `--profile <profile>`. This writes into the
+    /// user's codex home, so it is persistent: prefer
+    /// [`config_overrides`](Self::config_overrides) for a single run.
+    pub fn write_profile(&self, codex_home: impl AsRef<Path>, profile: &str) -> Result<PathBuf> {
+        let path = codex_home.as_ref().join(format!("{profile}.config.toml"));
+        std::fs::write(&path, self.to_toml()).map_err(|e| Error::Io {
+            message: format!("failed to write {}: {e}", path.display()),
+            source: e,
+            working_dir: Some(codex_home.as_ref().to_path_buf()),
+        })?;
+        Ok(path)
+    }
+
+    /// Whether any server has been added.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.servers.is_empty()
+    }
+}
+
+/// A TOML basic string, quoted and escaped.
+fn toml_string(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04X}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// A TOML key, bare when it can be and quoted when it cannot.
+///
+/// Server names come from the caller, so a name with a dot would otherwise
+/// silently become a nested table rather than a server called `a.b`.
+fn toml_key(key: &str) -> String {
+    let bare = !key.is_empty()
+        && key
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if bare {
+        key.to_string()
+    } else {
+        toml_string(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exactly the forms accepted by `codex exec --strict-config` on 0.145.0.
+    #[test]
+    fn overrides_match_the_verified_forms() {
+        let mcp = McpConfigBuilder::new()
+            .server(
+                "files",
+                McpServerConfig::stdio("npx").arg("-y").arg("server"),
+            )
+            .server(
+                "docs",
+                McpServerConfig::http("https://example.com/mcp").bearer_token_env_var("TOKEN"),
+            );
+
+        assert_eq!(
+            mcp.config_overrides(),
+            vec![
+                r#"mcp_servers.docs.url="https://example.com/mcp""#,
+                r#"mcp_servers.docs.bearer_token_env_var="TOKEN""#,
+                r#"mcp_servers.files.command="npx""#,
+                r#"mcp_servers.files.args=["-y","server"]"#,
+            ]
+        );
+    }
+
+    #[test]
+    fn env_becomes_an_inline_table() {
+        let mcp = McpConfigBuilder::new().server(
+            "files",
+            McpServerConfig::stdio("run").env("B", "2").env("A", "1"),
+        );
+
+        assert_eq!(
+            mcp.config_overrides(),
+            vec![
+                r#"mcp_servers.files.command="run""#,
+                r#"mcp_servers.files.env={A="1",B="2"}"#,
+            ],
+            "entries are ordered, so the same set produces the same arguments"
+        );
+    }
+
+    /// A value carrying a quote or a backslash must not break out of the TOML
+    /// string and turn into a different override than intended.
+    #[test]
+    fn values_are_escaped() {
+        let mcp = McpConfigBuilder::new().server(
+            "s",
+            McpServerConfig::stdio(r#"say "hi""#)
+                .arg("back\\slash")
+                .arg("two\nlines"),
+        );
+
+        let overrides = mcp.config_overrides();
+        assert_eq!(overrides[0], r#"mcp_servers.s.command="say \"hi\"""#);
+        assert_eq!(
+            overrides[1],
+            r#"mcp_servers.s.args=["back\\slash","two\nlines"]"#
+        );
+    }
+
+    /// A dotted name would otherwise become a nested table rather than a
+    /// server whose name contains a dot.
+    #[test]
+    fn a_name_needing_quotes_gets_them() {
+        let mcp = McpConfigBuilder::new().stdio_server("my.server", "run");
+        assert_eq!(
+            mcp.config_overrides(),
+            vec![r#"mcp_servers."my.server".command="run""#]
+        );
+    }
+
+    #[test]
+    fn args_and_bearer_token_apply_only_where_they_belong() {
+        // An HTTP server ignores launch args; a stdio server ignores the token.
+        let http =
+            McpConfigBuilder::new().server("h", McpServerConfig::http("https://x").arg("-y"));
+        assert_eq!(
+            http.config_overrides(),
+            vec![r#"mcp_servers.h.url="https://x""#]
+        );
+
+        let stdio = McpConfigBuilder::new()
+            .server("s", McpServerConfig::stdio("run").bearer_token_env_var("T"));
+        assert_eq!(
+            stdio.config_overrides(),
+            vec![r#"mcp_servers.s.command="run""#]
+        );
+    }
+
+    #[test]
+    fn to_toml_produces_a_profile_document() {
+        let mcp = McpConfigBuilder::new().server("files", McpServerConfig::stdio("npx").arg("-y"));
+
+        assert_eq!(
+            mcp.to_toml(),
+            "[mcp_servers.files]\ncommand = \"npx\"\nargs = [\"-y\"]\n\n"
+        );
+    }
+
+    #[test]
+    fn write_profile_lands_where_profile_would_look() {
+        let home = std::env::temp_dir().join(format!("codex-wrapper-mcp-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&home);
+        std::fs::create_dir_all(&home).unwrap();
+
+        let path = McpConfigBuilder::new()
+            .stdio_server("files", "npx")
+            .write_profile(&home, "isolated")
+            .unwrap();
+
+        assert_eq!(path, home.join("isolated.config.toml"));
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("[mcp_servers.files]"), "{written}");
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    #[test]
+    fn an_empty_builder_produces_nothing() {
+        let mcp = McpConfigBuilder::new();
+        assert!(mcp.is_empty());
+        assert!(mcp.config_overrides().is_empty());
+        assert_eq!(mcp.to_toml(), "");
+    }
+}

--- a/crates/codex-wrapper/tests/contract.rs
+++ b/crates/codex-wrapper/tests/contract.rs
@@ -648,3 +648,56 @@ fn dangerous_flags_contract() {
         .args();
     assert_contract("ReviewCommand::dangerous", args, 2);
 }
+
+// ---------------------------------------------------------------------------
+// MCP config overrides (#87)
+//
+// codex has no --mcp-config flag, so per-run MCP servers are expressed as `-c`
+// overrides. These are generated strings rather than builder flags, so
+// `assert_contract` does not see them: this feeds the builder's real output to
+// the CLI and asserts config load accepts it.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore]
+fn mcp_config_overrides_contract() {
+    use codex_wrapper::{McpConfigBuilder, McpServerConfig};
+
+    let mcp = McpConfigBuilder::new()
+        .server(
+            "files",
+            McpServerConfig::stdio("npx")
+                .arg("-y")
+                .arg("server")
+                .env("API_KEY", "x"),
+        )
+        .server(
+            "docs",
+            McpServerConfig::http("https://example.com/mcp").bearer_token_env_var("TOKEN"),
+        );
+
+    let mut args = vec!["exec".to_string(), "--strict-config".to_string()];
+    for override_ in mcp.config_overrides() {
+        args.push("-c".into());
+        args.push(override_);
+    }
+    args.push("probe".into());
+
+    let output = run_codex(&args);
+
+    // Config load happens before anything else, so any rejection of these
+    // overrides shows up here. A malformed server fails with `invalid
+    // transport`, and an unknown field with `unknown configuration field`.
+    assert!(
+        !output.contains("unknown configuration field"),
+        "the CLI rejected a generated MCP override:\n{output}"
+    );
+    assert!(
+        !output.contains("invalid transport"),
+        "the CLI could not read a generated MCP server:\n{output}"
+    );
+    assert!(
+        !output.contains("Error loading config.toml"),
+        "config load failed on the generated overrides:\n{output}"
+    );
+}


### PR DESCRIPTION
Refs #87, reshaped around what the CLI actually supports.

## Why not the file-based shape the issue describes

codex has no `--mcp-config`. On 0.145.0 the only config-bearing options on `codex exec` are `-c/--config`, `--profile` (which layers `$CODEX_HOME/<name>.config.toml`), and `--ignore-user-config`. Nothing consumes a standalone server-config file, so `write_to`, `build_temp`, the `tempfile` feature, and "wire the resulting path into the exec builders" had nothing to wire into. That shape came from `claude-wrapper`, whose CLI does have the flag.

`-c` overrides serve the issue's stated goal better than a file would: nothing is written, nothing survives a cancelled run, and concurrent runs cannot collide. No new dependency and no new feature.

```rust
let mcp = McpConfigBuilder::new()
    .server("files", McpServerConfig::stdio("npx").arg("-y").arg("server"))
    .server("docs", McpServerConfig::http("https://example.com/mcp")
        .bearer_token_env_var("TOKEN"));

for override_ in mcp.config_overrides() {
    cmd = cmd.config(override_);
}
```

## Verified against the CLI, not assumed

`--strict-config` validates the `mcp_servers` shape rather than passing it through: a server table with no transport is rejected with `invalid transport`. Every emitted form was confirmed accepted:

```text
mcp_servers.<name>.command="npx"
mcp_servers.<name>.args=["-y","server"]
mcp_servers.<name>.env={API_KEY="x"}
mcp_servers.<name>.url="https://example.com/mcp"
mcp_servers.<name>.bearer_token_env_var="TOKEN"
```

Then the builder's *real output* was fed back to the CLI, which accepted all ten arguments. That is committed as `mcp_config_overrides_contract`, since these are generated strings rather than builder flags and `assert_contract` cannot see them.

## The file case is still covered

`to_toml()` and `write_profile()` produce a `$CODEX_HOME/<name>.config.toml`, which is the one file codex will layer, reachable as `--profile <name>`. It is persistent, so the docs point callers at overrides for single runs.

## Details worth a look

- **Values are TOML-escaped and keys quoted when needed.** A server name containing a dot would otherwise silently become a nested table rather than a server of that name. Tested, along with quotes, backslashes and newlines in values.
- **Only the bearer token's variable *name* is ever recorded**, never a token, matching `mcp add --bearer-token-env-var`.
- **`arg` on an HTTP server and `bearer_token_env_var` on a stdio one are ignored** rather than emitting a field the transport does not have. Tested both ways.

`Refs` rather than `Closes`: the issue as written asks for a file builder that cannot exist here, so it needs your call on whether this satisfies it.

## Local checks

fmt, clippy `-D warnings`, 223 lib tests all-features, 137 no-default, 28 doc tests, rustdoc `-D warnings`, and 19 contract checks against the real CLI.