### PR TITLE
feat(process): implement durable worker containment

### DIFF
--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -1734,6 +1734,7 @@ mod tests {
         assert!(output.success);
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn spawn_observer_reports_each_buffered_child_before_returning() {
         use std::sync::{Arc, Mutex};
@@ -1754,6 +1755,7 @@ mod tests {
         assert!(output.stdout.contains("probe"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn spawn_receipt_never_claims_a_shared_group() {
         use std::sync::{Arc, Mutex};
@@ -1776,6 +1778,7 @@ mod tests {
         assert_eq!(die_with_parent_supported(), cfg!(target_os = "linux"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn parent_death_policy_composes_with_spawn_observation() {
         use std::sync::{Arc, Mutex};

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -1839,7 +1839,7 @@ mod tests {
         let stdout = helper.stdout.take().expect("piped stdout");
         let pid = BufReader::new(stdout)
             .lines()
-            .map_while(Result::ok)
+            .map_while(std::result::Result::ok)
             .find_map(|line| line.strip_prefix("PID ").and_then(|pid| pid.parse().ok()))
             .expect("helper reported child pid");
 

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -110,6 +110,78 @@ pub(crate) fn own_process_group(cmd: &mut Command, enabled: bool) {
 #[cfg(not(unix))]
 pub(crate) fn own_process_group(_cmd: &mut Command, _enabled: bool) {}
 
+/// Whether [`CodexBuilder::die_with_parent`](crate::CodexBuilder::die_with_parent)
+/// has a kernel-level effect on this platform.
+///
+/// This is true only on Linux, where `PR_SET_PDEATHSIG` is available. A
+/// supervisor that needs portable containment should use
+/// [`CodexBuilder::on_spawn`](crate::CodexBuilder::on_spawn) to maintain its
+/// own watchdog on other targets.
+#[must_use]
+pub const fn die_with_parent_supported() -> bool {
+    cfg!(target_os = "linux")
+}
+
+/// Ask the kernel to SIGKILL the child when its immediate parent dies.
+///
+/// The parent pid is captured before the fork. After arming the signal in the
+/// child, the hook checks it again and exits if the parent changed in the
+/// fork-to-prctl window. Every call here is async-signal-safe because this hook
+/// runs after `fork` and before `exec`.
+#[cfg(unix)]
+fn pdeathsig_hook() -> impl FnMut() -> std::io::Result<()> + Send + Sync + 'static {
+    let parent = std::process::id();
+    move || {
+        #[cfg(target_os = "linux")]
+        {
+            // SAFETY: prctl, getppid, and _exit are async-signal-safe calls.
+            unsafe {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                if libc::getppid() as u32 != parent {
+                    libc::_exit(1);
+                }
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = parent;
+        }
+        Ok(())
+    }
+}
+
+/// Apply the parent-death policy to a spawn command.
+pub(crate) fn apply_die_with_parent(cmd: &mut Command, enabled: bool) {
+    #[cfg(unix)]
+    if enabled {
+        // SAFETY: `pdeathsig_hook` uses only async-signal-safe operations.
+        unsafe {
+            cmd.pre_exec(pdeathsig_hook());
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (cmd, enabled);
+    }
+}
+
+/// Arm group cleanup and notify the observer from one process receipt.
+pub(crate) fn arm_and_notify(
+    process_group: bool,
+    pid: Option<u32>,
+    on_spawn: Option<&crate::SpawnObserver>,
+) -> GroupKillGuard {
+    if let (Some(pid), Some(observer)) = (pid, on_spawn) {
+        observer(crate::SpawnInfo {
+            pid,
+            pgid: process_group.then_some(pid),
+        });
+    }
+    GroupKillGuard::new(process_group.then_some(pid).flatten())
+}
+
 /// Signal a process group, given the group leader's pid.
 ///
 /// Unix only: there is no non-unix counterpart, because every caller of this
@@ -337,6 +409,8 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                         working_dir: codex.working_dir.as_deref(),
                         stdin_prompt: None,
                         process_group: codex.process_group,
+                        die_with_parent: codex.die_with_parent,
+                        on_spawn: codex.on_spawn.as_ref(),
                     },
                     Some(timeout_stop(timeout)),
                     codex.termination_grace,
@@ -344,13 +418,20 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                 .await
             }
             None => {
-                run_internal(
-                    &codex.binary,
-                    &command_args,
-                    &codex.env,
-                    codex.clear_env,
-                    codex.working_dir.as_deref(),
-                    codex.process_group,
+                run_internal_inner(
+                    SpawnSpec {
+                        binary: &codex.binary,
+                        args: &command_args,
+                        env: &codex.env,
+                        clear_env: codex.clear_env,
+                        working_dir: codex.working_dir.as_deref(),
+                        stdin_prompt: None,
+                        process_group: codex.process_group,
+                        die_with_parent: codex.die_with_parent,
+                        on_spawn: codex.on_spawn.as_ref(),
+                    },
+                    None,
+                    Duration::ZERO,
                 )
                 .await
             }
@@ -403,6 +484,8 @@ where
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: None,
                 process_group: codex.process_group,
+                die_with_parent: codex.die_with_parent,
+                on_spawn: codex.on_spawn.as_ref(),
             },
             Some(stop),
             codex.termination_grace,
@@ -494,6 +577,8 @@ pub async fn run_codex_with_stdin_prompt(
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: Some(prompt),
                 process_group: codex.process_group,
+                die_with_parent: codex.die_with_parent,
+                on_spawn: codex.on_spawn.as_ref(),
             },
             stop,
             codex.termination_grace,
@@ -542,6 +627,8 @@ where
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: Some(prompt),
                 process_group: codex.process_group,
+                die_with_parent: codex.die_with_parent,
+                on_spawn: codex.on_spawn.as_ref(),
             },
             Some(stop),
             codex.termination_grace,
@@ -555,30 +642,6 @@ where
         result
     }
     .instrument(span)
-    .await
-}
-
-async fn run_internal(
-    binary: &std::path::Path,
-    args: &[String],
-    env: &std::collections::HashMap<String, String>,
-    clear_env: bool,
-    working_dir: Option<&std::path::Path>,
-    process_group: bool,
-) -> Result<CommandOutput> {
-    run_internal_inner(
-        SpawnSpec {
-            binary,
-            args,
-            env,
-            clear_env,
-            working_dir,
-            stdin_prompt: None,
-            process_group,
-        },
-        None,
-        Duration::from_secs(0),
-    )
     .await
 }
 
@@ -648,6 +711,10 @@ struct SpawnSpec<'a> {
     stdin_prompt: Option<&'a str>,
     /// Whether the run leads its own process group.
     process_group: bool,
+    /// Whether the child should die with its immediate parent on Linux.
+    die_with_parent: bool,
+    /// Who to notify immediately after a successful spawn.
+    on_spawn: Option<&'a crate::SpawnObserver>,
 }
 
 async fn run_internal_inner(
@@ -663,6 +730,8 @@ async fn run_internal_inner(
         working_dir,
         stdin_prompt,
         process_group,
+        die_with_parent,
+        on_spawn,
     } = spec;
     let mut cmd = Command::new(binary);
     cmd.args(args);
@@ -680,6 +749,7 @@ async fn run_internal_inner(
     // and codex keeps running with no handle left to stop it.
     cmd.kill_on_drop(true);
     own_process_group(&mut cmd, process_group);
+    apply_die_with_parent(&mut cmd, die_with_parent);
 
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);
@@ -703,7 +773,7 @@ async fn run_internal_inner(
     // group, which is what reaches the subprocesses codex started.
     // Only meaningful when the run leads its own group. Sharing the parent's
     // means signalling it would hit the parent too.
-    let mut group = GroupKillGuard::new(process_group.then(|| child.id()).flatten());
+    let mut group = arm_and_notify(process_group, child.id(), on_spawn);
     let child_stdin = child.stdin.take();
     let mut child_stdout = child.stdout.take().expect("stdout was configured as piped");
     let mut child_stderr = child.stderr.take().expect("stderr was configured as piped");
@@ -1662,6 +1732,128 @@ mod tests {
             .await
             .unwrap();
         assert!(output.success);
+    }
+
+    #[tokio::test]
+    async fn spawn_observer_reports_each_buffered_child_before_returning() {
+        use std::sync::{Arc, Mutex};
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .on_spawn(Arc::new(move |info| sink.lock().unwrap().push(info)))
+            .build()
+            .expect("echo must exist");
+
+        let output = run_codex(&codex, vec!["probe".into()]).await.unwrap();
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert!(seen[0].pid > 0);
+        assert_eq!(seen[0].pgid, Some(seen[0].pid));
+        assert!(output.stdout.contains("probe"));
+    }
+
+    #[tokio::test]
+    async fn spawn_receipt_never_claims_a_shared_group() {
+        use std::sync::{Arc, Mutex};
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .process_group(false)
+            .on_spawn(Arc::new(move |info| sink.lock().unwrap().push(info)))
+            .build()
+            .expect("echo must exist");
+
+        run_codex(&codex, vec!["probe".into()]).await.unwrap();
+        assert_eq!(seen.lock().unwrap()[0].pgid, None);
+    }
+
+    #[test]
+    fn parent_death_support_matches_the_target() {
+        assert_eq!(die_with_parent_supported(), cfg!(target_os = "linux"));
+    }
+
+    #[tokio::test]
+    async fn parent_death_policy_composes_with_spawn_observation() {
+        use std::sync::{Arc, Mutex};
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sink = Arc::clone(&seen);
+        let codex = Codex::builder()
+            .binary("/bin/echo")
+            .die_with_parent(true)
+            .on_spawn(Arc::new(move |info| sink.lock().unwrap().push(info)))
+            .build()
+            .expect("echo must exist");
+
+        run_codex(&codex, vec!["probe".into()]).await.unwrap();
+        assert_eq!(seen.lock().unwrap().len(), 1);
+    }
+
+    const PDEATHSIG_HELPER_ENV: &str = "CODEX_WRAPPER_PDEATHSIG_HELPER";
+
+    #[test]
+    fn pdeathsig_helper_process() {
+        if std::env::var(PDEATHSIG_HELPER_ENV).is_err() {
+            return;
+        }
+        use std::io::Write;
+        use std::sync::Arc;
+
+        let codex = Codex::builder()
+            .binary("/bin/sleep")
+            .die_with_parent(true)
+            .on_spawn(Arc::new(|info| {
+                println!("PID {}", info.pid);
+                let _ = std::io::stdout().flush();
+            }))
+            .build()
+            .unwrap();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _ = runtime.block_on(run_codex(&codex, vec!["300".into()]));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn child_dies_when_its_parent_is_sigkilled() {
+        use std::io::{BufRead, BufReader};
+        use std::process::{Command, Stdio};
+
+        let executable = std::env::current_exe().expect("test binary path");
+        let mut helper = Command::new(executable)
+            .args([
+                "--exact",
+                "exec::tests::pdeathsig_helper_process",
+                "--nocapture",
+            ])
+            .env(PDEATHSIG_HELPER_ENV, "1")
+            .stdout(Stdio::piped())
+            .spawn()
+            .expect("spawn helper");
+        let stdout = helper.stdout.take().expect("piped stdout");
+        let pid = BufReader::new(stdout)
+            .lines()
+            .map_while(Result::ok)
+            .find_map(|line| line.strip_prefix("PID ").and_then(|pid| pid.parse().ok()))
+            .expect("helper reported child pid");
+
+        // SAFETY: this deliberately simulates an uncatchable supervisor crash.
+        unsafe { libc::kill(helper.id() as i32, libc::SIGKILL) };
+        let _ = helper.wait();
+
+        for _ in 0..50 {
+            if !crate::test_support::is_running_for_test(pid) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        panic!("child {pid} survived its SIGKILLed parent");
     }
 
     /// Opting out is not cosmetic: without a group of its own, cancelling

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -247,6 +247,30 @@ pub use version::{
     CliVersion, CliVersionStatus, TESTED_CLI_VERSION_MAX, TESTED_CLI_VERSION_MIN, VersionParseError,
 };
 
+/// What the crate knows about a child the moment it is spawned.
+///
+/// Delivered to the [`CodexBuilder::on_spawn`] observer before the run can
+/// produce output. This lets a supervisor durably record the child while the
+/// run is still in progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SpawnInfo {
+    /// The child's process id.
+    pub pid: u32,
+    /// The child's process group id, when it leads its own group.
+    ///
+    /// `None` when [`CodexBuilder::process_group`] is disabled. In that case
+    /// the child shares the parent's group and its pid must not be passed to
+    /// `killpg`, which would signal the caller's own process group.
+    pub pgid: Option<u32>,
+}
+
+/// Called with [`SpawnInfo`] each time the crate spawns a CLI child.
+///
+/// Must not block. It runs inline between `spawn` and the first read of the
+/// child's output.
+pub type SpawnObserver = std::sync::Arc<dyn Fn(SpawnInfo) + Send + Sync>;
+
 /// Shared Codex CLI client configuration.
 ///
 /// Holds the binary path, working directory, environment variables, global
@@ -274,6 +298,8 @@ pub struct Codex {
     pub(crate) timeout: Option<Duration>,
     pub(crate) termination_grace: Duration,
     pub(crate) process_group: bool,
+    pub(crate) die_with_parent: bool,
+    pub(crate) on_spawn: Option<SpawnObserver>,
     pub(crate) retry_policy: Option<RetryPolicy>,
     pub(crate) tested_cli_version_range: (CliVersion, CliVersion),
 }
@@ -448,6 +474,8 @@ impl fmt::Debug for Codex {
             .field("timeout", &self.timeout)
             .field("termination_grace", &self.termination_grace)
             .field("process_group", &self.process_group)
+            .field("die_with_parent", &self.die_with_parent)
+            .field("has_spawn_observer", &self.on_spawn.is_some())
             .field("retry_policy", &self.retry_policy)
             .field("tested_cli_version_range", &self.tested_cli_version_range)
             .finish()
@@ -490,6 +518,8 @@ pub struct CodexBuilder {
     timeout: Option<Duration>,
     termination_grace: Option<Duration>,
     process_group: Option<bool>,
+    die_with_parent: bool,
+    on_spawn: Option<SpawnObserver>,
     retry_policy: Option<RetryPolicy>,
     tested_cli_version_range: Option<(CliVersion, CliVersion)>,
 }
@@ -602,6 +632,39 @@ impl CodexBuilder {
         self
     }
 
+    /// Observe every child this client spawns, at spawn time.
+    ///
+    /// The observer fires before the run produces output, including for
+    /// buffered, streaming, stdin, cancellable, and retried runs. A retry
+    /// fires once per attempt because each attempt is a distinct process.
+    ///
+    /// The observer runs inline on the spawning thread and must not block.
+    /// A supervisor can use it to write a pidfile or send the receipt to a
+    /// channel before the child can be orphaned.
+    #[must_use]
+    pub fn on_spawn(mut self, observer: SpawnObserver) -> Self {
+        self.on_spawn = Some(observer);
+        self
+    }
+
+    /// Ask the kernel to kill spawned children when this process dies.
+    ///
+    /// This uses `PR_SET_PDEATHSIG` on Linux. Check
+    /// [`die_with_parent_supported`](crate::exec::die_with_parent_supported)
+    /// before relying on it; other targets accept the option as a no-op. A
+    /// portable supervisor should combine this with [`on_spawn`](Self::on_spawn)
+    /// and reconcile recorded children after a restart.
+    ///
+    /// The post-fork hook closes the parent-death race by rechecking the
+    /// parent after arming the signal. This is off by default because it is
+    /// appropriate for supervised work but not for deliberately backgrounded
+    /// CLI processes.
+    #[must_use]
+    pub fn die_with_parent(mut self, enabled: bool) -> Self {
+        self.die_with_parent = enabled;
+        self
+    }
+
     /// Append a raw global argument passed before any subcommand.
     ///
     /// When an exec command has a typed rollout budget, conflicting global
@@ -671,6 +734,8 @@ impl CodexBuilder {
                 .termination_grace
                 .unwrap_or_else(|| Duration::from_secs(5)),
             process_group: self.process_group.unwrap_or(true),
+            die_with_parent: self.die_with_parent,
+            on_spawn: self.on_spawn,
             timeout: self.timeout,
             retry_policy: self.retry_policy,
             tested_cli_version_range: self.tested_cli_version_range.unwrap_or((
@@ -695,6 +760,8 @@ impl fmt::Debug for CodexBuilder {
             .field("timeout", &self.timeout)
             .field("termination_grace", &self.termination_grace)
             .field("process_group", &self.process_group)
+            .field("die_with_parent", &self.die_with_parent)
+            .field("has_spawn_observer", &self.on_spawn.is_some())
             .field("retry_policy", &self.retry_policy)
             .field("tested_cli_version_range", &self.tested_cli_version_range)
             .finish()

--- a/crates/codex-wrapper/src/streaming.rs
+++ b/crates/codex-wrapper/src/streaming.rs
@@ -106,6 +106,7 @@ where
     // and codex keeps running with no handle left to stop it.
     child_cmd.kill_on_drop(true);
     crate::exec::own_process_group(&mut child_cmd, codex.process_group);
+    crate::exec::apply_die_with_parent(&mut child_cmd, codex.die_with_parent);
 
     if let Some(dir) = &codex.working_dir {
         child_cmd.current_dir(dir);
@@ -122,7 +123,7 @@ where
     // which reaches the subprocesses codex started for tool use; kill_on_drop
     // alone would leave those running (#78).
     let mut group =
-        crate::exec::GroupKillGuard::new(codex.process_group.then(|| child.id()).flatten());
+        crate::exec::arm_and_notify(codex.process_group, child.id(), codex.on_spawn.as_ref());
 
     let stdout = child.stdout.take().expect("stdout was configured as piped");
     let stderr = child.stderr.take().expect("stderr was configured as piped");
@@ -342,6 +343,35 @@ mod tests {
 
         let events = events.lock().unwrap();
         assert!(!events.is_empty(), "expected at least one event");
+    }
+
+    #[tokio::test]
+    async fn streaming_reports_the_child_before_events_are_delivered() {
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let spawn_order = Arc::clone(&order);
+        let event_order = Arc::clone(&order);
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex.sh");
+        let codex = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .on_spawn(Arc::new(move |_| spawn_order.lock().unwrap().push("spawn")))
+            .build()
+            .expect("bash must exist");
+
+        crate::ExecCommand::new("probe")
+            .json()
+            .stream(&codex, move |_| {
+                let mut order = event_order.lock().unwrap();
+                if !order.contains(&"event") {
+                    order.push("event");
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(&order.lock().unwrap()[..2], ["spawn", "event"]);
     }
 
     /// Streaming owns a separate process builder from buffered execution.


### PR DESCRIPTION
## Summary

Follow-up to #128, which merged the planning commit before the implementation was pushed.

- expose an immediate spawn receipt for every Codex child
- add opt-in Linux parent-death signaling with race protection
- apply the policy to buffered, cancellable, stdin, retry, and streaming paths
- cover observer timing, process-group honesty, and Linux worker death

Required by joshrotenberg/tower-agent#63.