### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0](https://github.com/joshrotenberg/codex-wrapper/compare/v0.3.1...v0.4.0) - 2026-08-17
+
+### Added
+
+- support resume prompts over stdin ([#124](https://github.com/joshrotenberg/codex-wrapper/pull/124))
+- *(process)* support cleared child environments ([#121](https://github.com/joshrotenberg/codex-wrapper/pull/121))
+- *(exec)* type the native rollout budget configuration ([#118](https://github.com/joshrotenberg/codex-wrapper/pull/118))
+
 ## [0.3.1](https://github.com/joshrotenberg/codex-wrapper/compare/v0.3.0...v0.3.1) - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-wrapper"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "libc",
  "serde",

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-wrapper"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `codex-wrapper`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `codex-wrapper` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Error::ConfigParse 9 -> 10 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:116
  variant Error::DangerousNotAllowed 10 -> 11 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:127
  variant Error::Cancelled 11 -> 12 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:138
  variant Error::Json 12 -> 13 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:146
  variant Error::VersionMismatch 13 -> 14 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:154
  variant Error::UntestedCliVersion 14 -> 15 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:166
  variant Error::ConfigParse 9 -> 10 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:116
  variant Error::DangerousNotAllowed 10 -> 11 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:127
  variant Error::Cancelled 11 -> 12 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:138
  variant Error::Json 12 -> 13 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:146
  variant Error::VersionMismatch 13 -> 14 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:154
  variant Error::UntestedCliVersion 14 -> 15 in /tmp/.tmpM3srVN/codex-wrapper/crates/codex-wrapper/src/error.rs:166
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/joshrotenberg/codex-wrapper/compare/v0.3.1...v0.4.0) - 2026-08-17

### Added

- support resume prompts over stdin ([#124](https://github.com/joshrotenberg/codex-wrapper/pull/124))
- *(process)* support cleared child environments ([#121](https://github.com/joshrotenberg/codex-wrapper/pull/121))
- *(exec)* type the native rollout budget configuration ([#118](https://github.com/joshrotenberg/codex-wrapper/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).