### PR TITLE
feat: catch up to codex-cli 0.147.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
         # ends of the range declared by TESTED_CLI_VERSION_MIN and
         # TESTED_CLI_VERSION_MAX in src/version.rs, and a test asserts the two
         # stay in step. Bump deliberately, fixing any drift in the same change.
-        codex: ["0.145.0", "0.146.0"]
+        codex: ["0.145.0", "0.147.0"]
     steps:
       - uses: actions/checkout@v7
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ let output = ExecCommand::new("fix the failing tests")
 | `enable()` / `disable()` | `--enable` / `--disable` | Feature flags |
 | `oss()` | `--oss` | Use local OSS provider |
 | `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
+| `approve_for_me()` | `--approve-for-me` | Route approvals through automatic review (needs 0.147.0) |
 | `prompt_via_stdin()` | *(prompt becomes `-`)* | Send the prompt on stdin |
 | `retry()` | *(client-side)* | Per-command retry policy |
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -157,6 +157,7 @@ let output = ExecCommand::new("fix the failing tests")
 | `enable()` / `disable()` | `--enable` / `--disable` | Feature flags |
 | `oss()` | `--oss` | Use local OSS provider |
 | `local_provider()` | `--local-provider` | Specify lmstudio/ollama |
+| `approve_for_me()` | `--approve-for-me` | Route approvals through automatic review (needs 0.147.0) |
 | `prompt_via_stdin()` | *(prompt becomes `-`)* | Send the prompt on stdin |
 | `retry()` | *(client-side)* | Per-command retry policy |
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -66,6 +66,7 @@ pub(crate) fn effective_sandbox(
 /// ```
 #[derive(Debug, Clone)]
 pub struct ExecCommand {
+    approve_for_me: bool,
     prompt: Option<String>,
     prompt_via_stdin: bool,
     approval_policy: Option<ApprovalPolicyConfig>,
@@ -101,6 +102,7 @@ impl ExecCommand {
     #[must_use]
     pub fn new(prompt: impl Into<String>) -> Self {
         Self {
+            approve_for_me: false,
             prompt: Some(prompt.into()),
             prompt_via_stdin: false,
             approval_policy: None,
@@ -352,6 +354,19 @@ impl ExecCommand {
         self
     }
 
+    /// Route approval requests through automatic review, using the
+    /// workspace-write sandbox (`--approve-for-me`).
+    ///
+    /// Added in `codex-cli` 0.147.0. Older releases reject it as an unexpected
+    /// argument, so this is the one builder method with a floor above the
+    /// wrapper's tested minimum. `codex exec review` and `codex exec resume`
+    /// do not accept it.
+    #[must_use]
+    pub fn approve_for_me(mut self) -> Self {
+        self.approve_for_me = true;
+        self
+    }
+
     /// Bypass all approval prompts and sandbox restrictions.
     ///
     /// Passes `--dangerously-bypass-approvals-and-sandbox`. Use with caution.
@@ -527,6 +542,9 @@ impl CodexCommand for ExecCommand {
         if let Some(profile) = &self.profile {
             args.push("--profile".into());
             args.push(profile.clone());
+        }
+        if self.approve_for_me {
+            args.push("--approve-for-me".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());

--- a/crates/codex-wrapper/src/command/fork.rs
+++ b/crates/codex-wrapper/src/command/fork.rs
@@ -11,6 +11,7 @@ use crate::types::{ApprovalPolicy, SandboxMode};
 /// Fork a previous interactive Codex session, creating a new branch of conversation.
 #[derive(Debug, Clone)]
 pub struct ForkCommand {
+    approve_for_me: bool,
     session_id: Option<String>,
     prompt: Option<String>,
     last: bool,
@@ -41,6 +42,7 @@ impl ForkCommand {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            approve_for_me: false,
             session_id: None,
             prompt: None,
             last: false,
@@ -168,6 +170,19 @@ impl ForkCommand {
         self
     }
 
+    /// Route approval requests through automatic review, using the
+    /// workspace-write sandbox (`--approve-for-me`).
+    ///
+    /// Added in `codex-cli` 0.147.0. Older releases reject it as an unexpected
+    /// argument, so this is the one builder method with a floor above the
+    /// wrapper's tested minimum. `codex exec review` and `codex exec resume`
+    /// do not accept it.
+    #[must_use]
+    pub fn approve_for_me(mut self) -> Self {
+        self.approve_for_me = true;
+        self
+    }
+
     #[must_use]
     pub(crate) fn set_bypass_approvals_and_sandbox(mut self) -> Self {
         self.dangerously_bypass_approvals_and_sandbox = true;
@@ -286,6 +301,9 @@ impl CodexCommand for ForkCommand {
         if let Some(policy) = self.approval_policy {
             args.push("--ask-for-approval".into());
             args.push(policy.as_arg().into());
+        }
+        if self.approve_for_me {
+            args.push("--approve-for-me".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());

--- a/crates/codex-wrapper/src/command/resume.rs
+++ b/crates/codex-wrapper/src/command/resume.rs
@@ -11,6 +11,7 @@ use crate::types::{ApprovalPolicy, SandboxMode};
 /// Resume a previous interactive Codex session.
 #[derive(Debug, Clone)]
 pub struct ResumeCommand {
+    approve_for_me: bool,
     session_id: Option<String>,
     prompt: Option<String>,
     last: bool,
@@ -42,6 +43,7 @@ impl ResumeCommand {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            approve_for_me: false,
             session_id: None,
             prompt: None,
             last: false,
@@ -167,6 +169,19 @@ impl ResumeCommand {
     #[must_use]
     pub fn full_auto(mut self) -> Self {
         self.full_auto = true;
+        self
+    }
+
+    /// Route approval requests through automatic review, using the
+    /// workspace-write sandbox (`--approve-for-me`).
+    ///
+    /// Added in `codex-cli` 0.147.0. Older releases reject it as an unexpected
+    /// argument, so this is the one builder method with a floor above the
+    /// wrapper's tested minimum. `codex exec review` and `codex exec resume`
+    /// do not accept it.
+    #[must_use]
+    pub fn approve_for_me(mut self) -> Self {
+        self.approve_for_me = true;
         self
     }
 
@@ -296,6 +311,9 @@ impl CodexCommand for ResumeCommand {
         if let Some(policy) = self.approval_policy {
             args.push("--ask-for-approval".into());
             args.push(policy.as_arg().into());
+        }
+        if self.approve_for_me {
+            args.push("--approve-for-me".into());
         }
         if self.dangerously_bypass_approvals_and_sandbox {
             args.push("--dangerously-bypass-approvals-and-sandbox".into());

--- a/crates/codex-wrapper/src/version.rs
+++ b/crates/codex-wrapper/src/version.rs
@@ -27,7 +27,7 @@ pub const TESTED_CLI_VERSION_MIN: CliVersion = CliVersion {
 /// Highest `codex-cli` version this wrapper is tested against.
 pub const TESTED_CLI_VERSION_MAX: CliVersion = CliVersion {
     major: 0,
-    minor: 146,
+    minor: 147,
     patch: 0,
 };
 

--- a/crates/codex-wrapper/tests/contract.rs
+++ b/crates/codex-wrapper/tests/contract.rs
@@ -701,3 +701,65 @@ fn mcp_config_overrides_contract() {
         "config load failed on the generated overrides:\n{output}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --approve-for-me (0.147.0)
+//
+// This flag arrived in 0.147.0, which is the tested range's upper bound but
+// not its lower one. It cannot go in the maximal builders above, because the
+// contract job also runs against 0.145.0 where it does not exist.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore]
+fn approve_for_me_contract() {
+    use codex_wrapper::CliVersion;
+
+    let introduced = CliVersion::new(0, 147, 0);
+    let installed = CliVersion::parse_version_output(&cli_version())
+        .expect("the CLI should report a parsable version");
+
+    // Asserted in both directions rather than skipped below 0.147, so a wrong
+    // floor is caught either way: if the flag turns up earlier than claimed,
+    // the else branch fails and the docs need correcting.
+    for subcommand in [
+        vec!["exec".to_string()],
+        vec!["fork".to_string()],
+        vec!["resume".to_string()],
+    ] {
+        let accepted = help_flags(&subcommand);
+        let name = subcommand.join(" ");
+        if installed >= introduced {
+            assert!(
+                accepted.contains("--approve-for-me"),
+                "`codex {name}` no longer accepts --approve-for-me on {installed}"
+            );
+        } else {
+            assert!(
+                !accepted.contains("--approve-for-me"),
+                "`codex {name}` accepts --approve-for-me on {installed}, earlier than \
+                 the 0.147.0 floor documented on the builder methods"
+            );
+        }
+    }
+
+    if installed < introduced {
+        return;
+    }
+
+    assert_contract(
+        "ExecCommand::approve_for_me",
+        ExecCommand::new("probe").approve_for_me().args(),
+        1,
+    );
+    assert_contract(
+        "ForkCommand::approve_for_me",
+        ForkCommand::new().last().approve_for_me().args(),
+        1,
+    );
+    assert_contract(
+        "ResumeCommand::approve_for_me",
+        ResumeCommand::new().last().approve_for_me().args(),
+        1,
+    );
+}


### PR DESCRIPTION
The codex-specific half of #41. Trait alignment is deliberately not here; it is filed separately.

## Drift check first

The tested range topped out at 0.146.0 while the published CLI is 0.147.0. Before changing anything, ran the existing contract suite against 0.147.0:

```
test result: ok. 19 passed
```

So nothing the wrapper already emits has broken. The weekly `contract-latest` job last ran 2026-08-03 and passed, which predates 0.147.0.

## What is actually new

Diffed the CLI surface between 0.145.0 and 0.147.0:

| | Change |
|---|---|
| top-level subcommands | none added, none removed |
| `exec` flags | `--approve-for-me` added |
| `fork` flags | `--approve-for-me` added |
| `resume` flags | `--approve-for-me` added |
| `exec resume` flags | none |
| `review` flags | none |

> Route approval requests through automatic review using the workspace-write sandbox

Added as `approve_for_me()` on the three builders that accept it, and deliberately not on `ExecResumeCommand` or `ReviewCommand`.

## The contract check needed a different shape

`--approve-for-me` is absent in 0.146.0 and present in 0.147.0. It cannot go in the maximal builders, because the contract job also runs against the range's lower bound of 0.145.0, where `assert_contract` would fail on it.

So it gets its own check that asserts the relationship in **both** directions:

- at or above 0.147.0, the flag must be accepted by all three subcommands
- below 0.147.0, it must be absent

That way a wrong floor is caught either way. If the flag turns out to predate 0.147.0, the lower branch fails and the docs are corrected, rather than the check quietly skipping.

## Verified against all three CLIs

Installed 0.146.0 and 0.147.0 into a scratch prefix, leaving the global install alone:

```
0.145.0  20 passed
0.146.0  20 passed
0.147.0  20 passed
```

`TESTED_CLI_VERSION_MAX` and the CI matrix move together, which the existing `tested_range_matches_the_ci_contract_matrix` test already enforced.

## Local checks

fmt, clippy `-D warnings` under both feature sets, 231 lib tests, 141 no-default, 28 doc tests, rustdoc `-D warnings`.