### PR TITLE
fix: implement awaited cancellation settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ Fields on open: `subcommand`, `binary`, `working_dir`. On close: `outcome`, `dur
 | `ok` | exited zero |
 | `failed` | exited non-zero |
 | `timeout` | hit the client's timeout |
-| `cancelled` | the future was dropped, so the run was abandoned and the process killed |
+| `cancelled` | explicit cancellation settled, or the future was dropped and the run abandoned |
 
 **The prompt is never recorded.** It travels in argv, so recording the arguments would put it in
 the host's logs; the same goes for the environment. Note that the existing `debug!` line does log
@@ -855,38 +855,34 @@ the full argv, prompt included, as a debugging aid at that level.
 
 ## Cancellation
 
-Dropping the future returned by a command kills the spawned `codex` process. That covers a
-timeout, an aborted task, and a caller that stops awaiting during a graceful shutdown:
-cancelling the future cancels the work, rather than leaving codex running and billing with no
-handle left to stop it.
+Use the cancellable exec methods when terminal settlement matters. They accept a future that
+resolves when cancellation is requested. The wrapper sends SIGTERM to the Unix process group,
+waits for `termination_grace`, sends SIGKILL, and awaits the direct child before returning
+`Error::Cancelled`. Buffered client timeouts use the same cleanup path.
 
 ```rust
-use codex_wrapper::{ExecCommand, CodexCommand};
+use codex_wrapper::{Codex, ExecCommand};
 use std::time::Duration;
-
-// The codex process is killed when the timeout drops the future.
-let result = tokio::time::timeout(
-    Duration::from_secs(30),
-    ExecCommand::new("long task").execute(&codex),
-)
-.await;
-```
-
-The whole process group goes, not just the `codex` process: each run is spawned into its own
-group, so the subprocesses codex started for tool use die with it.
-
-`Drop` cannot wait, so that path is an immediate kill. For a graceful stop, cancel explicitly:
-
-```rust
-use codex_wrapper::exec::run_codex_cancellable;
 
 let codex = Codex::builder()
     .termination_grace(Duration::from_secs(5))
     .build()?;
 
 // SIGTERM to the group, then five seconds, then SIGKILL.
-let result = run_codex_cancellable(&codex, args, async { shutdown.await }).await;
+// The direct child has been reaped when this future returns.
+let result = ExecCommand::new("long task")
+    .execute_json_cancellable(&codex, async { shutdown.await })
+    .await;
 ```
+
+`ExecCommand` and `ExecResumeCommand` both provide `execute_cancellable()`,
+`execute_json_lines_cancellable()`, and `execute_json_cancellable()`. Stdin prompts use the same
+path. Retry does not apply because a cancelled attempt is a caller decision, not a transient
+failure.
+
+Dropping an ordinary command future remains an abrupt safety net. `kill_on_drop` stops the direct
+child and a drop guard kills the Unix process group, but `Drop` cannot await reaping. A supervisor
+that needs settlement should signal the cancellable method and keep polling it until it returns.
 
 Groups are on by default, and can be turned off:
 
@@ -900,9 +896,9 @@ terminal-attached host that shells out synchronously and treats the terminal as 
 the default suits a supervisor that cancels programmatically. `claude-wrapper` has the same
 option under the same name.
 
-One limit remains: reaping needs the tokio runtime to still be running, so a future dropped as
-part of runtime shutdown may not get far enough. Process groups are unix-only; elsewhere this
-degrades to killing the direct child.
+Process groups are Unix-only. Elsewhere explicit cancellation kills and awaits the direct child,
+but the wrapper cannot make the same descendant-process guarantee. Reaping also needs the Tokio
+runtime to remain alive; the abrupt dropped-future fallback cannot settle during runtime teardown.
 
 ## Retry Policy
 

--- a/crates/codex-wrapper/README.md
+++ b/crates/codex-wrapper/README.md
@@ -847,7 +847,7 @@ Fields on open: `subcommand`, `binary`, `working_dir`. On close: `outcome`, `dur
 | `ok` | exited zero |
 | `failed` | exited non-zero |
 | `timeout` | hit the client's timeout |
-| `cancelled` | the future was dropped, so the run was abandoned and the process killed |
+| `cancelled` | explicit cancellation settled, or the future was dropped and the run abandoned |
 
 **The prompt is never recorded.** It travels in argv, so recording the arguments would put it in
 the host's logs; the same goes for the environment. Note that the existing `debug!` line does log
@@ -855,38 +855,34 @@ the full argv, prompt included, as a debugging aid at that level.
 
 ## Cancellation
 
