### PR TITLE
feat: make the run's own process group opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,18 @@ let codex = Codex::builder()
 let result = run_codex_cancellable(&codex, args, async { shutdown.await }).await;
 ```
 
+Groups are on by default, and can be turned off:
+
+```rust
+let codex = Codex::builder().process_group(false).build()?;
+```
+
+Off, the child shares the parent's group, so a terminal Ctrl-C reaches the whole run directly and
+a wrapper-side cancel reaches only the direct child. That is the right contract for a
+terminal-attached host that shells out synchronously and treats the terminal as the supervisor;
+the default suits a supervisor that cancels programmatically. `claude-wrapper` has the same
+option under the same name.
+
 One limit remains: reaping needs the tokio runtime to still be running, so a future dropped as
 part of runtime shutdown may not get far enough. Process groups are unix-only; elsewhere this
 degrades to killing the direct child.

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -815,6 +815,18 @@ let codex = Codex::builder()
 let result = run_codex_cancellable(&codex, args, async { shutdown.await }).await;
 ```
 
+Groups are on by default, and can be turned off:
+
+```rust
+let codex = Codex::builder().process_group(false).build()?;
+```
+
+Off, the child shares the parent's group, so a terminal Ctrl-C reaches the whole run directly and
+a wrapper-side cancel reaches only the direct child. That is the right contract for a
+terminal-attached host that shells out synchronously and treats the terminal as the supervisor;
+the default suits a supervisor that cancels programmatically. `claude-wrapper` has the same
+option under the same name.
+
 One limit remains: reaping needs the tokio runtime to still be running, so a future dropped as
 part of runtime shutdown may not get far enough. Process groups are unix-only; elsewhere this
 degrades to killing the direct child.

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -101,12 +101,14 @@ impl Drop for SpanOutcome {
 /// subprocesses for tool use. Without a group of its own, cancelling leaves
 /// those running (#78).
 #[cfg(unix)]
-pub(crate) fn own_process_group(cmd: &mut Command) {
-    cmd.process_group(0);
+pub(crate) fn own_process_group(cmd: &mut Command, enabled: bool) {
+    if enabled {
+        cmd.process_group(0);
+    }
 }
 
 #[cfg(not(unix))]
-pub(crate) fn own_process_group(_cmd: &mut Command) {}
+pub(crate) fn own_process_group(_cmd: &mut Command, _enabled: bool) {}
 
 /// Signal a process group, given the group leader's pid.
 ///
@@ -309,6 +311,7 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                     &codex.env,
                     codex.working_dir.as_deref(),
                     timeout,
+                    codex.process_group,
                 )
                 .await
             }
@@ -318,6 +321,7 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                     &command_args,
                     &codex.env,
                     codex.working_dir.as_deref(),
+                    codex.process_group,
                 )
                 .await
             }
@@ -361,11 +365,14 @@ where
 
         let mut outcome = SpanOutcome::start(outcome_span);
         let result = run_internal_inner(
-            &codex.binary,
-            &command_args,
-            &codex.env,
-            codex.working_dir.as_deref(),
-            None,
+            SpawnSpec {
+                binary: &codex.binary,
+                args: &command_args,
+                env: &codex.env,
+                working_dir: codex.working_dir.as_deref(),
+                stdin_prompt: None,
+                process_group: codex.process_group,
+            },
             Some(Box::pin(cancel)),
             codex.termination_grace,
         )
