### PR TITLE
feat(exec): bound captured child output by bytes (closes #132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,43 @@ Each CLI subcommand is a separate builder:
 | `VersionCommand` | `codex --version` | Get CLI version |
 | `RawCommand` | *(any)* | Escape hatch for arbitrary args |
 
+### Bounding captured output
+
+Both captured streams are read to completion by default, so peak memory for a
+run is whatever the child decides to print. A consumer cannot add this bound
+itself: by the time it holds a `CommandOutput` the bytes are already resident,
+and for a JSONL run already parsed.
+
+```rust
+use codex_wrapper::{Codex, Error, ExecCommand, CodexCommand};
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let codex = Codex::builder()
+    .output_limit(8 * 1024 * 1024)
+    .build()?;
+
+match ExecCommand::new("summarize this repository").execute(&codex).await {
+    Ok(result) => println!("{}", result.stdout),
+    Err(Error::OutputLimitExceeded { stream, limit_bytes }) => {
+        eprintln!("codex {stream} passed {limit_bytes} bytes and was stopped");
+    }
+    Err(other) => return Err(other.into()),
+}
+# Ok(())
+# }
+```
+
+With a ceiling set, each buffer stays under it, so a run holds at most twice
+the ceiling across stdout and stderr. Passing it stops the run the way
+cancellation does, rather than letting the child keep writing into a buffer
+nothing will read.
+
+`Error::OutputLimitExceeded` carries no captured bytes. A prefix returned as
+though it were the whole result would be indistinguishable from a genuinely
+short answer, which is the failure this prevents; enough of the prefix to
+identify the runaway is logged at warn instead. The ceiling is off by default,
+so nothing changes until a host opts in.
+
 ## ExecCommand
 
 Full coverage of `codex exec` options:

--- a/crates/codex-wrapper/src/error.rs
+++ b/crates/codex-wrapper/src/error.rs
@@ -2,6 +2,25 @@
 
 use std::path::PathBuf;
 
+/// Which of a child's captured streams an [`Error::OutputLimitExceeded`]
+/// refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OutputStream {
+    /// The child's standard output.
+    Stdout,
+    /// The child's standard error.
+    Stderr,
+}
+
+impl std::fmt::Display for OutputStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        })
+    }
+}
+
 /// Errors returned by `codex-wrapper` operations.
 ///
 /// This enum is `#[non_exhaustive]`: match arms must include a `_` catch-all so
@@ -13,6 +32,26 @@ pub enum Error {
     /// The `codex` binary was not found in PATH.
     #[error("codex binary not found in PATH")]
     NotFound,
+
+    /// A captured stream passed the ceiling set by
+    /// [`CodexBuilder::output_limit`](crate::CodexBuilder::output_limit).
+    ///
+    /// The run is stopped the same way [`Error::Cancelled`] and
+    /// [`Error::Timeout`] stop it, so the child does not keep writing into a
+    /// buffer nothing will read. No captured bytes are carried here: output
+    /// seen before the ceiling tripped is logged at warn instead, because
+    /// returning a prefix as if it were the result is the truncated success
+    /// this exists to prevent.
+    ///
+    /// The ceiling is off by default and this error cannot occur while it is
+    /// unset.
+    #[error("codex {stream} exceeded the {limit_bytes}-byte capture limit")]
+    OutputLimitExceeded {
+        /// Which captured stream exceeded the ceiling.
+        stream: OutputStream,
+        /// The configured ceiling, in bytes, that was exceeded.
+        limit_bytes: usize,
+    },
 
     /// The CLI could not authenticate.
     ///

--- a/crates/codex-wrapper/src/exec.rs
+++ b/crates/codex-wrapper/src/exec.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 use tracing::{Instrument, Span, debug, field, info_span};
 
 use crate::Codex;
-use crate::error::{Error, Result};
+use crate::error::{Error, OutputStream, Result};
 
 /// Build the span covering one invocation.
 ///
@@ -409,6 +409,7 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                         working_dir: codex.working_dir.as_deref(),
                         stdin_prompt: None,
                         process_group: codex.process_group,
+                        output_limit: codex.output_limit,
                         die_with_parent: codex.die_with_parent,
                         on_spawn: codex.on_spawn.as_ref(),
                     },
