### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3](https://github.com/joshrotenberg/codex-wrapper/compare/v0.4.2...v0.4.3) - 2026-08-27
+
+### Added
+
+- *(exec)* bound captured child output by bytes (closes #132) ([#133](https://github.com/joshrotenberg/codex-wrapper/pull/133))
+
 ## [0.4.2](https://github.com/joshrotenberg/codex-wrapper/compare/v0.4.1...v0.4.2) - 2026-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "codex-wrapper"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "libc",
  "serde",

--- a/crates/codex-wrapper/Cargo.toml
+++ b/crates/codex-wrapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-wrapper"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `codex-wrapper`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/joshrotenberg/codex-wrapper/compare/v0.4.2...v0.4.3) - 2026-08-27

### Added

- *(exec)* bound captured child output by bytes (closes #132) ([#133](https://github.com/joshrotenberg/codex-wrapper/pull/133))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).