-Dropping the future returned by a command kills the spawned `codex` process. That covers a
-timeout, an aborted task, and a caller that stops awaiting during a graceful shutdown:
-cancelling the future cancels the work, rather than leaving codex running and billing with no
-handle left to stop it.
+Use the cancellable exec methods when terminal settlement matters. They accept a future that
+resolves when cancellation is requested. The wrapper sends SIGTERM to the Unix process group,
+waits for `termination_grace`, sends SIGKILL, and awaits the direct child before returning
+`Error::Cancelled`. Buffered client timeouts use the same cleanup path.
 
 ```rust
-use codex_wrapper::{ExecCommand, CodexCommand};
+use codex_wrapper::{Codex, ExecCommand};
 use std::time::Duration;
-
-// The codex process is killed when the timeout drops the future.
-let result = tokio::time::timeout(
-    Duration::from_secs(30),
-    ExecCommand::new("long task").execute(&codex),
-)
-.await;
-```
-
-The whole process group goes, not just the `codex` process: each run is spawned into its own
-group, so the subprocesses codex started for tool use die with it.
-
-`Drop` cannot wait, so that path is an immediate kill. For a graceful stop, cancel explicitly:
-
-```rust
-use codex_wrapper::exec::run_codex_cancellable;
 
 let codex = Codex::builder()
     .termination_grace(Duration::from_secs(5))
     .build()?;
 
 // SIGTERM to the group, then five seconds, then SIGKILL.
-let result = run_codex_cancellable(&codex, args, async { shutdown.await }).await;
+// The direct child has been reaped when this future returns.
+let result = ExecCommand::new("long task")
+    .execute_json_cancellable(&codex, async { shutdown.await })
+    .await;
 ```
+
+`ExecCommand` and `ExecResumeCommand` both provide `execute_cancellable()`,
+`execute_json_lines_cancellable()`, and `execute_json_cancellable()`. Stdin prompts use the same
+path. Retry does not apply because a cancelled attempt is a caller decision, not a transient
+failure.
+
+Dropping an ordinary command future remains an abrupt safety net. `kill_on_drop` stops the direct
+child and a drop guard kills the Unix process group, but `Drop` cannot await reaping. A supervisor
+that needs settlement should signal the cancellable method and keep polling it until it returns.
 
 Groups are on by default, and can be turned off:
 
@@ -900,9 +896,9 @@ terminal-attached host that shells out synchronously and treats the terminal as 
 the default suits a supervisor that cancels programmatically. `claude-wrapper` has the same
 option under the same name.
 
-One limit remains: reaping needs the tokio runtime to still be running, so a future dropped as
-part of runtime shutdown may not get far enough. Process groups are unix-only; elsewhere this
-degrades to killing the direct child.
+Process groups are Unix-only. Elsewhere explicit cancellation kills and awaits the direct child,
+but the wrapper cannot make the same descendant-process guarantee. Reaping also needs the Tokio
+runtime to remain alive; the abrupt dropped-future fallback cannot settle during runtime teardown.
 
 ## Retry Policy
 

--- a/crates/codex-wrapper/src/command/exec.rs
+++ b/crates/codex-wrapper/src/command/exec.rs
@@ -500,6 +500,29 @@ impl ExecCommand {
         crate::streaming::stream_exec(codex, self, handler).await
     }
 
+    /// Execute with an explicit cancellation signal.
+    ///
+    /// When `cancel` resolves, the wrapper terminates the owned process group,
+    /// awaits the direct child, and then returns [`Error::Cancelled`]. The
+    /// client timeout uses the same settled cleanup path. Retry does not
+    /// apply to cancellable execution.
+    pub async fn execute_cancellable<C>(&self, codex: &Codex, cancel: C) -> Result<CommandOutput>
+    where
+        C: std::future::Future<Output = ()> + Send,
+    {
+        if self.prompt_via_stdin {
+            let prompt = self.prompt.as_deref().unwrap_or_default();
+            return exec::run_codex_with_stdin_prompt_cancellable(
+                codex,
+                self.args(),
+                prompt,
+                cancel,
+            )
+            .await;
+        }
+        exec::run_codex_cancellable(codex, self.args(), cancel).await
+    }
+
     /// Execute the command and parse the output as JSON Lines events.
     ///
     /// Automatically appends `--json` if not already set. Requires the `json`
@@ -520,6 +543,33 @@ impl ExecCommand {
         parse_json_lines(&output.stdout)
     }
 
