### PR TITLE
feat(exec): type the native rollout budget configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,38 @@ The resolution was read off `codex doctor` on 0.145.0 rather than assumed, inclu
 where both a stored login and an env key are present, which the CLI itself flags as "mixed auth
 signals" and resolves in favour of the environment key.
 
-## Token Budgets
+## Native Rollout Budgets
+
+Bound one `codex exec` process with Codex's native rollout budget:
+
+```rust
+use codex_wrapper::{ExecCommand, ExecResumeCommand, RolloutBudgetConfig};
+
+let budget = RolloutBudgetConfig::builder(200_000)
+    .reminder_at_remaining_tokens([100_000, 25_000])
+    .sampling_token_weight(1.0)
+    .prefill_token_weight(0.25)
+    .build()?;
+
+let opening = ExecCommand::new("implement the change")
+    .rollout_budget(budget.clone());
+let resumed = ExecResumeCommand::new()
+    .session_id("thread-id")
+    .prompt("continue")
+    .rollout_budget(budget);
+```
+
+The limit is native weighted units, not portable total tokens. Codex uses a provider-reported
+`codex_rollout_budget_units` value when one is available. Otherwise it counts output tokens times
+`sampling_token_weight` plus non-cached input tokens times `prefill_token_weight`; cached input is
+excluded from that fallback. Enforcement happens after each completed response, so one response
+can overshoot the configured limit. Subagents within that CLI execution share the same budget.
+
+The wrapper emits the typed table after raw config and feature switches, so those cannot silently
+disable it. A separate CLI process, including a later resume, needs the config again. This is why
+both exec builders expose the same method.
+
+## Post-turn Token Budgets
 
 Cap what a session may consume. The ceiling is in tokens, not dollars, because the CLI reports
 token counts and no monetary cost:

--- a/README.md
+++ b/README.md
@@ -751,9 +751,10 @@ The limit is native weighted units, not portable total tokens. Codex uses a prov
 excluded from that fallback. Enforcement happens after each completed response, so one response
 can overshoot the configured limit. Subagents within that CLI execution share the same budget.
 
-The wrapper emits the typed table after raw config and feature switches, so those cannot silently
-disable it. A separate CLI process, including a later resume, needs the config again. This is why
-both exec builders expose the same method.
+The wrapper emits the typed table after raw config and suppresses conflicting `rollout_budget`
+feature toggles. Codex applies feature toggles after every config override regardless of argv order,
+so retaining one would silently disable or replace the table. A separate CLI process, including a
+later resume, needs the config again. This is why both exec builders expose the same method.
 
 ## Post-turn Token Budgets
 

--- a/README.md
+++ b/README.md
@@ -745,16 +745,20 @@ let resumed = ExecResumeCommand::new()
     .rollout_budget(budget);
 ```
 
-The limit is native weighted units, not portable total tokens. Codex uses a provider-reported
-`codex_rollout_budget_units` value when one is available. Otherwise it counts output tokens times
-`sampling_token_weight` plus non-cached input tokens times `prefill_token_weight`; cached input is
-excluded from that fallback. Enforcement happens after each completed response, so one response
-can overshoot the configured limit. Subagents within that CLI execution share the same budget.
+The limit is native rollout-budget units, not portable total tokens. Codex 0.145 and 0.146 always
+count output tokens times `sampling_token_weight` plus non-cached input tokens times
+`prefill_token_weight`. Starting with Codex 0.147, a provider-reported
+`codex_rollout_budget_units` value takes precedence when available; the weighted formula remains
+the fallback. Cached input is excluded from that fallback. Provider-reported units may be opaque,
+so hosts must not assume that a CLI upgrade preserves identical meter semantics. Enforcement
+happens after each completed response, so one response can overshoot the configured limit.
+Subagents within that CLI execution share the same budget.
 
 The wrapper emits the typed table after raw config and suppresses conflicting `rollout_budget`
-feature toggles. Codex applies feature toggles after every config override regardless of argv order,
-so retaining one would silently disable or replace the table. A separate CLI process, including a
-later resume, needs the config again. This is why both exec builders expose the same method.
+feature toggles from both the command and its client. Codex applies feature toggles after every
+config override regardless of argv order, so retaining one would silently disable or replace the
+table. A separate CLI process, including a later resume, needs the config again. This is why both
+exec builders expose the same method.
 
 ## Post-turn Token Budgets
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -724,7 +724,38 @@ The resolution was read off `codex doctor` on 0.145.0 rather than assumed, inclu
 where both a stored login and an env key are present, which the CLI itself flags as "mixed auth
 signals" and resolves in favour of the environment key.
 
-## Token Budgets
+## Native Rollout Budgets
+
+Bound one `codex exec` process with Codex's native rollout budget:
+
+```rust
+use codex_wrapper::{ExecCommand, ExecResumeCommand, RolloutBudgetConfig};
+
+let budget = RolloutBudgetConfig::builder(200_000)
+    .reminder_at_remaining_tokens([100_000, 25_000])
+    .sampling_token_weight(1.0)
+    .prefill_token_weight(0.25)
+    .build()?;
+
+let opening = ExecCommand::new("implement the change")
+    .rollout_budget(budget.clone());
+let resumed = ExecResumeCommand::new()
+    .session_id("thread-id")
+    .prompt("continue")
+    .rollout_budget(budget);
+```
+
+The limit is native weighted units, not portable total tokens. Codex uses a provider-reported
+`codex_rollout_budget_units` value when one is available. Otherwise it counts output tokens times
+`sampling_token_weight` plus non-cached input tokens times `prefill_token_weight`; cached input is
+excluded from that fallback. Enforcement happens after each completed response, so one response
+can overshoot the configured limit. Subagents within that CLI execution share the same budget.
+
+The wrapper emits the typed table after raw config and feature switches, so those cannot silently
+disable it. A separate CLI process, including a later resume, needs the config again. This is why
+both exec builders expose the same method.
+
+## Post-turn Token Budgets
 
 Cap what a session may consume. The ceiling is in tokens, not dollars, because the CLI reports
 token counts and no monetary cost:

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -751,9 +751,10 @@ The limit is native weighted units, not portable total tokens. Codex uses a prov
 excluded from that fallback. Enforcement happens after each completed response, so one response
 can overshoot the configured limit. Subagents within that CLI execution share the same budget.
 
-The wrapper emits the typed table after raw config and feature switches, so those cannot silently
-disable it. A separate CLI process, including a later resume, needs the config again. This is why
-both exec builders expose the same method.
+The wrapper emits the typed table after raw config and suppresses conflicting `rollout_budget`
+feature toggles. Codex applies feature toggles after every config override regardless of argv order,
+so retaining one would silently disable or replace the table. A separate CLI process, including a
+later resume, needs the config again. This is why both exec builders expose the same method.
 
 ## Post-turn Token Budgets
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -745,16 +745,20 @@ let resumed = ExecResumeCommand::new()
     .rollout_budget(budget);
 ```
 
