### PR TITLE
feat(process): support cleared child environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,39 @@ Options:
 - `binary()` -- path to `codex` binary (auto-detected via `PATH` by default)
 - `working_dir()` -- working directory for commands
 - `env()` / `envs()` -- environment variables
+- `clear_env()` -- clear inherited variables before applying `env()` / `envs()`
 - `timeout_secs()` / `timeout()` -- command timeout
 - `config()` -- global config overrides (`-c key=value`)
 - `enable()` / `disable()` -- global feature flags
 - `retry()` -- default retry policy
+
+### Child Environment Policy
+
+Children inherit the wrapper process's environment by default for backwards
+compatibility. Use `clear_env()` to construct the direct Codex child's
+environment explicitly:
+
+```rust
+use codex_wrapper::Codex;
+
+let codex = Codex::builder()
+    .clear_env()
+    .envs([
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("CODEX_HOME", "/srv/codex/agent-home"),
+    ])
+    .build()?;
+```
+
+`clear_env()` is call-order independent, so explicit entries survive whether
+they are added before or after it. `config()` and `auth_status()` use the same
+effective environment as the child and do not fall back to ambient variables
+for a cleared client. Debug output reports explicit variable names but never
+their values.
+
+This is direct-child environment control, not OS or same-user isolation. It
+does not prevent Codex from reading files, process metadata, sockets, or other
+resources available to its user and sandbox.
 
 ### Command Builders
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -68,10 +68,39 @@ Options:
 - `binary()` -- path to `codex` binary (auto-detected via `PATH` by default)
 - `working_dir()` -- working directory for commands
 - `env()` / `envs()` -- environment variables
+- `clear_env()` -- clear inherited variables before applying `env()` / `envs()`
 - `timeout_secs()` / `timeout()` -- command timeout
 - `config()` -- global config overrides (`-c key=value`)
 - `enable()` / `disable()` -- global feature flags
 - `retry()` -- default retry policy
+
+### Child Environment Policy
+
+Children inherit the wrapper process's environment by default for backwards
+compatibility. Use `clear_env()` to construct the direct Codex child's
+environment explicitly:
+
+```rust
+use codex_wrapper::Codex;
+
+let codex = Codex::builder()
+    .clear_env()
+    .envs([
+        ("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        ("CODEX_HOME", "/srv/codex/agent-home"),
+    ])
+    .build()?;
+```
+
+`clear_env()` is call-order independent, so explicit entries survive whether
+they are added before or after it. `config()` and `auth_status()` use the same
+effective environment as the child and do not fall back to ambient variables
+for a cleared client. Debug output reports explicit variable names but never
+their values.
+
+This is direct-child environment control, not OS or same-user isolation. It
+does not prevent Codex from reading files, process metadata, sockets, or other
+resources available to its user and sandbox.
 
 ### Command Builders
 

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -332,6 +332,7 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                     &codex.binary,
                     &command_args,
                     &codex.env,
+                    codex.clear_env,
                     codex.working_dir.as_deref(),
                     timeout,
                     codex.process_group,
@@ -343,6 +344,7 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                     &codex.binary,
                     &command_args,
                     &codex.env,
+                    codex.clear_env,
                     codex.working_dir.as_deref(),
                     codex.process_group,
                 )
@@ -392,6 +394,7 @@ where
                 binary: &codex.binary,
                 args: &command_args,
                 env: &codex.env,
+                clear_env: codex.clear_env,
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: None,
                 process_group: codex.process_group,