+    /// Execute cancellably and parse the output as JSON Lines events.
+    ///
+    /// Automatically appends `--json` if not already set. Process cleanup is
+    /// complete before a cancellation or timeout error is returned.
+    #[cfg(feature = "json")]
+    pub async fn execute_json_lines_cancellable<C>(
+        &self,
+        codex: &Codex,
+        cancel: C,
+    ) -> Result<Vec<JsonLineEvent>>
+    where
+        C: std::future::Future<Output = ()> + Send,
+    {
+        let mut args = self.args();
+        if !self.json {
+            args.push("--json".into());
+        }
+
+        let output = if self.prompt_via_stdin {
+            let prompt = self.prompt.as_deref().unwrap_or_default();
+            exec::run_codex_with_stdin_prompt_cancellable(codex, args, prompt, cancel).await?
+        } else {
+            exec::run_codex_cancellable(codex, args, cancel).await?
+        };
+        parse_json_lines(&output.stdout)
+    }
+
     /// Execute the command and return a typed [`QueryResult`].
     ///
     /// Assembles the final result text, ids, and token usage from the JSONL
@@ -528,6 +578,19 @@ impl ExecCommand {
     #[cfg(feature = "json")]
     pub async fn execute_json(&self, codex: &Codex) -> Result<QueryResult> {
         let events = self.execute_json_lines(codex).await?;
+        Ok(QueryResult::from_events(events))
+    }
+
+    /// Execute cancellably and return a typed [`QueryResult`].
+    ///
+    /// The wrapper does not return a terminal cancellation or timeout result
+    /// until process cleanup has completed.
+    #[cfg(feature = "json")]
+    pub async fn execute_json_cancellable<C>(&self, codex: &Codex, cancel: C) -> Result<QueryResult>
+    where
+        C: std::future::Future<Output = ()> + Send,
+    {
+        let events = self.execute_json_lines_cancellable(codex, cancel).await?;
         Ok(QueryResult::from_events(events))
     }
 }
@@ -946,6 +1009,29 @@ impl ExecResumeCommand {
         self
     }
 
+    /// Execute this resumed turn with an explicit cancellation signal.
+    ///
+    /// When `cancel` resolves, the wrapper terminates the owned process group,
+    /// awaits the direct child, and then returns [`Error::Cancelled`]. The
+    /// client timeout uses the same settled cleanup path. Retry does not
+    /// apply to cancellable execution.
+    pub async fn execute_cancellable<C>(&self, codex: &Codex, cancel: C) -> Result<CommandOutput>
+    where
+        C: std::future::Future<Output = ()> + Send,
+    {
+        if self.prompt_via_stdin {
+            let prompt = self.prompt.as_deref().unwrap_or_default();
+            return exec::run_codex_with_stdin_prompt_cancellable(
+                codex,
+                self.args(),
+                prompt,
+                cancel,
+            )
+            .await;
+        }
+        exec::run_codex_cancellable(codex, self.args(), cancel).await
+    }
+
     /// Execute the command and parse the output as JSON Lines events.
     ///
     /// Automatically appends `--json` if not already set. Requires the `json`
@@ -966,6 +1052,33 @@ impl ExecResumeCommand {
         parse_json_lines(&output.stdout)
     }
 
+    /// Execute this resumed turn cancellably and parse JSON Lines events.
+    ///
+    /// Automatically appends `--json` if not already set. Process cleanup is
+    /// complete before a cancellation or timeout error is returned.
+    #[cfg(feature = "json")]
+    pub async fn execute_json_lines_cancellable<C>(
+        &self,
+        codex: &Codex,
+        cancel: C,
+    ) -> Result<Vec<JsonLineEvent>>
+    where
+        C: std::future::Future<Output = ()> + Send,
+    {
+        let mut args = self.args();
+        if !self.json {
+            args.push("--json".into());
+        }
+
+        let output = if self.prompt_via_stdin {
+            let prompt = self.prompt.as_deref().unwrap_or_default();
+            exec::run_codex_with_stdin_prompt_cancellable(codex, args, prompt, cancel).await?
+        } else {
+            exec::run_codex_cancellable(codex, args, cancel).await?
+        };
+        parse_json_lines(&output.stdout)
+    }
+
     /// Execute the resume command and return a typed [`QueryResult`].
     ///
     /// Assembles the final result text, ids, and token usage from the JSONL