-The limit is native weighted units, not portable total tokens. Codex uses a provider-reported
-`codex_rollout_budget_units` value when one is available. Otherwise it counts output tokens times
-`sampling_token_weight` plus non-cached input tokens times `prefill_token_weight`; cached input is
-excluded from that fallback. Enforcement happens after each completed response, so one response
-can overshoot the configured limit. Subagents within that CLI execution share the same budget.
+The limit is native rollout-budget units, not portable total tokens. Codex 0.145 and 0.146 always
+count output tokens times `sampling_token_weight` plus non-cached input tokens times
+`prefill_token_weight`. Starting with Codex 0.147, a provider-reported
+`codex_rollout_budget_units` value takes precedence when available; the weighted formula remains
+the fallback. Cached input is excluded from that fallback. Provider-reported units may be opaque,
+so hosts must not assume that a CLI upgrade preserves identical meter semantics. Enforcement
+happens after each completed response, so one response can overshoot the configured limit.
+Subagents within that CLI execution share the same budget.
 
 The wrapper emits the typed table after raw config and suppresses conflicting `rollout_budget`
-feature toggles. Codex applies feature toggles after every config override regardless of argv order,
-so retaining one would silently disable or replace the table. A separate CLI process, including a
-later resume, needs the config again. This is why both exec builders expose the same method.
+feature toggles from both the command and its client. Codex applies feature toggles after every
+config override regardless of argv order, so retaining one would silently disable or replace the
+table. A separate CLI process, including a later resume, needs the config again. This is why both
+exec builders expose the same method.
 
 ## Post-turn Token Budgets
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -262,18 +262,20 @@ impl ExecCommand {
         self
     }
 
-    /// Enforce a Codex-native weighted-token budget for this execution.
+    /// Enforce a Codex-native rollout-unit budget for this execution.
     ///
     /// Codex checks the budget at response boundaries, so one response can
-    /// cross the limit before the run stops. The native meter prefers
-    /// provider-supplied rollout units; its fallback weights output and
-    /// non-cached input rather than portable total-token usage. See
-    /// [`RolloutBudgetConfig`] for the exact contract.
+    /// cross the limit before the run stops. Codex 0.145-0.146 use weighted
+    /// output and non-cached input; starting with 0.147, a provider-supplied
+    /// rollout-unit value takes precedence when available. Neither is
+    /// portable total-token usage. See [`RolloutBudgetConfig`] for the exact
+    /// versioned contract.
     ///
     /// This typed override is emitted after raw config, and conflicting