@@ -427,6 +428,7 @@ async fn run_codex_once(codex: &Codex, args: Vec<String>) -> Result<CommandOutpu
                         working_dir: codex.working_dir.as_deref(),
                         stdin_prompt: None,
                         process_group: codex.process_group,
+                        output_limit: codex.output_limit,
                         die_with_parent: codex.die_with_parent,
                         on_spawn: codex.on_spawn.as_ref(),
                     },
@@ -484,6 +486,7 @@ where
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: None,
                 process_group: codex.process_group,
+                output_limit: codex.output_limit,
                 die_with_parent: codex.die_with_parent,
                 on_spawn: codex.on_spawn.as_ref(),
             },
@@ -577,6 +580,7 @@ pub async fn run_codex_with_stdin_prompt(
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: Some(prompt),
                 process_group: codex.process_group,
+                output_limit: codex.output_limit,
                 die_with_parent: codex.die_with_parent,
                 on_spawn: codex.on_spawn.as_ref(),
             },
@@ -627,6 +631,7 @@ where
                 working_dir: codex.working_dir.as_deref(),
                 stdin_prompt: Some(prompt),
                 process_group: codex.process_group,
+                output_limit: codex.output_limit,
                 die_with_parent: codex.die_with_parent,
                 on_spawn: codex.on_spawn.as_ref(),
             },
@@ -711,11 +716,79 @@ struct SpawnSpec<'a> {
     stdin_prompt: Option<&'a str>,
     /// Whether the run leads its own process group.
     process_group: bool,
+    /// Stop capturing a stream once it passes this many bytes.
+    output_limit: Option<usize>,
     /// Whether the child should die with its immediate parent on Linux.
     die_with_parent: bool,
     /// Who to notify immediately after a successful spawn.
     on_spawn: Option<&'a crate::SpawnObserver>,
 }