@@ -481,6 +484,7 @@ pub async fn run_codex_with_stdin_prompt(
                 binary: &codex.binary,
                 args: &command_args,
                 env: &codex.env,
+                clear_env: codex.clear_env,
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: Some(prompt),
                 process_group: codex.process_group,
@@ -509,6 +513,7 @@ async fn run_internal(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     process_group: bool,
 ) -> Result<CommandOutput> {
@@ -517,6 +522,7 @@ async fn run_internal(
             binary,
             args,
             env,
+            clear_env,
             working_dir,
             stdin_prompt: None,
             process_group,
@@ -534,6 +540,8 @@ struct SpawnSpec<'a> {
     binary: &'a std::path::Path,
     args: &'a [String],
     env: &'a std::collections::HashMap<String, String>,
+    /// Whether the child starts without the wrapper's ambient environment.
+    clear_env: bool,
     working_dir: Option<&'a std::path::Path>,
     /// A prompt to deliver on stdin, for `codex exec -`.
     stdin_prompt: Option<&'a str>,
@@ -550,6 +558,7 @@ async fn run_internal_inner(
         binary,
         args,
         env,
+        clear_env,
         working_dir,
         stdin_prompt,
         process_group,
@@ -575,9 +584,7 @@ async fn run_internal_inner(
         cmd.current_dir(dir);
     }
 
-    for (key, value) in env {
-        cmd.env(key, value);
-    }
+    apply_child_environment(&mut cmd, clear_env, env);
 
     // Always spawn rather than using `Command::output`: the pid is needed to
     // signal the process group, and `output` does not surrender it. It also
@@ -669,17 +676,33 @@ async fn run_internal_inner(
     })
 }
 
+/// Apply the client environment policy to a direct child process.
+///
+/// Kept in one helper because buffered and streaming execution construct
+/// separate commands. Clearing must happen before explicit values are added.
+pub(crate) fn apply_child_environment(
+    cmd: &mut Command,
+    clear_env: bool,
+    env: &std::collections::HashMap<String, String>,
+) {
+    if clear_env {
+        cmd.env_clear();
+    }
+    cmd.envs(env);
+}
+
 async fn run_with_timeout(
     binary: &std::path::Path,
     args: &[String],
     env: &std::collections::HashMap<String, String>,
+    clear_env: bool,
     working_dir: Option<&std::path::Path>,
     timeout: Duration,
     process_group: bool,
 ) -> Result<CommandOutput> {
     tokio::time::timeout(
         timeout,
-        run_internal(binary, args, env, working_dir, process_group),
+        run_internal(binary, args, env, clear_env, working_dir, process_group),
     )
     .await
     .map_err(|_| Error::Timeout {
@@ -799,6 +822,135 @@ mod tests {
         let debug = format!("{output:?}");
         assert!(debug.contains("... (300 bytes total)"));
         assert!(!debug.contains(&long));
+    }
+
+    /// Compatibility is explicit: callers that do not opt in keep the
+    /// ambient environment they relied on before `clear_env` existed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn child_environment_is_inherited_by_default() {
+        let capture = crate::test_support::EnvCapture::new("env-default");
+        let codex = crate::test_support::env_capturing_codex(&capture)
+            .build()
+            .expect("bash must exist");
+
+        crate::ExecCommand::new("probe")
+            .execute(&codex)
+            .await
+            .unwrap();
+
+        let environment = capture.read();
+        assert_eq!(
+            environment.get("PATH"),
+            Some(&std::env::var("PATH").expect("test process must have PATH"))
+        );
+    }
+
+    /// The timeout and ordinary buffered paths use different wrapper entry
+    /// points. Opening and resume both have to reach the same environment
+    /// policy, and explicit values on either side of `clear_env` must survive.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cleared_environment_reaches_buffered_open_and_resume() {
+        let capture = crate::test_support::EnvCapture::new("env-buffered");
+        let opening_client = crate::test_support::env_capturing_codex(&capture)
+            .clear_env()
+            .env("CODEX_WRAPPER_EXPLICIT", "opening")
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("bash must exist");
+
+        crate::ExecCommand::new("probe")
+            .execute(&opening_client)
+            .await
+            .unwrap();
+        let opening_environment = capture.read();
+        assert!(!opening_environment.contains_key("PATH"));
+        assert_eq!(
+            opening_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("opening")
+        );
+        assert!(opening_environment.contains_key("CODEX_WRAPPER_ENV_CAPTURE"));
+
+        let resume_client = crate::test_support::env_capturing_codex(&capture)
+            .clear_env()
+            .env("CODEX_WRAPPER_EXPLICIT", "resume")
+            .build()
+            .expect("bash must exist");
+        crate::ExecResumeCommand::new()
+            .last()
+            .execute(&resume_client)
+            .await
+            .unwrap();
+        let resume_environment = capture.read();
+        assert!(!resume_environment.contains_key("PATH"));
+        assert_eq!(
+            resume_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("resume")
+        );
+    }
+
+    /// Stdin delivery and graceful cancellation each construct their own
+    /// spawn specification, so cover both instead of treating the buffered
+    /// test as proof for them.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cleared_environment_reaches_stdin_and_cancellable_runs() {
+        let capture = crate::test_support::EnvCapture::new("env-specialized");
+        let codex = crate::test_support::env_capturing_codex(&capture)
+            .env("CODEX_WRAPPER_EXPLICIT", "specialized")
+            .clear_env()
+            .build()
+            .expect("bash must exist");
+
+        crate::ExecCommand::new("stdin prompt")
+            .prompt_via_stdin()
+            .execute(&codex)
+            .await
+            .unwrap();
+        let stdin_environment = capture.read();
+        assert!(!stdin_environment.contains_key("PATH"));
+        assert_eq!(
+            stdin_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("specialized")
+        );
+
+        let never = std::future::pending::<()>();
+        run_codex_cancellable(&codex, crate::ExecCommand::new("cancellable").args(), never)
+            .await
+            .unwrap();
+        let cancellable_environment = capture.read();
+        assert!(!cancellable_environment.contains_key("PATH"));
+        assert_eq!(
+            cancellable_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("specialized")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn environment_values_do_not_leak_into_spawn_errors() {
+        let secret = "spawn-error-must-not-leak-this";
+        let codex = Codex::builder()
+            .binary("/codex-wrapper/this-binary-does-not-exist")
+            .clear_env()
+            .env("CODEX_WRAPPER_SECRET", secret)
+            .build()
+            .unwrap();
+
+        let error = run_codex(&codex, vec!["exec".into()])
+            .await
+            .expect_err("the fake path must not spawn");
+        assert!(!error.to_string().contains(secret));
+        assert!(!format!("{error:?}").contains(secret));
     }
 
     /// A wrapper timeout drops `run_internal`'s future. Without

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -82,6 +82,14 @@
 //! # }
 //! ```
 //!
+//! # Child Environment Policy
+//!
+//! Child processes inherit the wrapper process's environment by default.
+//! [`CodexBuilder::clear_env`] opts into clearing that environment before
+//! applying entries from [`CodexBuilder::env`] and [`CodexBuilder::envs`].
+//! The setting controls the direct child's environment, not same-user access
+//! to files, process metadata, sockets, or other OS resources.
+//!
 //! # Available Commands
 //!
 //! | Command | CLI equivalent |
@@ -190,6 +198,7 @@ pub mod types;
 pub mod version;
 
 use std::collections::HashMap;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -254,11 +263,12 @@ pub use version::{
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Codex {
     pub(crate) binary: PathBuf,
     pub(crate) working_dir: Option<PathBuf>,
     pub(crate) env: HashMap<String, String>,
+    pub(crate) clear_env: bool,
     pub(crate) global_args: Vec<String>,
     pub(crate) timeout: Option<Duration>,
     pub(crate) termination_grace: Duration,
@@ -294,26 +304,25 @@ impl Codex {
         clone
     }
 
-    /// Query the installed Codex CLI version.
     /// Read `config.toml` for this client's `CODEX_HOME`.
+    ///
+    /// Uses the same effective environment as spawned commands. A client
+    /// built with [`clear_env`](CodexBuilder::clear_env) does not fall back to
+    /// ambient `CODEX_HOME` or `HOME` values.
     ///
     /// `Ok(None)` when there is no config file. Requires the `config` feature.
     /// See [`crate::config`] for what is typed and what stays raw.
     #[cfg(feature = "config")]
     pub fn config(&self) -> Result<Option<crate::config::CodexConfig>> {
-        let home = crate::codex_home::resolve(&|key| {
-            self.env
-                .get(key)
-                .cloned()
-                .or_else(|| std::env::var(key).ok())
-        });
+        let home = crate::codex_home::resolve(&|key| self.environment_value(key));
         crate::config::load_from_home(home)
     }
 
     /// Which credential this client's CLI would use, without spawning it.
     ///
     /// Honors a `CODEX_HOME` set on this client via
-    /// [`env`](CodexBuilder::env), falling back to the process environment.
+    /// [`env`](CodexBuilder::env), falling back to the process environment
+    /// unless [`clear_env`](CodexBuilder::clear_env) was selected.
     /// See [`crate::auth`] for what the strategies mean and how they were
     /// determined.
     ///
@@ -331,11 +340,20 @@ impl Codex {
     #[cfg(feature = "json")]
     #[must_use]
     pub fn auth_status(&self) -> crate::auth::AuthStatus {
-        crate::auth::detect_with(|key| {
-            self.env
-                .get(key)
-                .cloned()
-                .or_else(|| std::env::var(key).ok())
+        crate::auth::detect_with(|key| self.environment_value(key))
+    }
+
+    /// Resolve one variable exactly as this client's direct child will see
+    /// it. Read-side helpers use the same policy as process spawning so a
+    /// preflight cannot report credentials or config excluded from the child.
+    #[cfg(any(feature = "json", feature = "config"))]
+    fn environment_value(&self, key: &str) -> Option<String> {
+        self.env.get(key).cloned().or_else(|| {
+            if self.clear_env {
+                None
+            } else {
+                std::env::var(key).ok()
+            }
         })
     }
 
@@ -415,6 +433,26 @@ impl Codex {
     }
 }
 
+impl fmt::Debug for Codex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut env_keys: Vec<&str> = self.env.keys().map(String::as_str).collect();
+        env_keys.sort_unstable();
+
+        f.debug_struct("Codex")
+            .field("binary", &self.binary)
+            .field("working_dir", &self.working_dir)
+            .field("env_keys", &env_keys)
+            .field("clear_env", &self.clear_env)
+            .field("global_args", &self.global_args)
+            .field("timeout", &self.timeout)
+            .field("termination_grace", &self.termination_grace)
+            .field("process_group", &self.process_group)
+            .field("retry_policy", &self.retry_policy)
+            .field("tested_cli_version_range", &self.tested_cli_version_range)
+            .finish()
+    }
+}
+
 fn warn_on_drift(status: &CliVersionStatus) {
     match status {
         CliVersionStatus::Tested => {}
@@ -441,11 +479,12 @@ fn warn_on_drift(status: &CliVersionStatus) {
 ///
 /// All options are optional. By default the builder discovers the `codex`
 /// binary via `PATH`.
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct CodexBuilder {
     binary: Option<PathBuf>,
     working_dir: Option<PathBuf>,
     env: HashMap<String, String>,
+    clear_env: bool,
     global_args: Vec<String>,
     timeout: Option<Duration>,
     termination_grace: Option<Duration>,
@@ -496,6 +535,22 @@ impl CodexBuilder {
         for (key, value) in vars {
             self.env.insert(key.into(), value.into());
         }
+        self
+    }
+
+    /// Clear the inherited environment before applying variables supplied by
+    /// [`env`](Self::env) and [`envs`](Self::envs).
+    ///
+    /// By default, child processes inherit the wrapper process's environment.
+    /// This opt-in is call-order independent: explicit variables survive
+    /// whether they are added before or after `clear_env`.
+    ///
+    /// This controls the direct Codex child's environment. It is not OS or
+    /// same-user isolation: the child can still access files, process metadata,
+    /// sockets, and other resources allowed to its user and sandbox.
+    #[must_use]
+    pub fn clear_env(mut self) -> Self {
+        self.clear_env = true;
         self
     }
 
@@ -609,6 +664,7 @@ impl CodexBuilder {
             binary,
             working_dir: self.working_dir,
             env: self.env,
+            clear_env: self.clear_env,
             global_args: self.global_args,
             termination_grace: self
                 .termination_grace
@@ -621,6 +677,26 @@ impl CodexBuilder {
                 version::TESTED_CLI_VERSION_MAX,
             )),
         })
+    }
+}
+
+impl fmt::Debug for CodexBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut env_keys: Vec<&str> = self.env.keys().map(String::as_str).collect();
+        env_keys.sort_unstable();
+
+        f.debug_struct("CodexBuilder")
+            .field("binary", &self.binary)
+            .field("working_dir", &self.working_dir)
+            .field("env_keys", &env_keys)
+            .field("clear_env", &self.clear_env)
+            .field("global_args", &self.global_args)
+            .field("timeout", &self.timeout)
+            .field("termination_grace", &self.termination_grace)
+            .field("process_group", &self.process_group)
+            .field("retry_policy", &self.retry_policy)
+            .field("tested_cli_version_range", &self.tested_cli_version_range)
+            .finish()
     }
 }
 
@@ -639,7 +715,73 @@ mod tests {
 
         assert_eq!(codex.binary, PathBuf::from("/usr/local/bin/codex"));
         assert_eq!(codex.env.get("FOO").unwrap(), "bar");
+        assert!(!codex.clear_env);
         assert_eq!(codex.timeout, Some(Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn clear_env_is_opt_in_and_keeps_explicit_entries() {
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .env("BEFORE_CLEAR", "one")
+            .clear_env()
+            .env("AFTER_CLEAR", "two")
+            .build()
+            .unwrap();
+
+        assert!(codex.clear_env);
+        assert_eq!(
+            codex.env.get("BEFORE_CLEAR").map(String::as_str),
+            Some("one")
+        );
+        assert_eq!(
+            codex.env.get("AFTER_CLEAR").map(String::as_str),
+            Some("two")
+        );
+    }
+
+    #[test]
+    fn client_and_builder_debug_hide_environment_values() {
+        let builder = Codex::builder()
+            .binary("/bin/echo")
+            .env("CODEX_WRAPPER_SECRET", "debug-must-not-leak-this");
+
+        let builder_debug = format!("{builder:?}");
+        assert!(builder_debug.contains("CODEX_WRAPPER_SECRET"));
+        assert!(!builder_debug.contains("debug-must-not-leak-this"));
+
+        let codex = builder.build().unwrap();
+        let client_debug = format!("{codex:?}");
+        assert!(client_debug.contains("CODEX_WRAPPER_SECRET"));
+        assert!(!client_debug.contains("debug-must-not-leak-this"));
+    }
+
+    /// Read-side helpers must answer from the environment the child receives,
+    /// not from ambient values that `clear_env` removes at spawn time.
+    #[cfg(any(feature = "json", feature = "config"))]
+    #[test]
+    fn effective_environment_lookup_obeys_clear_env() {
+        let ambient_path = std::env::var("PATH").expect("test process must have PATH");
+        let inherited = Codex::builder().binary("/bin/echo").build().unwrap();
+        assert_eq!(inherited.environment_value("PATH"), Some(ambient_path));
+
+        let cleared = Codex::builder()
+            .binary("/bin/echo")
+            .clear_env()
+            .build()
+            .unwrap();
+        assert_eq!(cleared.environment_value("PATH"), None);
+
+        let explicit = Codex::builder()
+            .binary("/bin/echo")
+            .clear_env()
+            .env("PATH", "/intentional/bin")
+            .build()
+            .unwrap();
+        assert_eq!(
+            explicit.environment_value("PATH").as_deref(),
+            Some("/intentional/bin")
+        );
     }
 
     #[test]
@@ -732,5 +874,17 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(feature = "json")]
+    #[test]
+    fn auth_status_does_not_fall_back_to_ambient_home_when_cleared() {
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .clear_env()
+            .build()
+            .unwrap();
+
+        assert_eq!(codex.auth_status().codex_home, PathBuf::from(".codex"));
     }
 }

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -110,9 +110,7 @@ where
     if let Some(dir) = &codex.working_dir {
         child_cmd.current_dir(dir);
     }
-    for (key, value) in &codex.env {
-        child_cmd.env(key, value);
-    }
+    crate::exec::apply_child_environment(&mut child_cmd, codex.clear_env, &codex.env);
 
     let mut child = child_cmd.spawn().map_err(|e| Error::Io {
         message: format!("failed to spawn codex: {e}"),
@@ -344,6 +342,60 @@ mod tests {
 
         let events = events.lock().unwrap();
         assert!(!events.is_empty(), "expected at least one event");
+    }
+
+    /// Streaming owns a separate process builder from buffered execution.
+    /// Cover opening, stdin opening, and resume so none can regress to ambient
+    /// inheritance while the others stay isolated.
+    #[tokio::test]
+    async fn cleared_environment_reaches_every_streaming_variant() {
+        let capture = crate::test_support::EnvCapture::new("env-streaming");
+        let codex = crate::test_support::env_capturing_codex(&capture)
+            .clear_env()
+            .env("CODEX_WRAPPER_EXPLICIT", "streaming")
+            .build()
+            .expect("bash must exist");
+
+        crate::ExecCommand::new("opening")
+            .stream(&codex, |_| {})
+            .await
+            .unwrap();
+        let opening_environment = capture.read();
+        assert!(!opening_environment.contains_key("PATH"));
+        assert_eq!(
+            opening_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("streaming")
+        );
+
+        crate::ExecCommand::new("stdin")
+            .prompt_via_stdin()
+            .stream(&codex, |_| {})
+            .await
+            .unwrap();
+        let stdin_environment = capture.read();
+        assert!(!stdin_environment.contains_key("PATH"));
+        assert_eq!(
+            stdin_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("streaming")
+        );
+
+        crate::ExecResumeCommand::new()
+            .last()
+            .stream(&codex, |_| {})
+            .await
+            .unwrap();
+        let resume_environment = capture.read();
+        assert!(!resume_environment.contains_key("PATH"));
+        assert_eq!(
+            resume_environment
+                .get("CODEX_WRAPPER_EXPLICIT")
+                .map(String::as_str),
+            Some("streaming")
+        );
     }
 
     /// Contract captured from a paid 0.145.0 run: the callback receives the

--- a/crates/codex-wrapper/src/test_support.rs
+++ b/crates/codex-wrapper/src/test_support.rs
@@ -16,6 +16,54 @@ pub(crate) struct PidFile {
     path: PathBuf,
 }
 
+/// Complete environment recorded by the fake Codex child, cleaned up on
+/// drop. Each caller supplies a unique label because unit tests share a pid.
+pub(crate) struct EnvCapture {
+    path: PathBuf,
+}
+
+impl EnvCapture {
+    pub(crate) fn new(label: &str) -> Self {
+        let path =
+            std::env::temp_dir().join(format!("codex-wrapper-{}-{label}.env", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        Self { path }
+    }
+
+    pub(crate) fn read(&self) -> std::collections::BTreeMap<String, String> {
+        let contents = std::fs::read_to_string(&self.path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", self.path.display()));
+        contents
+            .lines()
+            .filter_map(|line| {
+                let (key, value) = line.split_once('=')?;
+                Some((key.to_string(), value.to_string()))
+            })
+            .collect()
+    }
+}
+
+impl Drop for EnvCapture {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// A [`Codex`] builder backed by a fake binary that records its full
+/// environment and then emits valid JSONL for streaming callers.
+pub(crate) fn env_capturing_codex(capture: &EnvCapture) -> CodexBuilder {
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fake-codex-capture-env.sh");
+    Codex::builder()
+        .binary("/bin/bash")
+        .arg(script.to_str().expect("fixture path is utf-8"))
+        .env(
+            "CODEX_WRAPPER_ENV_CAPTURE",
+            capture.path.to_str().expect("capture path is utf-8"),
+        )
+}
+
 impl PidFile {
     /// Reserve a PID file path. `label` distinguishes concurrent tests, which
     /// share a process ID because cargo runs them as threads.

--- a/crates/codex-wrapper/tests/fake-codex-capture-env.sh
+++ b/crates/codex-wrapper/tests/fake-codex-capture-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fake codex that records the complete child environment before emitting
+# verified JSONL event shapes. It uses absolute utility paths so a cleared
+# environment does not need PATH in order for the fixture itself to run.
+set -eu
+
+: "${CODEX_WRAPPER_ENV_CAPTURE:?capture path is required}"
+/usr/bin/env > "${CODEX_WRAPPER_ENV_CAPTURE}"
+
+for arg in "$@"; do
+    if [ "${arg}" = "-" ]; then
+        /bin/cat >/dev/null
+        break
+    fi
+done
+
+echo '{"type":"thread.started","thread_id":"thread_env"}'
+echo '{"type":"turn.started"}'
+echo '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"ok"}}'
+echo '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":1,"reasoning_output_tokens":0}}'


### PR DESCRIPTION
Closes #120.

Adds opt-in `CodexBuilder::clear_env()` while preserving inherited-environment compatibility by default.

- applies one clear-then-explicit-overlay policy to buffered, timeout, stdin, cancellable, and streaming open/resume paths
- makes client-scoped config/auth inspection describe the effective child environment
- redacts environment values from `Codex` and `CodexBuilder` Debug output
- documents that this is direct-child environment control, not OS or same-UID isolation
- captures default inheritance, explicit survival, open/resume parity, and error redaction with deterministic fake-child tests

Verification:
- all-features and no-default-feature test matrices
- strict all-target/all-feature clippy
- doctests, rustdoc warnings, formatting, and mirrored README check