@@ -447,11 +454,14 @@ pub async fn run_codex_with_stdin_prompt(
 
         let mut outcome = SpanOutcome::start(outcome_span);
         let run = run_internal_inner(
-            &codex.binary,
-            &command_args,
-            &codex.env,
-            codex.working_dir.as_deref(),
-            Some(prompt),
+            SpawnSpec {
+                binary: &codex.binary,
+                args: &command_args,
+                env: &codex.env,
+                working_dir: codex.working_dir.as_deref(),
+                stdin_prompt: Some(prompt),
+                process_group: codex.process_group,
+            },
             None,
             Duration::from_secs(0),
         );
@@ -477,13 +487,17 @@ async fn run_internal(
     args: &[String],
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
+    process_group: bool,
 ) -> Result<CommandOutput> {
     run_internal_inner(
-        binary,
-        args,
-        env,
-        working_dir,
-        None,
+        SpawnSpec {
+            binary,
+            args,
+            env,
+            working_dir,
+            stdin_prompt: None,
+            process_group,
+        },
         None,
         Duration::from_secs(0),
     )
@@ -492,15 +506,31 @@ async fn run_internal(
 
 type CancelFuture<'a> = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>;
 
+/// Everything one spawn needs, gathered so the signature stays readable.
+struct SpawnSpec<'a> {
+    binary: &'a std::path::Path,
+    args: &'a [String],
+    env: &'a std::collections::HashMap<String, String>,
+    working_dir: Option<&'a std::path::Path>,
+    /// A prompt to deliver on stdin, for `codex exec -`.
+    stdin_prompt: Option<&'a str>,
+    /// Whether the run leads its own process group.
+    process_group: bool,
+}
+
 async fn run_internal_inner(
-    binary: &std::path::Path,
-    args: &[String],
-    env: &std::collections::HashMap<String, String>,
-    working_dir: Option<&std::path::Path>,
-    stdin_prompt: Option<&str>,
+    spec: SpawnSpec<'_>,
     cancel: Option<CancelFuture<'_>>,
     grace: Duration,
 ) -> Result<CommandOutput> {
+    let SpawnSpec {
+        binary,
+        args,
+        env,
+        working_dir,
+        stdin_prompt,
+        process_group,
+    } = spec;
     let mut cmd = Command::new(binary);
     cmd.args(args);
 
@@ -516,7 +546,7 @@ async fn run_internal_inner(
     // cancellation, or on task abort. Without this, tokio detaches the child
     // and codex keeps running with no handle left to stop it.
     cmd.kill_on_drop(true);
-    own_process_group(&mut cmd);
+    own_process_group(&mut cmd, process_group);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
@@ -540,7 +570,9 @@ async fn run_internal_inner(
 
     // Armed for the whole run. If this future is dropped, its Drop signals the
     // group, which is what reaches the subprocesses codex started.
-    let mut group = GroupKillGuard::new(child.id());
+    // Only meaningful when the run leads its own group. Sharing the parent's
+    // means signalling it would hit the parent too.
+    let mut group = GroupKillGuard::new(process_group.then(|| child.id()).flatten());
     let child_stdin = child.stdin.take();
 
     let write = async move {
@@ -620,12 +652,16 @@ async fn run_with_timeout(
     env: &std::collections::HashMap<String, String>,
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
+    process_group: bool,
 ) -> Result<CommandOutput> {
-    tokio::time::timeout(timeout, run_internal(binary, args, env, working_dir))
-        .await
-        .map_err(|_| Error::Timeout {
-            timeout_seconds: timeout.as_secs(),
-        })?
+    tokio::time::timeout(
+        timeout,
+        run_internal(binary, args, env, working_dir, process_group),
+    )
+    .await
+    .map_err(|_| Error::Timeout {
+        timeout_seconds: timeout.as_secs(),
+    })?
 }
 
 #[cfg(test)]
@@ -1158,5 +1194,52 @@ mod tests {
             .await
             .unwrap();
         assert!(output.success);
+    }
+
+    /// Opting out is not cosmetic: without a group of its own, cancelling
+    /// reaches the direct child only and its subprocesses survive. That is the
+    /// terminal-attached contract, where the terminal is the supervisor and
+    /// Ctrl-C reaches the whole run directly instead.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn opting_out_of_process_groups_leaves_the_subprocess() {
+        use crate::test_support::wait_until_gone;
+
+        let pid_file = crate::test_support::PidFile::new("group-optout");
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-spawns-child.sh");
+        let codex = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .env(
+                "CODEX_WRAPPER_TEST_PIDFILE",
+                pid_file.path().to_str().unwrap(),
+            )
+            .process_group(false)
+            .build()
+            .expect("bash must exist");
+
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(400),
+            run_codex(&codex, vec!["exec".into()]),
+        )
+        .await;
+        assert!(cancelled.is_err(), "the run should still have been going");
+
+        let (parent, child) = read_pids(&pid_file).await;
+        assert!(
+            wait_until_gone(parent).await,
+            "kill_on_drop still reaps the direct child ({parent})"
+        );
+        // The point of the contrast with
+        // `cancelling_kills_the_whole_process_group`.
+        assert!(
+            crate::test_support::is_running_for_test(child),
+            "with groups off, the subprocess ({child}) is expected to survive"
+        );
+        // Do not leave it behind.
+        signal_group(child, libc::SIGKILL);
+        unsafe { libc::kill(i32::try_from(child).unwrap_or(0), libc::SIGKILL) };
     }
 }

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -260,6 +260,7 @@ pub struct Codex {
     pub(crate) global_args: Vec<String>,
     pub(crate) timeout: Option<Duration>,
     pub(crate) termination_grace: Duration,
+    pub(crate) process_group: bool,
     pub(crate) retry_policy: Option<RetryPolicy>,
     pub(crate) tested_cli_version_range: (CliVersion, CliVersion),
 }
@@ -446,6 +447,7 @@ pub struct CodexBuilder {
     global_args: Vec<String>,
     timeout: Option<Duration>,
     termination_grace: Option<Duration>,
+    process_group: Option<bool>,
     retry_policy: Option<RetryPolicy>,
     tested_cli_version_range: Option<(CliVersion, CliVersion)>,
 }
@@ -522,6 +524,26 @@ impl CodexBuilder {
         self
     }
 
+    /// Whether each run gets its own process group. On by default.
+    ///
+    /// With a group of its own, cancelling a run reaches the subprocesses
+    /// codex spawned for tool use, not just codex itself (#78). That is the
+    /// right contract for a supervisor that cancels programmatically.
+    ///
+    /// Opting out puts the child in the parent's group, so a terminal Ctrl-C
+    /// reaches the whole run directly. Then a wrapper-side kill reaches only
+    /// the direct child, and its subprocesses survive. That is the right
+    /// contract for a terminal-attached host that shells out synchronously and
+    /// treats the terminal as the supervisor.
+    ///
+    /// Matches `claude-wrapper`'s option of the same name. No effect on
+    /// non-unix targets, which have no process groups.
+    #[must_use]
+    pub fn process_group(mut self, enabled: bool) -> Self {
+        self.process_group = Some(enabled);
+        self
+    }
+
     /// Append a raw global argument passed before any subcommand.
     #[must_use]
     pub fn arg(mut self, arg: impl Into<String>) -> Self {
@@ -578,6 +600,7 @@ impl CodexBuilder {
             termination_grace: self
                 .termination_grace
                 .unwrap_or_else(|| Duration::from_secs(5)),
+            process_group: self.process_group.unwrap_or(true),
             timeout: self.timeout,
             retry_policy: self.retry_policy,
             tested_cli_version_range: self.tested_cli_version_range.unwrap_or((

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -105,7 +105,7 @@ where
     // cancellation, or on task abort. Without this, tokio detaches the child
     // and codex keeps running with no handle left to stop it.
     child_cmd.kill_on_drop(true);
-    crate::exec::own_process_group(&mut child_cmd);
+    crate::exec::own_process_group(&mut child_cmd, codex.process_group);
 
     if let Some(dir) = &codex.working_dir {
         child_cmd.current_dir(dir);
@@ -123,7 +123,8 @@ where
     // Armed for the whole stream. Dropping this future signals the group,
     // which reaches the subprocesses codex started for tool use; kill_on_drop
     // alone would leave those running (#78).
-    let mut group = crate::exec::GroupKillGuard::new(child.id());
+    let mut group =
+        crate::exec::GroupKillGuard::new(codex.process_group.then(|| child.id()).flatten());
 
     let stdout = child.stdout.take().expect("stdout was configured as piped");
     let stderr = child.stderr.take().expect("stderr was configured as piped");

--- a/crates/codex-wrapper/src/test_support.rs
+++ b/crates/codex-wrapper/src/test_support.rs
@@ -85,6 +85,12 @@ pub(crate) async fn wait_until_gone(pid: u32) -> bool {
     false
 }
 
+/// Public-in-crate view of [`is_running`], for a test that asserts a process
+/// is still alive rather than waiting for it to go.
+pub(crate) fn is_running_for_test(pid: u32) -> bool {
+    is_running(pid)
+}
+
 /// `true` while `pid` is a live process. Empty `ps` output means the PID is
 /// gone; a leading `Z` means it exited and is awaiting reaping.
 fn is_running(pid: u32) -> bool {


### PR DESCRIPTION
Follows #106, which I got half right.

## What I missed

#106 put every run in its own process group unconditionally. That is correct for a supervisor cancelling programmatically, which is what #78 was about. It is wrong for a terminal-attached host: a child in its own group no longer receives the terminal's Ctrl-C, so `codex` survives an interrupt that previously killed it.

I found this auditing `CodexBuilder` against `ClaudeBuilder` for #41. `claude-wrapper` already models it, as a `process_group` option defaulting to on, with the reasoning spelled out in its doc comment. So this is both a fix and a parity item.

```rust
let codex = Codex::builder().process_group(false).build()?;
```

| | Groups on (default) | Groups off |
|---|---|---|
| wrapper-side cancel | kills codex and its tool subprocesses | kills codex only |
| terminal Ctrl-C | does not reach the run | reaches the whole run |
| suits | a programmatic supervisor | a terminal-attached host |

The kill guard is not armed when groups are off, because signalling a shared group would hit the parent too.

## Tested both ways

`cancelling_kills_the_whole_process_group` already asserts the subprocess dies. The new `opting_out_of_process_groups_leaves_the_subprocess` asserts it survives, which is the behaviour a terminal-attached host is deliberately choosing. Asserting the contrast is the only way to show the flag does something.

## Incidental refactor

Threading the flag through pushed `run_internal_inner` to 8 arguments, past what clippy allows. Grouped into a `SpawnSpec` struct rather than silencing the lint; the call sites read better for it.

## Local checks

fmt, clippy `-D warnings` under both all-features and no-default-features, 231 lib tests, 141 no-default, 28 doc tests, rustdoc `-D warnings`.