### PR TITLE
ci: lint every target without default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,15 @@ jobs:
       - name: Build the config feature alone
         run: cargo build --no-default-features --features config
 
+      # The lib builds and tests without default features, and every target
+      # builds with all of them, but nothing checked the intersection: a test
+      # naming a json-only API compiles under --all-features and breaks here.
+      # Clippy rather than check, so an unused import that only appears in
+      # this configuration fails too.
+      - name: Lint every target without default features
+        if: matrix.rust == 'stable'
+        run: cargo clippy --all-targets --no-default-features -- -D warnings
+
       - name: Unit tests
         run: cargo test --lib --all-features
 

--- a/crates/codex-wrapper/tests/integration.rs
+++ b/crates/codex-wrapper/tests/integration.rs
@@ -8,11 +8,13 @@
 
 use codex_wrapper::{
     ApplyCommand, ArchiveCommand, Codex, CodexCommand, CompletionCommand, DeleteCommand,
-    DoctorCommand, ExecCommand, ExecResumeCommand, FeaturesListCommand, ForkCommand,
-    LoginStatusCommand, McpListCommand, McpServerCommand, PluginListCommand,
-    PluginMarketplaceListCommand, ResumeCommand, ReviewCommand, SandboxCommand, Shell,
-    UnarchiveCommand, VersionCommand,
+    DoctorCommand, ExecCommand, FeaturesListCommand, ForkCommand, LoginStatusCommand,
+    McpListCommand, McpServerCommand, PluginListCommand, PluginMarketplaceListCommand,
+    ResumeCommand, ReviewCommand, SandboxCommand, Shell, UnarchiveCommand, VersionCommand,
 };
+// Only the json-gated tests use this one.
+#[cfg(feature = "json")]
+use codex_wrapper::ExecResumeCommand;
 
 fn codex() -> Codex {
     Codex::builder()
@@ -140,6 +142,7 @@ async fn mcp_list() {
     assert!(output.success);
 }
 
+#[cfg(feature = "json")]
 #[tokio::test]
 #[ignore]
 async fn mcp_list_json() {
@@ -185,6 +188,7 @@ async fn exec_simple() {
     assert!(output.success);
 }
 
+#[cfg(feature = "json")]
 #[tokio::test]
 #[ignore]
 async fn exec_json_lines() {
@@ -203,6 +207,7 @@ async fn exec_json_lines() {
     );
 }
 
+#[cfg(feature = "json")]
 #[tokio::test]
 #[ignore]
 async fn exec_query_result() {
@@ -223,6 +228,7 @@ async fn exec_query_result() {
     );
 }
 
+#[cfg(feature = "json")]
 #[tokio::test]
 #[ignore]
 async fn exec_resume_json_lines() {
@@ -262,6 +268,7 @@ async fn review_uncommitted() {
 /// Requires uncommitted changes in the working tree to review. With a clean
 /// tree the CLI exits non-zero and this reports that rather than a schema
 /// problem.
+#[cfg(feature = "json")]
 #[tokio::test]
 #[ignore]
 async fn review_query_result() {
@@ -450,6 +457,7 @@ async fn timeout_fires() {
 /// something out of each. Ignored because it depends on local state, but it is
 /// the check that matters: the fixtures in `history.rs` are transcriptions,
 /// and only a real history has the full spread of CLI versions that wrote it.
+#[cfg(feature = "json")]
 #[tokio::test]
 #[ignore]
 async fn history_reads_every_real_session() {


### PR DESCRIPTION
Closes #107.

## The gap

Each axis was covered and their intersection was not:

| Job | Covers `tests/` | Covers no-default-features |
|---|---|---|
| `clippy --all-targets --all-features` | yes | no |
| `build --no-default-features` | no, lib only | yes |
| `test --lib --no-default-features` | no, lib only | yes |
| `test --test '*' --all-features` | yes | no |

So `tests/integration.rs` accumulated json-gated API with no `cfg`, and by the time this was written `cargo clippy --all-targets --no-default-features` failed with six errors.

## Fix

Six tests gated, plus the one import only they use. Nothing shipped was affected: the library built and tested fine under every feature set, and this is the integration target only.

## Clippy rather than check

The issue suggested either. Clippy, because `cargo check` would have reported the unused `ExecResumeCommand` import in this configuration without failing on it, and that was the second thing wrong here. Gated to `stable` to match the existing clippy step.

Verified both directions are clean:

```
cargo clippy --all-targets --no-default-features -- -D warnings   # 0 errors
cargo clippy --all-targets --all-features       -- -D warnings   # 0 errors
```

## Local checks

230 lib tests all-features, both test binaries compile, and the two clippy runs above.