+
+/// Read one captured stream to EOF, or stop once it passes `limit`.
+///
+/// With no limit this is `read_to_end`, unchanged. With one, the buffer never
+/// exceeds the ceiling, so a run holds at most twice it across the two
+/// streams no matter what the child prints.
+///
+/// Exceeding it is an error rather than a truncated success. A prefix
+/// returned as though it were the whole result would be indistinguishable
+/// from a short answer, which is the failure worth preventing. Enough of the
+/// prefix to identify the runaway is logged instead.
+async fn capture<R>(
+    reader: &mut R,
+    limit: Option<usize>,
+    stream: OutputStream,
+    working_dir: Option<&std::path::Path>,
+) -> Result<Vec<u8>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+
+    let io_error = |e: std::io::Error| Error::Io {
+        message: format!("failed to read codex {stream}: {e}"),
+        source: e,
+        working_dir: working_dir.map(std::path::Path::to_path_buf),
+    };
+
+    let Some(limit) = limit else {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes).await.map_err(io_error)?;
+        return Ok(bytes);
+    };
+
+    let mut bytes = Vec::new();
+    let mut chunk = [0u8; CAPTURE_CHUNK];
+    loop {
+        let read = reader.read(&mut chunk).await.map_err(io_error)?;
+        if read == 0 {
+            return Ok(bytes);
+        }
+        if bytes.len() + read > limit {
+            bytes.truncate(BREACH_LOG_BYTES.min(bytes.len()));
+            tracing::warn!(
+                %stream,
+                limit_bytes = limit,
+                head = %String::from_utf8_lossy(&bytes),
+                "codex output exceeded its capture limit; stopping the run"
+            );
+            return Err(Error::OutputLimitExceeded {
+                stream,
+                limit_bytes: limit,
+            });
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+}
+
+/// Read size for a bounded capture. Large enough not to syscall per line,
+/// small enough that the overshoot before noticing stays trivial.
+const CAPTURE_CHUNK: usize = 8 * 1024;
+
+/// How much of the prefix to log when a stream breaches its ceiling. The
+/// whole point is not to hold the output, but the first few KiB usually name
+/// the runaway.
+const BREACH_LOG_BYTES: usize = 2 * 1024;
 
 async fn run_internal_inner(
     spec: SpawnSpec<'_>,
@@ -730,6 +803,7 @@ async fn run_internal_inner(
         working_dir,
         stdin_prompt,
         process_group,
+        output_limit,
         die_with_parent,
         on_spawn,
     } = spec;
@@ -805,30 +879,22 @@ async fn run_internal_inner(
     // meanwhile blocks until we read that. Waiting for the write to finish
     // before draining stdout would deadlock both.
     let read_stdout = async move {
-        use tokio::io::AsyncReadExt;
-        let mut bytes = Vec::new();
-        child_stdout
-            .read_to_end(&mut bytes)
-            .await
-            .map(|_| bytes)
-            .map_err(|e| Error::Io {
-                message: format!("failed to read codex stdout: {e}"),
-                source: e,
-                working_dir: working_dir.map(|p| p.to_path_buf()),
-            })
+        capture(
+            &mut child_stdout,
+            output_limit,
+            OutputStream::Stdout,
+            working_dir,
+        )
+        .await
     };
     let read_stderr = async move {
-        use tokio::io::AsyncReadExt;
-        let mut bytes = Vec::new();
-        child_stderr
-            .read_to_end(&mut bytes)
-            .await
-            .map(|_| bytes)
-            .map_err(|e| Error::Io {
-                message: format!("failed to read codex stderr: {e}"),
-                source: e,
-                working_dir: working_dir.map(|p| p.to_path_buf()),
-            })
+        capture(
+            &mut child_stderr,
+            output_limit,
+            OutputStream::Stderr,
+            working_dir,
+        )
+        .await
     };
     let wait = async { child.wait().await.map_err(|e| wait_error(e, working_dir)) };
     let run = async {
@@ -1425,6 +1491,104 @@ mod tests {
         assert!(matches!(result, Err(Error::Timeout { .. })), "{result:?}");
 
         assert_eq!(recorder.value("outcome").as_deref(), Some("timeout"));
+    }
+
+    // -----------------------------------------------------------------
+    // Bounded capture (#132)
+    // -----------------------------------------------------------------
+
+    #[cfg(unix)]
+    fn flooding_codex(stream: &str, limit: Option<usize>) -> Codex {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-floods.sh");
+        let mut builder = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .env("CODEX_WRAPPER_TEST_FLOOD_STREAM", stream);
+        if let Some(max_bytes) = limit {
+            builder = builder.output_limit(max_bytes);
+        }
+        builder.build().expect("bash must exist")
+    }
+
+    /// The ceiling has to hold on a single unbroken line, or it is really
+    /// just a line-length check that a runaway one-line writer defeats.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_stream_past_the_ceiling_fails_without_carrying_its_bytes() {
+        for stream in ["stdout", "stderr"] {
+            let codex = flooding_codex(stream, Some(64 * 1024));
+            let error = crate::ExecCommand::new("hello")
+                .execute(&codex)
+                .await
+                .expect_err("the flood exceeds the ceiling");
+
+            let Error::OutputLimitExceeded {
+                stream: reported,
+                limit_bytes,
+            } = error
+            else {
+                panic!("expected OutputLimitExceeded for {stream}, got {error:?}");
+            };
+            assert_eq!(reported.to_string(), stream);
+            assert_eq!(limit_bytes, 64 * 1024);
+
+            // The captured bytes must not ride along in the error, or the
+            // ceiling has bounded nothing.
+            let error = Error::OutputLimitExceeded {
+                stream: reported,
+                limit_bytes,
+            };
+            let rendered = format!("{error} {error:?}");
+            assert!(!rendered.contains("xxxxxxxx"), "{rendered}");
+            assert!(rendered.len() < 512, "error text grew with the output");
+        }
+    }
+
+    /// Off by default, so adding the control changes nothing until a host
+    /// asks for it. This is also the measurement of what the ceiling buys:
+    /// the same child hands back a megabyte when nothing bounds it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn without_a_ceiling_the_whole_flood_is_captured() {
+        let codex = flooding_codex("stdout", None);
+        let result = crate::ExecCommand::new("hello")
+            .execute(&codex)
+            .await
+            .expect("an unbounded capture succeeds, however large");
+        assert_eq!(result.stdout.len(), 128 * 8192);
+    }
+
+    /// A run that stays under its ceiling is untouched.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn output_within_the_ceiling_is_returned_whole() {
+        let script = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests")
+            .join("fake-codex-echo-stdin.sh");
+        let codex = Codex::builder()
+            .binary("/bin/bash")
+            .arg(script.to_str().unwrap())
+            .output_limit(64 * 1024)
+            .build()
+            .expect("bash must exist");
+        let result = crate::ExecCommand::new("a short prompt")
+            .execute(&codex)
+            .await
+            .expect("well under the ceiling");
+        // Whole means whole: the last line of the stream has to survive, not
+        // just the first, or the ceiling is silently truncating.
+        assert!(
+            result.stdout.contains("thread.started"),
+            "{}",
+            result.stdout
+        );
+        assert!(
+            result.stdout.contains("turn.completed"),
+            "{}",
+            result.stdout
+        );
     }
 
     // -----------------------------------------------------------------

--- a/crates/codex-wrapper/src/lib.rs
+++ b/crates/codex-wrapper/src/lib.rs
@@ -233,7 +233,7 @@ pub use command::update::UpdateCommand;
 pub use command::version::VersionCommand;
 #[cfg(feature = "config")]
 pub use config::CodexConfig;
-pub use error::{Error, FailureKind, Result};
+pub use error::{Error, FailureKind, OutputStream, Result};
 pub use exec::CommandOutput;
 #[cfg(feature = "json")]
 pub use history::{SessionFile, SessionLog, SessionMeta, SessionQuery};
@@ -298,6 +298,7 @@ pub struct Codex {
     pub(crate) timeout: Option<Duration>,
     pub(crate) termination_grace: Duration,
     pub(crate) process_group: bool,
+    pub(crate) output_limit: Option<usize>,
     pub(crate) die_with_parent: bool,
     pub(crate) on_spawn: Option<SpawnObserver>,
     pub(crate) retry_policy: Option<RetryPolicy>,
@@ -518,6 +519,7 @@ pub struct CodexBuilder {
     timeout: Option<Duration>,
     termination_grace: Option<Duration>,
     process_group: Option<bool>,
+    output_limit: Option<usize>,
     die_with_parent: bool,
     on_spawn: Option<SpawnObserver>,
     retry_policy: Option<RetryPolicy>,
@@ -632,6 +634,28 @@ impl CodexBuilder {
         self
     }
 
+    /// Stop capturing a stream once it passes `max_bytes`.
+    ///
+    /// Without a ceiling both captured streams are read to EOF, so peak
+    /// memory for a run is whatever the child decides to print. A consumer
+    /// cannot add this itself: by the time it holds a result the bytes are
+    /// already resident, and for a JSON run already parsed.
+    ///
+    /// With a ceiling set, each buffer stays under `max_bytes`, so a run
+    /// holds at most twice that across stdout and stderr. Passing it stops
+    /// the run the way cancellation does and fails with
+    /// [`Error::OutputLimitExceeded`], which carries no captured bytes: a
+    /// prefix returned as though it were the whole result is the failure
+    /// this prevents.
+    ///
+    /// Off by default, so existing behavior is unchanged until a host opts
+    /// in.
+    #[must_use]
+    pub fn output_limit(mut self, max_bytes: usize) -> Self {
+        self.output_limit = Some(max_bytes);
+        self
+    }
+
     /// Observe every child this client spawns, at spawn time.
     ///
     /// The observer fires before the run produces output, including for
@@ -734,6 +758,7 @@ impl CodexBuilder {
                 .termination_grace
                 .unwrap_or_else(|| Duration::from_secs(5)),
             process_group: self.process_group.unwrap_or(true),
+            output_limit: self.output_limit,
             die_with_parent: self.die_with_parent,
             on_spawn: self.on_spawn,
             timeout: self.timeout,

--- a/crates/codex-wrapper/tests/fake-codex-floods.sh
+++ b/crates/codex-wrapper/tests/fake-codex-floods.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Fake codex that prints far more than any sane capture ceiling.
+#
+# Deliberately emits one enormous line rather than many small ones: a bound
+# that only noticed at line boundaries would pass a line-oriented fixture and
+# still hold the whole stream in memory.
+#
+# CODEX_WRAPPER_TEST_FLOOD_STREAM picks which stream floods, so the ceiling
+# can be shown to cover stderr as well as stdout.
+stream=${CODEX_WRAPPER_TEST_FLOOD_STREAM:-stdout}
+chunk=$(head -c 8192 /dev/zero | tr '\0' 'x')
+i=0
+while [ $i -lt 128 ]; do
+  if [ "$stream" = stderr ]; then
+    printf '%s' "$chunk" >&2
+  else
+    printf '%s' "$chunk"
+  fi
+  i=$((i + 1))
+done


### PR DESCRIPTION
Closes #132. Mirrors joshrotenberg/claude-wrapper#796, so the two wrappers expose the same control with the same semantics.

## Problem

`exec.rs` read stdout and stderr with `read_to_end`, so peak memory for a run was whatever the child decided to print. A consumer cannot add this bound itself: by the time it holds a `CommandOutput` the bytes are resident, and for a JSONL run already parsed.

Measured with the new fixture: an unbounded run of a child that prints a megabyte returns all 1,048,576 bytes, and succeeds while doing it.

## Change

`CodexBuilder::output_limit(max_bytes)`, off by default. With a ceiling each buffer stays under it, so a run holds at most twice the ceiling across the two streams regardless of what the child does. Passing it stops the run the way cancellation does, rather than leaving the child writing into a buffer nothing will read.

Exceeding it is `Error::OutputLimitExceeded { stream, limit_bytes }`, naming which stream tripped and the configured ceiling.

## Two decisions the issue asked about

**Typed, not truncated.** The error carries no captured bytes. A prefix returned as though it were the whole result is indistinguishable from a genuinely short answer, and a caller that cannot tell those apart will act on a partial answer believing it is complete. Enough of the prefix to identify the runaway is logged at warn instead.

**It stops the child.** Continuing to drain past a ceiling defeats the purpose, so the run terminates through the existing cancellation path and inherits its process-group cleanup and reaping unchanged.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo test --lib --all-features` 269 pass, `cargo test --lib --no-default-features` 165 pass.

The fixture floods on **one unbroken line**. A bound that only noticed at line boundaries would pass a line-oriented test and still hold the entire stream, so this is the case worth testing. Tests cover the ceiling tripping on stdout and on stderr, the error carrying none of the flooded bytes (asserted by size and by content), a run under its ceiling returning both the first and last line of its stream so truncation cannot hide, and the default leaving a megabyte capture untouched.

## Downstream

`tower-agent` consumes the Claude side already (joshrotenberg/tower-agent#138) and has the Codex half open at joshrotenberg/tower-agent#99, waiting on this release.