@@ -973,6 +1086,19 @@ impl ExecResumeCommand {
     #[cfg(feature = "json")]
     pub async fn execute_json(&self, codex: &Codex) -> Result<QueryResult> {
         let events = self.execute_json_lines(codex).await?;
+        Ok(QueryResult::from_events(events))
+    }
+
+    /// Execute this resumed turn cancellably and return a typed [`QueryResult`].
+    ///
+    /// The wrapper does not return a terminal cancellation or timeout result
+    /// until process cleanup has completed.
+    #[cfg(feature = "json")]
+    pub async fn execute_json_cancellable<C>(&self, codex: &Codex, cancel: C) -> Result<QueryResult>
+    where
+        C: std::future::Future<Output = ()> + Send,
+    {
+        let events = self.execute_json_lines_cancellable(codex, cancel).await?;
         Ok(QueryResult::from_events(events))
     }
 
@@ -1430,6 +1556,57 @@ mod tests {
                 "--output-schema",
                 "/tmp/schema.json"
             ]
+        );
+    }
+
+    #[cfg(all(unix, feature = "json"))]
+    #[tokio::test]
+    async fn fresh_json_cancellation_returns_after_reaping() {
+        use crate::test_support::{PidFile, blocking_codex, is_running_for_test};
+
+        let pid_file = PidFile::new("fresh-json-cancellable");
+        let codex = blocking_codex(&pid_file)
+            .termination_grace(std::time::Duration::from_millis(10))
+            .build()
+            .expect("bash must exist");
+
+        let result = ExecCommand::new("probe")
+            .execute_json_cancellable(&codex, async {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            })
+            .await;
+
+        assert!(matches!(result, Err(Error::Cancelled { .. })));
+        let pid = pid_file.read_pid().await;
+        assert!(
+            !is_running_for_test(pid),
+            "codex ({pid}) survived cancellation"
+        );
+    }
+
+    #[cfg(all(unix, feature = "json"))]
+    #[tokio::test]
+    async fn resumed_stdin_json_cancellation_returns_after_reaping() {
+        use crate::test_support::{PidFile, blocking_codex, is_running_for_test};
+
+        let pid_file = PidFile::new("resume-stdin-json-cancellable");
+        let codex = blocking_codex(&pid_file)
+            .termination_grace(std::time::Duration::from_millis(10))
+            .build()
+            .expect("bash must exist");
+
+        let result = ExecResumeCommand::from_stdin("continue")
+            .session_id("thread-1")
+            .execute_json_cancellable(&codex, async {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            })
+            .await;
+
+        assert!(matches!(result, Err(Error::Cancelled { .. })));
+        let pid = pid_file.read_pid().await;
+        assert!(
+            !is_running_for_test(pid),
+            "codex ({pid}) survived cancellation"
         );
     }
 

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -328,14 +328,18 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
         let mut outcome = SpanOutcome::start(outcome_span);
         let result = match codex.timeout {
             Some(timeout) => {
-                run_with_timeout(
-                    &codex.binary,
-                    &command_args,
-                    &codex.env,
-                    codex.clear_env,
-                    codex.working_dir.as_deref(),
-                    timeout,
-                    codex.process_group,
+                run_internal_inner(
+                    SpawnSpec {
+                        binary: &codex.binary,
+                        args: &command_args,
+                        env: &codex.env,
+                        clear_env: codex.clear_env,
+                        working_dir: codex.working_dir.as_deref(),
+                        stdin_prompt: None,
+                        process_group: codex.process_group,
+                    },
+                    Some(timeout_stop(timeout)),
+                    codex.termination_grace,
                 )
                 .await
             }
@@ -389,6 +393,7 @@ where
         debug!(binary = %codex.binary.display(), args = ?command_args, "executing cancellable codex command");
 
         let mut outcome = SpanOutcome::start(outcome_span);
+        let stop = cancellation_or_timeout(cancel, codex.timeout, codex.termination_grace);
         let result = run_internal_inner(
             SpawnSpec {
                 binary: &codex.binary,
@@ -399,7 +404,7 @@ where
                 stdin_prompt: None,
                 process_group: codex.process_group,
             },
-            Some(Box::pin(cancel)),
+            Some(stop),
             codex.termination_grace,
         )
         .await;
@@ -479,7 +484,8 @@ pub async fn run_codex_with_stdin_prompt(
         );
 
         let mut outcome = SpanOutcome::start(outcome_span);
-        let run = run_internal_inner(
+        let stop = codex.timeout.map(timeout_stop);
+        let result = run_internal_inner(
             SpawnSpec {
                 binary: &codex.binary,
                 args: &command_args,
@@ -489,20 +495,63 @@ pub async fn run_codex_with_stdin_prompt(
                 stdin_prompt: Some(prompt),
                 process_group: codex.process_group,
             },
-            None,
-            Duration::from_secs(0),
+            stop,
+            codex.termination_grace,
+        )
+        .await;
+        outcome.settle_from(&result);
+        result
+    }
+    .instrument(span)
+    .await
+}
+
+/// Run a codex command with a stdin prompt and an explicit cancellation signal.
+///
+/// Cancellation and the client's timeout both terminate the owned process
+/// group and await the direct child before returning. Retry does not apply.
+pub async fn run_codex_with_stdin_prompt_cancellable<C>(
+    codex: &Codex,
+    args: Vec<String>,
+    prompt: &str,
+    cancel: C,
+) -> Result<CommandOutput>
+where
+    C: std::future::Future<Output = ()> + Send,
+{
+    let span = command_span("codex.exec", codex, &args);
+    let outcome_span = span.clone();
+    let command_args = assemble_args(codex, args);
+
+    async move {
+        debug!(
+            binary = %codex.binary.display(),
+            args = ?command_args,
+            prompt_bytes = prompt.len(),
+            "executing cancellable codex command with a stdin prompt"
         );
 
-        let result = match codex.timeout {
-            Some(timeout) => match tokio::time::timeout(timeout, run).await {
-                Ok(result) => result,
-                Err(_) => Err(Error::Timeout {
-                    timeout_seconds: timeout.as_secs(),
-                }),
+        let mut outcome = SpanOutcome::start(outcome_span);
+        let stop = cancellation_or_timeout(cancel, codex.timeout, codex.termination_grace);
+        let result = run_internal_inner(
+            SpawnSpec {
+                binary: &codex.binary,
+                args: &command_args,
+                env: &codex.env,
+                clear_env: codex.clear_env,
+                working_dir: codex.working_dir.as_deref(),
+                stdin_prompt: Some(prompt),
+                process_group: codex.process_group,
             },
-            None => run.await,
-        };
-        outcome.settle_from(&result);
+            Some(stop),
+            codex.termination_grace,
+        )
+        .await;
+
+        match &result {
+            Err(Error::Cancelled { .. }) => outcome.settle("cancelled", None),
+            other => outcome.settle_from_ref(other),
+        }
         result
     }
     .instrument(span)
@@ -533,7 +582,59 @@ async fn run_internal(
     .await
 }
 
-type CancelFuture<'a> = std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'a>>;
+#[derive(Clone, Copy, Debug)]
+enum StopReason {
+    Cancelled { grace_seconds: u64 },
+    Timeout { timeout_seconds: u64 },
+}
+
+impl StopReason {
+    fn into_error(self) -> Error {
+        match self {
+            Self::Cancelled { grace_seconds } => Error::Cancelled { grace_seconds },
+            Self::Timeout { timeout_seconds } => Error::Timeout { timeout_seconds },
+        }
+    }
+}
+
+type StopFuture<'a> = std::pin::Pin<Box<dyn std::future::Future<Output = StopReason> + Send + 'a>>;
+
+fn timeout_stop(timeout: Duration) -> StopFuture<'static> {
+    Box::pin(async move {
+        tokio::time::sleep(timeout).await;
+        StopReason::Timeout {
+            timeout_seconds: timeout.as_secs(),
+        }
+    })
+}
+
+fn cancellation_or_timeout<'a, C>(
+    cancel: C,
+    timeout: Option<Duration>,
+    grace: Duration,
+) -> StopFuture<'a>
+where
+    C: std::future::Future<Output = ()> + Send + 'a,
+{
+    Box::pin(async move {
+        match timeout {
+            Some(timeout) => tokio::select! {
+                () = cancel => StopReason::Cancelled {
+                    grace_seconds: grace.as_secs(),
+                },
+                () = tokio::time::sleep(timeout) => StopReason::Timeout {
+                    timeout_seconds: timeout.as_secs(),
+                },
+            },
+            None => {
+                cancel.await;
+                StopReason::Cancelled {
+                    grace_seconds: grace.as_secs(),
+                }
+            }
+        }
+    })
+}
 
 /// Everything one spawn needs, gathered so the signature stays readable.
 struct SpawnSpec<'a> {
@@ -551,7 +652,7 @@ struct SpawnSpec<'a> {
 
 async fn run_internal_inner(
     spec: SpawnSpec<'_>,
-    cancel: Option<CancelFuture<'_>>,
+    stop: Option<StopFuture<'_>>,
     grace: Duration,
 ) -> Result<CommandOutput> {
     let SpawnSpec {
@@ -604,61 +705,106 @@ async fn run_internal_inner(
     // means signalling it would hit the parent too.
     let mut group = GroupKillGuard::new(process_group.then(|| child.id()).flatten());
     let child_stdin = child.stdin.take();
+    let mut child_stdout = child.stdout.take().expect("stdout was configured as piped");
+    let mut child_stderr = child.stderr.take().expect("stderr was configured as piped");
 
     let write = async move {
         let (Some(prompt), Some(mut stdin)) = (stdin_prompt, child_stdin) else {
             return Ok(());
         };
         use tokio::io::AsyncWriteExt;
-        stdin.write_all(prompt.as_bytes()).await?;
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| Error::Io {
+                message: format!("failed to write the prompt to codex stdin: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })?;
         // Closing the write half is what tells the CLI the prompt is
         // complete. Without it the child waits for more input.
-        stdin.shutdown().await
+        stdin.shutdown().await.map_err(|e| Error::Io {
+            message: format!("failed to close codex stdin: {e}"),
+            source: e,
+            working_dir: working_dir.map(|p| p.to_path_buf()),
+        })
     };
 
     // Concurrently, not sequentially: a prompt larger than the pipe buffer
     // blocks until the child reads it, and a child that writes to stdout
     // meanwhile blocks until we read that. Waiting for the write to finish
     // before draining stdout would deadlock both.
-    let run = async { tokio::join!(write, child.wait_with_output()) };
+    let read_stdout = async move {
+        use tokio::io::AsyncReadExt;
+        let mut bytes = Vec::new();
+        child_stdout
+            .read_to_end(&mut bytes)
+            .await
+            .map(|_| bytes)
+            .map_err(|e| Error::Io {
+                message: format!("failed to read codex stdout: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })
+    };
+    let read_stderr = async move {
+        use tokio::io::AsyncReadExt;
+        let mut bytes = Vec::new();
+        child_stderr
+            .read_to_end(&mut bytes)
+            .await
+            .map(|_| bytes)
+            .map_err(|e| Error::Io {
+                message: format!("failed to read codex stderr: {e}"),
+                source: e,
+                working_dir: working_dir.map(|p| p.to_path_buf()),
+            })
+    };
+    let wait = async { child.wait().await.map_err(|e| wait_error(e, working_dir)) };
+    let run = async {
+        let ((), stdout, stderr, status) = tokio::try_join!(write, read_stdout, read_stderr, wait)?;
+        Ok::<_, Error>((stdout, stderr, status))
+    };
 
-    let finished = match cancel {
-        None => Some(run.await),
+    let finished = match stop {
+        None => Ok(run.await),
         // Racing the run against the caller's signal. Cancellation here is
         // graceful, which is the whole reason it cannot live in `Drop`:
         // asking a process to stop and then waiting requires awaiting.
-        Some(cancel) => tokio::select! {
-            outcome = run => Some(outcome),
-            () = cancel => None,
+        Some(stop) => tokio::select! {
+            outcome = run => Ok(outcome),
+            reason = stop => Err(reason),
         },
     };
 
-    let Some((write_result, output_result)) = finished else {
-        group.terminate(grace).await;
-        return Err(Error::Cancelled {
-            grace_seconds: grace.as_secs(),
-        });
+    let (stdout, stderr, status) = match finished {
+        Ok(Ok(finished)) => finished,
+        Ok(Err(error)) => {
+            // A stdin or pipe failure can happen while the child continues
+            // running. Treat it as a stop request and settle ownership before
+            // exposing the I/O error.
+            terminate_and_reap(&mut child, &mut group, grace, working_dir).await?;
+            return Err(error);
+        }
+        Err(reason) => {
+            // The run future is gone before this branch executes, returning
+            // ownership of `child` so cleanup can explicitly reap it.
+            // `GroupKillGuard::terminate` reaches descendants on Unix. The
+            // direct-child kill below is the portable fallback and makes the
+            // wait authoritative on every platform.
+            terminate_and_reap(&mut child, &mut group, grace, working_dir).await?;
+            return Err(reason.into_error());
+        }
     };
-
-    write_result.map_err(|e| Error::Io {
-        message: format!("failed to write the prompt to codex stdin: {e}"),
-        source: e,
-        working_dir: working_dir.map(|p| p.to_path_buf()),
-    })?;
-    let output = output_result.map_err(|e| Error::Io {
-        message: format!("failed to wait on codex: {e}"),
-        source: e,
-        working_dir: working_dir.map(|p| p.to_path_buf()),
-    })?;
 
     // Finished on its own, so there is no group left to kill.
     group.disarm();
 
-    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    let exit_code = output.status.code().unwrap_or(-1);
+    let stdout = String::from_utf8_lossy(&stdout).to_string();
+    let stderr = String::from_utf8_lossy(&stderr).to_string();
+    let exit_code = status.code().unwrap_or(-1);
 
-    if !output.status.success() {
+    if !status.success() {
         return Err(Error::from_command_failure(
             format!("{} {}", binary.display(), args.join(" ")),
             exit_code,
@@ -676,6 +822,34 @@ async fn run_internal_inner(
     })
 }
 
+async fn terminate_and_reap(
+    child: &mut tokio::process::Child,
+    group: &mut GroupKillGuard,
+    grace: Duration,
+    working_dir: Option<&std::path::Path>,
+) -> Result<()> {
+    group.terminate(grace).await;
+    if child
+        .try_wait()
+        .map_err(|e| wait_error(e, working_dir))?
+        .is_none()
+        && let Err(error) = child.start_kill()
+        && error.kind() != std::io::ErrorKind::InvalidInput
+    {
+        return Err(wait_error(error, working_dir));
+    }
+    child.wait().await.map_err(|e| wait_error(e, working_dir))?;
+    Ok(())
+}
+
+fn wait_error(error: std::io::Error, working_dir: Option<&std::path::Path>) -> Error {
+    Error::Io {
+        message: format!("failed to wait on codex: {error}"),
+        source: error,
+        working_dir: working_dir.map(|p| p.to_path_buf()),
+    }
+}
+
 /// Apply the client environment policy to a direct child process.
 ///
 /// Kept in one helper because buffered and streaming execution construct
@@ -689,25 +863,6 @@ pub(crate) fn apply_child_environment(
         cmd.env_clear();
     }
     cmd.envs(env);
-}
-
-async fn run_with_timeout(
-    binary: &std::path::Path,
-    args: &[String],
-    env: &std::collections::HashMap<String, String>,
-    clear_env: bool,
-    working_dir: Option<&std::path::Path>,
-    timeout: Duration,
-    process_group: bool,
-) -> Result<CommandOutput> {
-    tokio::time::timeout(
-        timeout,
-        run_internal(binary, args, env, clear_env, working_dir, process_group),
-    )
-    .await
-    .map_err(|_| Error::Timeout {
-        timeout_seconds: timeout.as_secs(),
-    })?
 }
 
 #[cfg(test)]
@@ -953,13 +1108,11 @@ mod tests {
         assert!(!format!("{error:?}").contains(secret));
     }
 
-    /// A wrapper timeout drops `run_internal`'s future. Without
-    /// `kill_on_drop`, `Error::Timeout` would mean "we stopped waiting" while
-    /// codex kept running.
+    /// A wrapper timeout is not terminal until the direct child is reaped.
     #[cfg(unix)]
     #[tokio::test]
     async fn timeout_kills_the_spawned_process() {
-        use crate::test_support::{PidFile, blocking_codex, wait_until_gone};
+        use crate::test_support::{PidFile, blocking_codex, is_running_for_test};
 
         let pid_file = PidFile::new("exec-timeout");
         let codex = blocking_codex(&pid_file)
@@ -975,7 +1128,7 @@ mod tests {
 
         let pid = pid_file.read_pid().await;
         assert!(
-            wait_until_gone(pid).await,
+            !is_running_for_test(pid),
             "codex ({pid}) survived the timeout"
         );
     }
@@ -1376,7 +1529,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn run_codex_cancellable_stops_the_group_gracefully() {
-        use crate::test_support::wait_until_gone;
+        use crate::test_support::is_running_for_test;
 
         let (codex, pid_file) = spawning_codex("group-cancel");
         let codex = Codex::builder()
@@ -1407,10 +1560,90 @@ mod tests {
         );
 
         let (parent, child) = read_pids(&pid_file).await;
-        assert!(wait_until_gone(parent).await, "codex ({parent}) survived");
+        assert!(!is_running_for_test(parent), "codex ({parent}) survived");
         assert!(
-            wait_until_gone(child).await,
+            !is_running_for_test(child),
             "the subprocess ({child}) survived cancellation"
+        );
+    }
+
+    /// Buffered timeout uses the same settled process-tree cleanup as an
+    /// explicit cancellation signal.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn timeout_stops_the_group_before_returning() {
+        use crate::test_support::is_running_for_test;
+
+        let pid_file = crate::test_support::PidFile::new("group-timeout-settled");
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-spawns-child.sh");
+        let codex = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .env(
+                "CODEX_WRAPPER_TEST_PIDFILE",
+                pid_file.path().to_str().unwrap(),
+            )
+            .timeout(Duration::from_millis(300))
+            .termination_grace(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let result = run_codex(&codex, vec!["exec".into()]).await;
+        assert!(
+            matches!(result, Err(Error::Timeout { .. })),
+            "expected a timeout, got: {result:?}"
+        );
+
+        let (parent, child) = read_pids(&pid_file).await;
+        assert!(!is_running_for_test(parent), "codex ({parent}) survived");
+        assert!(
+            !is_running_for_test(child),
+            "the subprocess ({child}) survived the timeout"
+        );
+    }
+
+    /// A broken stdin pipe is terminal only after the process tree has been
+    /// stopped. Returning the write error first would release the caller while
+    /// the provider could still mutate the workspace.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stdin_write_failure_stops_and_reaps_before_returning() {
+        use crate::test_support::is_running_for_test;
+
+        let pid_file = crate::test_support::PidFile::new("stdin-write-failure");
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-closes-stdin-spawns-child.sh");
+        let codex = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .env(
+                "CODEX_WRAPPER_TEST_PIDFILE",
+                pid_file.path().to_str().unwrap(),
+            )
+            .termination_grace(Duration::from_millis(10))
+            .build()
+            .unwrap();
+
+        let prompt = "x".repeat(4 * 1024 * 1024);
+        let result = run_codex_with_stdin_prompt(
+            &codex,
+            crate::ExecCommand::from_stdin(&prompt).args(),
+            &prompt,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(Error::Io { ref message, .. }) if message.contains("stdin")),
+            "expected a stdin error, got: {result:?}"
+        );
+
+        let (parent, child) = read_pids(&pid_file).await;
+        assert!(!is_running_for_test(parent), "codex ({parent}) survived");
+        assert!(
+            !is_running_for_test(child),
+            "the subprocess ({child}) survived the stdin failure"
         );
     }
 

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -153,18 +153,19 @@
 //!
 //! # Cancellation
 //!
-//! Dropping the future returned by a command kills the spawned `codex`
-//! process. That covers a timeout, an aborted task, and a caller that stops
-//! awaiting during a graceful shutdown: cancelling the future cancels the
-//! work, rather than leaving codex running and billing with no handle left to
-//! stop it.
+//! [`ExecCommand::execute_cancellable`] and
+//! [`ExecResumeCommand::execute_cancellable`] accept an explicit cancellation
+//! future. They terminate the owned process group and await the direct child
+//! before returning. Buffered client timeouts use the same settled cleanup
+//! path.
 //!
-//! Two limits are worth knowing:
+//! Dropping an ordinary command future is an abrupt fallback. It kills the
+//! direct child and, on Unix, the owned process group, but `Drop` cannot await
+//! reaping. A supervisor that needs terminal settlement should signal a
+//! cancellable method and keep polling it until it returns.
 //!
-//! - The kill reaps the `codex` process itself. Subprocesses codex spawned for
-//!   tool use are not signalled and can outlive it.
-//! - Reaping needs the tokio runtime to still be running. A future dropped as
-//!   part of runtime shutdown may not get far enough to kill the child.
+//! Process groups are Unix-only. Elsewhere explicit cancellation kills and
+//! awaits the direct child, but cannot guarantee descendant cleanup.
 //!
 //! # Features
 //!
@@ -571,10 +572,10 @@ impl CodexBuilder {
     /// How long a cancelled run's process group gets to exit before it is
     /// killed. Defaults to five seconds.
     ///
-    /// Applies to
-    /// [`run_codex_cancellable`](crate::exec::run_codex_cancellable), which
-    /// sends SIGTERM, waits this long, then sends SIGKILL. A dropped future
-    /// does not use it: `Drop` cannot wait, so it kills immediately.
+    /// Applies to cancellable exec methods and buffered client timeouts. They
+    /// send SIGTERM, wait this long, send SIGKILL, and await the direct child.
+    /// A dropped future does not use it: `Drop` cannot wait, so it kills
+    /// immediately.
     #[must_use]
     pub fn termination_grace(mut self, duration: Duration) -> Self {
         self.termination_grace = Some(duration);

--- a/crates/codex-wrapper/tests/fake-codex-closes-stdin-spawns-child.sh
+++ b/crates/codex-wrapper/tests/fake-codex-closes-stdin-spawns-child.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Records a process tree, then closes stdin while continuing to run. A large
+# wrapper prompt therefore fails to write while both processes are alive.
+sleep 60 </dev/null &
+child=$!
+{
+  echo "parent=$$"
+  echo "child=$child"
+} > "$CODEX_WRAPPER_TEST_PIDFILE"
+exec 0<&-
+wait "$child"


### PR DESCRIPTION
## Summary

Implement the cancellation-settlement contract planned in #125.

## What changed

- buffered timeout and caller cancellation now converge on one stop path
- Unix process groups receive SIGTERM, then SIGKILL after the configured grace period
- the direct child is explicitly awaited before cancellation, timeout, or pipe-failure errors return
- stdin write, stdin close, stdout read, and stderr read failures also settle process ownership before surfacing
- `ExecCommand` and `ExecResumeCommand` expose cancellable raw, JSONL, and typed JSON methods, including stdin prompts
- documentation distinguishes awaited explicit cancellation from abrupt future-drop cleanup and states the non-Unix direct-child limit

## Why

Dropping an execution future could kill the process tree, but it could not prove that the direct child was reaped before a higher-level service released admission or reported terminal settlement.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (257 passed)
- `cargo test --lib --no-default-features` (157 passed)
- `cargo test --doc --all-features` (28 passed)
- root and crate READMEs are byte-identical
- `tower-agent-codex` tested against this local checkout: 8 passed, 1 ignored live test

Fake-process regressions prove no live direct child or Unix descendant remains when explicit cancellation, buffered timeout, or broken stdin returns.