-    /// `rollout_budget` feature toggles are suppressed. Codex applies feature
-    /// toggles after every `-c` value regardless of argv order, so retaining
-    /// either toggle would otherwise disable or replace this table.
+    /// `rollout_budget` feature toggles from both this command and its
+    /// [`crate::Codex`] client are suppressed. Codex applies feature toggles
+    /// after every `-c` value regardless of argv order, so retaining either
+    /// toggle would otherwise disable or replace this table.
     #[must_use]
     pub fn rollout_budget(mut self, budget: RolloutBudgetConfig) -> Self {
         self.rollout_budget = Some(budget);
@@ -821,7 +823,7 @@ impl ExecResumeCommand {
         self
     }
 
-    /// Enforce a Codex-native weighted-token budget for this resumed execution.
+    /// Enforce a Codex-native rollout-unit budget for this resumed execution.
     ///
     /// The meter and response-boundary overshoot are identical to
     /// [`ExecCommand::rollout_budget`]. Emitting the same config on resume is

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -270,8 +270,10 @@ impl ExecCommand {
     /// non-cached input rather than portable total-token usage. See
     /// [`RolloutBudgetConfig`] for the exact contract.
     ///
-    /// This typed override is emitted after raw config and feature switches,
-    /// so they cannot silently disable or widen it.
+    /// This typed override is emitted after raw config, and conflicting
+    /// `rollout_budget` feature toggles are suppressed. Codex applies feature
+    /// toggles after every `-c` value regardless of argv order, so retaining
+    /// either toggle would otherwise disable or replace this table.
     #[must_use]
     pub fn rollout_budget(mut self, budget: RolloutBudgetConfig) -> Self {
         self.rollout_budget = Some(budget);
@@ -536,8 +538,12 @@ impl CodexCommand for ExecCommand {
 
         push_typed_config(&mut args, self.approval_policy, self.web_search);
         push_repeat(&mut args, "-c", &self.config_overrides);
-        push_repeat(&mut args, "--enable", &self.enabled_features);
-        push_repeat(&mut args, "--disable", &self.disabled_features);
+        push_feature_toggles(
+            &mut args,
+            &self.enabled_features,
+            &self.disabled_features,
+            self.rollout_budget.is_some(),
+        );
         if let Some(budget) = &self.rollout_budget {
             args.push("-c".into());
             args.push(budget.config_override());
@@ -968,8 +974,12 @@ impl CodexCommand for ExecResumeCommand {
             ));
         }
         push_repeat(&mut args, "-c", &self.config_overrides);
-        push_repeat(&mut args, "--enable", &self.enabled_features);
-        push_repeat(&mut args, "--disable", &self.disabled_features);
+        push_feature_toggles(
+            &mut args,
+            &self.enabled_features,
+            &self.disabled_features,
+            self.rollout_budget.is_some(),
+        );
         if let Some(budget) = &self.rollout_budget {
             args.push("-c".into());
             args.push(budget.config_override());
@@ -1035,6 +1045,23 @@ fn push_repeat(args: &mut Vec<String>, flag: &str, values: &[String]) {
     for value in values {
         args.push(flag.into());
         args.push(value.clone());
+    }
+}
+
+fn push_feature_toggles(
+    args: &mut Vec<String>,
+    enabled: &[String],
+    disabled: &[String],
+    protects_rollout_budget: bool,
+) {
+    let keep = |feature: &&String| !protects_rollout_budget || feature.as_str() != "rollout_budget";
+    for feature in enabled.iter().filter(keep) {
+        args.push("--enable".into());
+        args.push(feature.clone());
+    }
+    for feature in disabled.iter().filter(keep) {
+        args.push("--disable".into());
+        args.push(feature.clone());
     }
 }
 
@@ -1239,13 +1266,19 @@ mod tests {
         let opening = ExecCommand::new("hi")
             .rollout_budget(budget.clone())
             .config("features.rollout_budget=false")
+            .enable("rollout_budget")
             .disable("rollout_budget")
+            .enable("keep-enabled")
+            .disable("keep-disabled")
             .args();
         let resumed = ExecResumeCommand::new()
             .session_id("thread")
             .rollout_budget(budget)
             .config("features.rollout_budget=false")
+            .enable("rollout_budget")
             .disable("rollout_budget")
+            .enable("keep-enabled")
+            .disable("keep-disabled")
             .args();
 
         for args in [opening, resumed] {
@@ -1254,14 +1287,24 @@ mod tests {
                 .iter()
                 .position(|arg| arg == "features.rollout_budget=false")
                 .unwrap();
-            let disabled_at = args.iter().position(|arg| arg == "rollout_budget").unwrap();
             assert!(
                 raw_at < budget_at,
                 "native budget must beat raw config: {args:?}"
             );
             assert!(
-                disabled_at < budget_at,
-                "native budget must beat feature disable: {args:?}"
+                !args.windows(2).any(|pair| {
+                    matches!(pair[0].as_str(), "--enable" | "--disable")
+                        && pair[1] == "rollout_budget"
+                }),
+                "native budget must suppress conflicting feature toggles: {args:?}"
+            );
+            assert!(
+                args.windows(2)
+                    .any(|pair| pair == ["--enable", "keep-enabled"])
+            );
+            assert!(
+                args.windows(2)
+                    .any(|pair| pair == ["--disable", "keep-disabled"])
             );
         }
     }

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -4,6 +4,7 @@ use crate::command::CodexCommand;
 use crate::error::Error;
 use crate::error::Result;
 use crate::exec::{self, CommandOutput};
+use crate::rollout_budget::RolloutBudgetConfig;
 use crate::types::{ApprovalPolicyConfig, Color, SandboxMode, WebSearchMode};
 #[cfg(feature = "json")]
 use crate::types::{JsonLineEvent, QueryResult};
@@ -74,6 +75,7 @@ pub struct ExecCommand {
     config_overrides: Vec<String>,
     enabled_features: Vec<String>,
     disabled_features: Vec<String>,
+    rollout_budget: Option<RolloutBudgetConfig>,
     images: Vec<String>,
     model: Option<String>,
     oss: bool,
@@ -110,6 +112,7 @@ impl ExecCommand {
             config_overrides: Vec::new(),
             enabled_features: Vec::new(),
             disabled_features: Vec::new(),
+            rollout_budget: None,
             images: Vec::new(),
             model: None,
             oss: false,
@@ -256,6 +259,22 @@ impl ExecCommand {
     #[must_use]
     pub fn disable(mut self, feature: impl Into<String>) -> Self {
         self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Enforce a Codex-native weighted-token budget for this execution.
+    ///
+    /// Codex checks the budget at response boundaries, so one response can
+    /// cross the limit before the run stops. The native meter prefers
+    /// provider-supplied rollout units; its fallback weights output and
+    /// non-cached input rather than portable total-token usage. See
+    /// [`RolloutBudgetConfig`] for the exact contract.
+    ///
+    /// This typed override is emitted after raw config and feature switches,
+    /// so they cannot silently disable or widen it.
+    #[must_use]
+    pub fn rollout_budget(mut self, budget: RolloutBudgetConfig) -> Self {
+        self.rollout_budget = Some(budget);
         self
     }
 
@@ -519,6 +538,10 @@ impl CodexCommand for ExecCommand {
         push_repeat(&mut args, "-c", &self.config_overrides);
         push_repeat(&mut args, "--enable", &self.enabled_features);
         push_repeat(&mut args, "--disable", &self.disabled_features);
+        if let Some(budget) = &self.rollout_budget {
+            args.push("-c".into());
+            args.push(budget.config_override());
+        }
         push_repeat(&mut args, "--image", &self.images);
 
         if let Some(model) = &self.model {
@@ -619,6 +642,7 @@ pub struct ExecResumeCommand {
     config_overrides: Vec<String>,
     enabled_features: Vec<String>,
     disabled_features: Vec<String>,
+    rollout_budget: Option<RolloutBudgetConfig>,
     images: Vec<String>,
     model: Option<String>,
     strict_config: bool,
@@ -649,6 +673,7 @@ impl ExecResumeCommand {
             config_overrides: Vec::new(),
             enabled_features: Vec::new(),
             disabled_features: Vec::new(),
+            rollout_budget: None,
             images: Vec::new(),
             model: None,
             strict_config: false,
@@ -787,6 +812,18 @@ impl ExecResumeCommand {
     #[must_use]
     pub fn disable(mut self, feature: impl Into<String>) -> Self {
         self.disabled_features.push(feature.into());
+        self
+    }
+
+    /// Enforce a Codex-native weighted-token budget for this resumed execution.
+    ///
+    /// The meter and response-boundary overshoot are identical to
+    /// [`ExecCommand::rollout_budget`]. Emitting the same config on resume is
+    /// required: a budget applied only to the opening process does not carry
+    /// into a later `codex exec resume` process.
+    #[must_use]
+    pub fn rollout_budget(mut self, budget: RolloutBudgetConfig) -> Self {
+        self.rollout_budget = Some(budget);
         self
     }
 
@@ -933,6 +970,10 @@ impl CodexCommand for ExecResumeCommand {
         push_repeat(&mut args, "-c", &self.config_overrides);
         push_repeat(&mut args, "--enable", &self.enabled_features);
         push_repeat(&mut args, "--disable", &self.disabled_features);
+        if let Some(budget) = &self.rollout_budget {
+            args.push("-c".into());
+            args.push(budget.config_override());
+        }
         if self.last {
             args.push("--last".into());
         }
@@ -1184,6 +1225,45 @@ mod tests {
             .position(|a| a == "approval_policy=\"untrusted\"")
             .unwrap();
         assert!(typed < raw, "raw override must win: {args:?}");
+    }
+
+    #[test]
+    fn native_rollout_budget_is_identical_and_final_on_open_and_resume() {
+        let budget = RolloutBudgetConfig::builder(10_000)
+            .reminder_at_remaining_tokens([5_000, 1_000])
+            .sampling_token_weight(1.0)
+            .prefill_token_weight(0.25)
+            .build()
+            .expect("valid budget");
+        let expected = budget.config_override();
+        let opening = ExecCommand::new("hi")
+            .rollout_budget(budget.clone())
+            .config("features.rollout_budget=false")
+            .disable("rollout_budget")
+            .args();
+        let resumed = ExecResumeCommand::new()
+            .session_id("thread")
+            .rollout_budget(budget)
+            .config("features.rollout_budget=false")
+            .disable("rollout_budget")
+            .args();
+
+        for args in [opening, resumed] {
+            let budget_at = args.iter().position(|arg| arg == &expected).unwrap();
+            let raw_at = args
+                .iter()
+                .position(|arg| arg == "features.rollout_budget=false")
+                .unwrap();
+            let disabled_at = args.iter().position(|arg| arg == "rollout_budget").unwrap();
+            assert!(
+                raw_at < budget_at,
+                "native budget must beat raw config: {args:?}"
+            );
+            assert!(
+                disabled_at < budget_at,
+                "native budget must beat feature disable: {args:?}"
+            );
+        }
     }
 
     /// #55: `--full-auto` is hidden and deprecated on the exec family.

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -99,6 +99,13 @@ pub enum Error {
         max_tokens: u64,
     },
 
+    /// A native rollout-budget configuration was invalid before launch.
+    #[error("invalid Codex rollout budget: {message}")]
+    InvalidRolloutBudget {
+        /// The failed invariant.
+        message: String,
+    },
+
     /// A file on disk could not be parsed.
     ///
     /// Distinct from [`Error::Config`], which is the CLI rejecting a

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -264,7 +264,30 @@ pub async fn run_codex_with_retry(
 /// [`CodexCommand::to_command_string`]: crate::command::CodexCommand::to_command_string
 pub(crate) fn assemble_args(codex: &Codex, args: Vec<String>) -> Vec<String> {
     let mut command_args = Vec::with_capacity(codex.global_args.len() + args.len());
-    command_args.extend(codex.global_args.iter().cloned());
+    let protects_rollout_budget = args
+        .windows(2)
+        .any(|pair| pair[0] == "-c" && crate::RolloutBudgetConfig::is_config_override(&pair[1]));
+    let mut global_args = codex.global_args.iter().peekable();
+    while let Some(arg) = global_args.next() {
+        if protects_rollout_budget
+            && matches!(arg.as_str(), "--enable" | "--disable")
+            && global_args
+                .peek()
+                .is_some_and(|feature| feature.as_str() == "rollout_budget")
+        {
+            global_args.next();
+            continue;
+        }
+        if protects_rollout_budget
+            && matches!(
+                arg.as_str(),
+                "--enable=rollout_budget" | "--disable=rollout_budget"
+            )
+        {
+            continue;
+        }
+        command_args.push(arg.clone());
+    }
     command_args.extend(args);
     command_args
 }
@@ -667,6 +690,66 @@ async fn run_with_timeout(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::CodexCommand;
+
+    #[test]
+    fn typed_rollout_budget_suppresses_conflicting_client_global_toggles() {
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .config("features.rollout_budget=false")
+            .enable("rollout_budget")
+            .disable("rollout_budget")
+            .arg("--enable=rollout_budget")
+            .arg("--disable=rollout_budget")
+            .arg("--disable")
+            .arg("rollout_budget")
+            .enable("keep-enabled")
+            .disable("keep-disabled")
+            .build()
+            .expect("echo must exist");
+        let budget = crate::RolloutBudgetConfig::builder(10_000)
+            .build()
+            .expect("valid budget");
+        let expected = budget.config_override();
+        let opening = crate::ExecCommand::new("hi")
+            .rollout_budget(budget.clone())
+            .args();
+        let resumed = crate::ExecResumeCommand::new()
+            .session_id("thread")
+            .rollout_budget(budget)
+            .args();
+
+        for args in [opening, resumed] {
+            let assembled = assemble_args(&codex, args);
+            assert!(assembled.iter().any(|arg| arg == &expected));
+            assert!(
+                !assembled.windows(2).any(|pair| {
+                    matches!(pair[0].as_str(), "--enable" | "--disable")
+                        && pair[1] == "rollout_budget"
+                }),
+                "typed budget must suppress paired client toggles: {assembled:?}"
+            );
+            assert!(
+                !assembled.iter().any(|arg| {
+                    matches!(
+                        arg.as_str(),
+                        "--enable=rollout_budget" | "--disable=rollout_budget"
+                    )
+                }),
+                "typed budget must suppress equals-form client toggles: {assembled:?}"
+            );
+            assert!(
+                assembled
+                    .windows(2)
+                    .any(|pair| pair == ["--enable", "keep-enabled"])
+            );
+            assert!(
+                assembled
+                    .windows(2)
+                    .any(|pair| pair == ["--disable", "keep-disabled"])
+            );
+        }
+    }
 
     fn make_output(stdout: &str, stderr: &str) -> CommandOutput {
         CommandOutput {

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -547,6 +547,11 @@ impl CodexBuilder {
     }
 
     /// Append a raw global argument passed before any subcommand.
+    ///
+    /// When an exec command has a typed rollout budget, conflicting global
+    /// `--enable/--disable rollout_budget` arguments are suppressed at final
+    /// assembly. Codex applies feature toggles after config regardless of argv
+    /// order, so retaining one could silently defeat the typed protection.
     #[must_use]
     pub fn arg(mut self, arg: impl Into<String>) -> Self {
         self.global_args.push(arg.into());
@@ -562,6 +567,9 @@ impl CodexBuilder {
     }
 
     /// Enable a feature flag globally (`--enable <name>`).
+    ///
+    /// A `rollout_budget` toggle is suppressed for an exec command that has a
+    /// typed [`RolloutBudgetConfig`].
     #[must_use]
     pub fn enable(mut self, feature: impl Into<String>) -> Self {
         self.global_args.push("--enable".into());
@@ -570,6 +578,9 @@ impl CodexBuilder {
     }
 
     /// Disable a feature flag globally (`--disable <name>`).
+    ///
+    /// A `rollout_budget` toggle is suppressed for an exec command that has a
+    /// typed [`RolloutBudgetConfig`].
     #[must_use]
     pub fn disable(mut self, feature: impl Into<String>) -> Self {
         self.global_args.push("--disable".into());

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -179,6 +179,7 @@ pub mod exec;
 pub mod history;
 pub mod mcp_config;
 pub mod retry;
+pub mod rollout_budget;
 #[cfg(feature = "json")]
 pub mod session;
 #[cfg(feature = "json")]
@@ -228,6 +229,7 @@ pub use exec::CommandOutput;
 pub use history::{SessionFile, SessionLog, SessionMeta, SessionQuery};
 pub use mcp_config::{McpConfigBuilder, McpServerConfig};
 pub use retry::{BackoffStrategy, RetryPolicy};
+pub use rollout_budget::{RolloutBudgetConfig, RolloutBudgetConfigBuilder};
 #[cfg(feature = "json")]
 pub use session::{Session, TurnRecord};
 pub use types::*;

--- a/crates/codex-wrapper/src/rollout_budget.rs
+++ b/crates/codex-wrapper/src/rollout_budget.rs
@@ -47,7 +47,7 @@ impl RolloutBudgetConfig {
         self.limit_tokens
     }
 
-    /// Remaining-token thresholds that make Codex restate the budget.
+    /// Remaining rollout-budget-unit thresholds that make Codex restate the budget.
     #[must_use]
     pub fn reminder_at_remaining_tokens(&self) -> &[u64] {
         &self.reminder_at_remaining_tokens

--- a/crates/codex-wrapper/src/rollout_budget.rs
+++ b/crates/codex-wrapper/src/rollout_budget.rs
@@ -1,0 +1,195 @@
+//! Native per-execution rollout-budget configuration.
+//!
+//! This is deliberately separate from [`crate::TokenBudget`]. That type sees
+//! usage only after a complete CLI turn and can refuse the next turn; this
+//! one asks Codex itself to stop an in-progress `exec` at a response boundary.
+//!
+//! The native meter is not portable total-token usage. Codex prefers a
+//! provider-reported `codex_rollout_budget_units` value. When that is absent,
+//! it computes `output_tokens * sampling_token_weight` plus non-cached input
+//! tokens times `prefill_token_weight`. Cached input is not included in that
+//! fallback. One response can cross the limit before Codex observes it.
+
+use crate::error::{Error, Result};
+
+/// A validated Codex-native rollout budget for one CLI execution.
+///
+/// Use [`RolloutBudgetConfig::builder`] and pass the result to
+/// [`crate::ExecCommand::rollout_budget`] or
+/// [`crate::ExecResumeCommand::rollout_budget`]. The same config shape is
+/// accepted by both opening and resumed `exec` commands.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RolloutBudgetConfig {
+    limit_tokens: u64,
+    reminder_at_remaining_tokens: Vec<u64>,
+    sampling_token_weight: f64,
+    prefill_token_weight: f64,
+}
+
+impl RolloutBudgetConfig {
+    /// Start a rollout-budget builder with the native weighted-token limit.
+    #[must_use]
+    pub fn builder(limit_tokens: u64) -> RolloutBudgetConfigBuilder {
+        RolloutBudgetConfigBuilder {
+            limit_tokens,
+            reminder_at_remaining_tokens: Vec::new(),
+            sampling_token_weight: 1.0,
+            prefill_token_weight: 1.0,
+        }
+    }
+
+    /// The configured native weighted-token limit.
+    #[must_use]
+    pub fn limit_tokens(&self) -> u64 {
+        self.limit_tokens
+    }
+
+    /// Remaining-token thresholds that make Codex restate the budget.
+    #[must_use]
+    pub fn reminder_at_remaining_tokens(&self) -> &[u64] {
+        &self.reminder_at_remaining_tokens
+    }
+
+    /// Weight applied to generated output tokens when provider units are absent.
+    #[must_use]
+    pub fn sampling_token_weight(&self) -> f64 {
+        self.sampling_token_weight
+    }
+
+    /// Weight applied to non-cached input tokens when provider units are absent.
+    #[must_use]
+    pub fn prefill_token_weight(&self) -> f64 {
+        self.prefill_token_weight
+    }
+
+    pub(crate) fn config_override(&self) -> String {
+        let reminders = self
+            .reminder_at_remaining_tokens
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(
+            "features.rollout_budget={{enabled=true,limit_tokens={},reminder_at_remaining_tokens=[{}],sampling_token_weight={},prefill_token_weight={}}}",
+            self.limit_tokens, reminders, self.sampling_token_weight, self.prefill_token_weight,
+        )
+    }
+}
+
+/// Builder for [`RolloutBudgetConfig`].
+#[derive(Debug, Clone)]
+pub struct RolloutBudgetConfigBuilder {
+    limit_tokens: u64,
+    reminder_at_remaining_tokens: Vec<u64>,
+    sampling_token_weight: f64,
+    prefill_token_weight: f64,
+}
+
+impl RolloutBudgetConfigBuilder {
+    /// Replace the remaining-token thresholds that make Codex restate the budget.
+    ///
+    /// An empty list is valid and disables threshold reminders. Codex still
+    /// includes the initial remaining-budget message and enforces the limit.
+    #[must_use]
+    pub fn reminder_at_remaining_tokens(
+        mut self,
+        thresholds: impl IntoIterator<Item = u64>,
+    ) -> Self {
+        self.reminder_at_remaining_tokens = thresholds.into_iter().collect();
+        self
+    }
+
+    /// Set the weight for generated output tokens when provider units are absent.
+    #[must_use]
+    pub fn sampling_token_weight(mut self, weight: f64) -> Self {
+        self.sampling_token_weight = weight;
+        self
+    }
+
+    /// Set the weight for non-cached input tokens when provider units are absent.
+    #[must_use]
+    pub fn prefill_token_weight(mut self, weight: f64) -> Self {
+        self.prefill_token_weight = weight;
+        self
+    }
+
+    /// Validate and build the native rollout-budget config.
+    pub fn build(self) -> Result<RolloutBudgetConfig> {
+        if self.limit_tokens == 0 || self.limit_tokens > i64::MAX as u64 {
+            return Err(invalid("limit_tokens must be in 1..=i64::MAX"));
+        }
+        if self
+            .reminder_at_remaining_tokens
+            .iter()
+            .any(|&threshold| threshold == 0 || threshold >= self.limit_tokens)
+        {
+            return Err(invalid(
+                "reminder thresholds must be positive and below limit_tokens",
+            ));
+        }
+        for (field, weight) in [
+            ("sampling_token_weight", self.sampling_token_weight),
+            ("prefill_token_weight", self.prefill_token_weight),
+        ] {
+            if !weight.is_finite() || weight < 0.0 {
+                return Err(invalid(format!("{field} must be finite and non-negative")));
+            }
+        }
+        Ok(RolloutBudgetConfig {
+            limit_tokens: self.limit_tokens,
+            reminder_at_remaining_tokens: self.reminder_at_remaining_tokens,
+            sampling_token_weight: self.sampling_token_weight,
+            prefill_token_weight: self.prefill_token_weight,
+        })
+    }
+}
+
+fn invalid(message: impl Into<String>) -> Error {
+    Error::InvalidRolloutBudget {
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_config_serializes_as_one_strict_cli_override() {
+        let budget = RolloutBudgetConfig::builder(100_000)
+            .reminder_at_remaining_tokens([50_000, 10_000])
+            .sampling_token_weight(1.5)
+            .prefill_token_weight(0.25)
+            .build()
+            .expect("valid budget");
+
+        assert_eq!(budget.limit_tokens(), 100_000);
+        assert_eq!(budget.reminder_at_remaining_tokens(), [50_000, 10_000]);
+        assert_eq!(
+            budget.config_override(),
+            "features.rollout_budget={enabled=true,limit_tokens=100000,reminder_at_remaining_tokens=[50000,10000],sampling_token_weight=1.5,prefill_token_weight=0.25}"
+        );
+    }
+
+    #[test]
+    fn invalid_limits_thresholds_and_weights_fail_before_launch() {
+        for result in [
+            RolloutBudgetConfig::builder(0).build(),
+            RolloutBudgetConfig::builder(i64::MAX as u64 + 1).build(),
+            RolloutBudgetConfig::builder(100)
+                .reminder_at_remaining_tokens([0])
+                .build(),
+            RolloutBudgetConfig::builder(100)
+                .reminder_at_remaining_tokens([100])
+                .build(),
+            RolloutBudgetConfig::builder(100)
+                .sampling_token_weight(f64::NAN)
+                .build(),
+            RolloutBudgetConfig::builder(100)
+                .prefill_token_weight(-1.0)
+                .build(),
+        ] {
+            assert!(matches!(result, Err(Error::InvalidRolloutBudget { .. })));
+        }
+    }
+}

--- a/crates/codex-wrapper/src/rollout_budget.rs
+++ b/crates/codex-wrapper/src/rollout_budget.rs
@@ -4,11 +4,14 @@
 //! usage only after a complete CLI turn and can refuse the next turn; this
 //! one asks Codex itself to stop an in-progress `exec` at a response boundary.
 //!
-//! The native meter is not portable total-token usage. Codex prefers a
-//! provider-reported `codex_rollout_budget_units` value. When that is absent,
-//! it computes `output_tokens * sampling_token_weight` plus non-cached input
-//! tokens times `prefill_token_weight`. Cached input is not included in that
-//! fallback. One response can cross the limit before Codex observes it.
+//! The native meter is not portable total-token usage. Codex 0.145 and 0.146
+//! always compute `output_tokens * sampling_token_weight` plus non-cached
+//! input tokens times `prefill_token_weight`. Starting with 0.147, Codex
+//! prefers a provider-reported `codex_rollout_budget_units` value when one is
+//! available and otherwise uses that weighted fallback. Cached input is not
+//! included in the fallback. Provider-reported units may have different,
+//! opaque semantics, so hosts must not treat a CLI upgrade as an unchanged
+//! portable meter. One response can cross the limit before Codex observes it.
 
 use crate::error::{Error, Result};
 
@@ -27,7 +30,7 @@ pub struct RolloutBudgetConfig {
 }
 
 impl RolloutBudgetConfig {
-    /// Start a rollout-budget builder with the native weighted-token limit.
+    /// Start a builder with the native rollout-budget-unit limit.
     #[must_use]
     pub fn builder(limit_tokens: u64) -> RolloutBudgetConfigBuilder {
         RolloutBudgetConfigBuilder {
@@ -38,7 +41,7 @@ impl RolloutBudgetConfig {
         }
     }
 
-    /// The configured native weighted-token limit.
+    /// The configured native rollout-budget-unit limit.
     #[must_use]
     pub fn limit_tokens(&self) -> u64 {
         self.limit_tokens
@@ -74,6 +77,10 @@ impl RolloutBudgetConfig {
             self.limit_tokens, reminders, self.sampling_token_weight, self.prefill_token_weight,
         )
     }
+
+    pub(crate) fn is_config_override(value: &str) -> bool {
+        value.starts_with("features.rollout_budget={enabled=true,limit_tokens=")
+    }
 }
 
 /// Builder for [`RolloutBudgetConfig`].
@@ -86,7 +93,7 @@ pub struct RolloutBudgetConfigBuilder {
 }
 
 impl RolloutBudgetConfigBuilder {
-    /// Replace the remaining-token thresholds that make Codex restate the budget.
+    /// Replace the remaining-unit thresholds that make Codex restate the budget.
     ///
     /// An empty list is valid and disables threshold reminders. Codex still
     /// includes the initial remaining-budget message and enforces the limit.

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -346,6 +346,36 @@ mod tests {
         assert!(!events.is_empty(), "expected at least one event");
     }
 
+    /// Contract captured from a paid 0.145.0 run: the callback receives the
+    /// typed terminal before the process reports its non-zero exit, including
+    /// an assistant message but no fabricated token counts.
+    #[tokio::test]
+    async fn stream_exec_classifies_native_rollout_budget_exhaustion() {
+        let codex = fake_codex("fake-codex-rollout-budget.sh");
+        let cmd = crate::command::exec::ExecCommand::new("probe").json();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let collected = Arc::clone(&events);
+
+        let error = stream_exec(&codex, &cmd, move |event| {
+            collected.lock().unwrap().push(event);
+        })
+        .await
+        .expect_err("captured rollout exhaustion exits non-zero");
+
+        assert_eq!(error.exit_code(), Some(1));
+        let events = events.lock().unwrap();
+        let terminal = events
+            .iter()
+            .find(|event| event.is_turn_failed())
+            .expect("turn.failed must be delivered");
+        assert_eq!(
+            terminal.turn_failure_kind(),
+            Some(crate::TurnFailureKind::RolloutBudgetExhausted)
+        );
+        assert_eq!(terminal.usage(), None);
+        assert_eq!(crate::QueryResult::from_events(events.clone()).result, "ok");
+    }
+
     #[tokio::test]
     async fn stream_exec_timeout() {
         let codex = Codex::builder()

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -26,6 +26,10 @@
 //!   `type` of `agent_message` and its text in a `text` field. A review's
 //!   diff-reading steps arrive as `command_execution` items on the same event.
 //! - A review's `turn.completed` reports a usage object of all zeros.
+//! - Exhausting the native rollout budget emits an `error` event followed by
+//!   `turn.failed`, both with `shared rollout token budget exhausted`. The
+//!   terminal event carries no usage object on 0.145.0 even though Codex used
+//!   its internal meter to make the decision.
 //!
 //! - The stream carries **no incremental text**. Three captured runs, a
 //!   one-word exec, a four-sentence exec, and a review, each delivered the
@@ -253,6 +257,22 @@ pub struct JsonLineEvent {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// A terminal `turn.failed` classification from the Codex JSONL stream.
+///
+/// Codex does not currently emit a machine-readable error code, so the one
+/// typed class here is pinned to the stable message captured from 0.145.0.
+/// Unknown failures remain distinguishable rather than being forced into the
+/// budget class.
+#[cfg(feature = "json")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TurnFailureKind {
+    /// Codex stopped after exhausting its native shared rollout budget.
+    RolloutBudgetExhausted,
+    /// A terminal failure not classified by this wrapper.
+    Other,
+}
+
 #[cfg(feature = "json")]
 impl JsonLineEvent {
     /// Returns the `session_id` field, if present and a string.
@@ -277,6 +297,42 @@ impl JsonLineEvent {
     #[must_use]
     pub fn is_turn_failed(&self) -> bool {
         self.event_type == "turn.failed"
+    }
+
+    /// The message carried by a terminal `turn.failed` event.
+    ///
+    /// The captured CLI shape nests it under `error.message`. A string-valued
+    /// `error` and a top-level `message` are accepted as compatible variants.
+    #[must_use]
+    pub fn turn_failure_message(&self) -> Option<&str> {
+        if !self.is_turn_failed() {
+            return None;
+        }
+        self.extra
+            .get("error")
+            .and_then(|error| {
+                error
+                    .as_str()
+                    .or_else(|| error.get("message").and_then(serde_json::Value::as_str))
+            })
+            .or_else(|| {
+                self.extra
+                    .get("message")
+                    .and_then(serde_json::Value::as_str)
+            })
+    }
+
+    /// Classify a terminal `turn.failed` event without downstream string matching.
+    #[must_use]
+    pub fn turn_failure_kind(&self) -> Option<TurnFailureKind> {
+        let message = self.turn_failure_message()?;
+        Some(
+            if message.contains("shared rollout token budget exhausted") {
+                TurnFailureKind::RolloutBudgetExhausted
+            } else {
+                TurnFailureKind::Other
+            },
+        )
     }
 
     /// Token counts reported by a `turn.completed` event.
@@ -399,8 +455,9 @@ impl JsonLineEvent {
 pub struct QueryResult {
     /// Assistant text, concatenated from the turn's agent-message items.
     ///
-    /// Empty when the turn produced no agent message, which includes every
-    /// failed turn.
+    /// Empty when the turn produced no agent message. A failed turn can still
+    /// carry text produced before its terminal failure; native rollout-budget
+    /// exhaustion is one observed example.
     pub result: String,
     /// The `session_id` captured from the event stream, if any.
     ///
@@ -737,6 +794,29 @@ mod tests {
         // The pre-#73 parser matched this. The CLI has never emitted it.
         let bogus: JsonLineEvent = serde_json::from_str(r#"{"type":"completed"}"#).unwrap();
         assert!(!bogus.is_turn_completed());
+    }
+
+    /// Transcribed from a paid `codex-cli` 0.145.0 run with a one-unit native
+    /// rollout budget. The CLI exposes the limit decision but no usage object.
+    #[cfg(feature = "json")]
+    #[test]
+    fn classifies_captured_rollout_budget_terminal_without_inventing_usage() {
+        let failed: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"turn.failed","error":{"message":"shared rollout token budget exhausted"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            failed.turn_failure_kind(),
+            Some(TurnFailureKind::RolloutBudgetExhausted)
+        );
+        assert_eq!(failed.usage(), None);
+
+        let other: JsonLineEvent = serde_json::from_str(
+            r#"{"type":"turn.failed","error":{"message":"tool policy rejected"}}"#,
+        )
+        .unwrap();
+        assert_eq!(other.turn_failure_kind(), Some(TurnFailureKind::Other));
     }
 
     #[cfg(feature = "json")]

--- a/crates/codex-wrapper/src/types.rs
+++ b/crates/codex-wrapper/src/types.rs
@@ -301,8 +301,7 @@ impl JsonLineEvent {
 
     /// The message carried by a terminal `turn.failed` event.
     ///
-    /// The captured CLI shape nests it under `error.message`. A string-valued
-    /// `error` and a top-level `message` are accepted as compatible variants.
+    /// The captured CLI shape nests it under `error.message`.
     #[must_use]
     pub fn turn_failure_message(&self) -> Option<&str> {
         if !self.is_turn_failed() {
@@ -310,29 +309,23 @@ impl JsonLineEvent {
         }
         self.extra
             .get("error")
-            .and_then(|error| {
-                error
-                    .as_str()
-                    .or_else(|| error.get("message").and_then(serde_json::Value::as_str))
-            })
-            .or_else(|| {
-                self.extra
-                    .get("message")
-                    .and_then(serde_json::Value::as_str)
-            })
+            .and_then(|error| error.get("message"))
+            .and_then(serde_json::Value::as_str)
     }
 
     /// Classify a terminal `turn.failed` event without downstream string matching.
     #[must_use]
     pub fn turn_failure_kind(&self) -> Option<TurnFailureKind> {
-        let message = self.turn_failure_message()?;
-        Some(
-            if message.contains("shared rollout token budget exhausted") {
+        self.is_turn_failed().then(|| {
+            if self
+                .turn_failure_message()
+                .is_some_and(|message| message.contains("shared rollout token budget exhausted"))
+            {
                 TurnFailureKind::RolloutBudgetExhausted
             } else {
                 TurnFailureKind::Other
-            },
-        )
+            }
+        })
     }
 
     /// Token counts reported by a `turn.completed` event.
@@ -817,6 +810,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(other.turn_failure_kind(), Some(TurnFailureKind::Other));
+
+        let missing_message: JsonLineEvent =
+            serde_json::from_str(r#"{"type":"turn.failed"}"#).unwrap();
+        assert_eq!(
+            missing_message.turn_failure_kind(),
+            Some(TurnFailureKind::Other)
+        );
+
+        let nonterminal: JsonLineEvent =
+            serde_json::from_str(r#"{"type":"turn.started"}"#).unwrap();
+        assert_eq!(nonterminal.turn_failure_kind(), None);
     }
 
     #[cfg(feature = "json")]

--- a/crates/codex-wrapper/tests/contract.rs
+++ b/crates/codex-wrapper/tests/contract.rs
@@ -53,7 +53,7 @@ use std::process::Command;
 
 use codex_wrapper::{
     ApprovalPolicy, ApprovalPolicyConfig, CodexCommand, Color, ExecCommand, ExecResumeCommand,
-    ForkCommand, ResumeCommand, ReviewCommand, SandboxMode, WebSearchMode,
+    ForkCommand, ResumeCommand, ReviewCommand, RolloutBudgetConfig, SandboxMode, WebSearchMode,
 };
 
 /// Value used to force a config-key probe to fail. Must never be a valid
@@ -218,6 +218,35 @@ fn probe_config_key(subcommand: &[String], key: &str) -> Result<BTreeSet<String>
         .collect())
 }
 
+/// Probe the generated rollout-budget table with a valid value and no prompt.
+///
+/// Unlike the enum keys, this config is a free-form table. A valid table gets
+/// as far as the CLI's empty-prompt refusal, which is after strict config load
+/// but before authentication or any provider request.
+fn probe_rollout_budget_config(subcommand: &[String], value: &str) -> Result<(), String> {
+    let mut args = subcommand.to_vec();
+    args.push("--strict-config".into());
+    args.push("-c".into());
+    args.push(format!("features.rollout_budget={value}"));
+    let output = run_codex(&args);
+
+    if output.contains("Error loading config.toml")
+        || output.contains("unknown configuration field")
+        || output.contains("features.rollout_budget.")
+    {
+        return Err(format!(
+            "generated rollout-budget config was rejected: {}",
+            output.lines().next().unwrap_or("").trim()
+        ));
+    }
+    if !output.contains("No prompt provided") {
+        return Err(format!(
+            "rollout-budget probe did not stop at the empty prompt; refusing a probe that might run a session. Output:\n{output}"
+        ));
+    }
+    Ok(())
+}
+
 /// Assert every flag and config key a builder emits is still accepted.
 fn assert_contract(label: &str, args: Vec<String>, subcommand_len: usize) {
     let emitted = split(&args, subcommand_len);
@@ -235,6 +264,12 @@ fn assert_contract(label: &str, args: Vec<String>, subcommand_len: usize) {
     }
 
     for (key, value) in &emitted.config_keys {
+        if key == "features.rollout_budget" {
+            if let Err(message) = probe_rollout_budget_config(&emitted.subcommand, value) {
+                drift.push(message);
+            }
+            continue;
+        }
         if !ENUM_CONFIG_KEYS.contains(&key.as_str()) {
             drift.push(format!(
                 "config key `{key}` has no probe policy; add it to ENUM_CONFIG_KEYS \
@@ -278,11 +313,17 @@ fn assert_contract(label: &str, args: Vec<String>, subcommand_len: usize) {
 #[test]
 #[ignore]
 fn exec_contract() {
+    let rollout_budget = RolloutBudgetConfig::builder(100_000)
+        .reminder_at_remaining_tokens([50_000, 10_000])
+        .prefill_token_weight(0.25)
+        .build()
+        .expect("valid contract budget");
     let args = ExecCommand::new("probe")
         .approval_policy(ApprovalPolicyConfig::Granular)
         .search_mode(WebSearchMode::Live)
         .enable("feature")
         .disable("other")
+        .rollout_budget(rollout_budget)
         .image("/tmp/a.png")
         .model("o3")
         .oss()
@@ -317,6 +358,11 @@ fn exec_full_auto_contract() {
 #[test]
 #[ignore]
 fn exec_resume_contract() {
+    let rollout_budget = RolloutBudgetConfig::builder(100_000)
+        .reminder_at_remaining_tokens([50_000, 10_000])
+        .prefill_token_weight(0.25)
+        .build()
+        .expect("valid contract budget");
     let args = ExecResumeCommand::new()
         .last()
         .prompt("probe")
@@ -324,6 +370,7 @@ fn exec_resume_contract() {
         .search_mode(WebSearchMode::Cached)
         .enable("feature")
         .disable("other")
+        .rollout_budget(rollout_budget)
         .image("/tmp/a.png")
         .model("o3")
         .strict_config()

--- a/crates/codex-wrapper/tests/fake-codex-rollout-budget.sh
+++ b/crates/codex-wrapper/tests/fake-codex-rollout-budget.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Captured codex-cli 0.145.0 JSONL shape for native rollout-budget exhaustion.
+# Identifiers are synthetic; event order, terminal message, missing usage, and
+# non-zero exit match the paid contract run made for codex-wrapper#117.
+printf '%s\n' '{"type":"thread.started","thread_id":"00000000-0000-0000-0000-000000000117"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"item_0","type":"error","message":"Under-development features enabled: rollout_budget."}}'
+printf '%s\n' '{"type":"turn.started"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"ok"}}'
+printf '%s\n' '{"type":"error","message":"shared rollout token budget exhausted"}'
+printf '%s\n' '{"type":"turn.failed","error":{"message":"shared rollout token budget exhausted"}}'
+exit 1


### PR DESCRIPTION
## Summary

- add a validated `RolloutBudgetConfig` for Codex-native rollout-budget units
- apply the same final override to opening and resumed exec commands
- seal command- and client-level feature-toggle precedence so `--enable/--disable rollout_budget` cannot defeat the typed table
- classify the paid-captured budget-exhaustion terminal without fabricating missing usage
- document response-boundary overshoot and the versioned meter: 0.145–0.146 always use weighted non-cached input plus output; 0.147 prefers provider-reported opaque units when available
- distinguish native in-process enforcement from the existing post-turn session budget

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (239 passed)
- `cargo test --lib --no-default-features` (146 passed)
- `RUSTDOCFLAGS="-D warnings" cargo test --doc --all-features` (28 passed)
- `CODEX_WRAPPER_ALLOW_DANGEROUS=1 cargo test -p codex-wrapper --test contract --all-features -- --ignored` (20 passed against installed codex-cli 0.145.0)
- paid one-unit Codex probe captured the terminal fixture; upstream missing-usage/code issue: openai/codex#37676

Closes #117.

Related: joshrotenberg/ciacola#78.